### PR TITLE
Change the gamified calculation to use the data from the day before yest...

### DIFF
--- a/CFC_WebApp/clients/gamified/gamified.py
+++ b/CFC_WebApp/clients/gamified/gamified.py
@@ -92,12 +92,19 @@ def getScore(user_uuid, start, end):
 def updateScore(user_uuid):
     today = datetime.now().date()
     yesterday = today - timedelta(days = 1)
+    dayBeforeYesterday = today - timedelta(days = 2)
+
+    dayBeforeYesterdayStart = datetime.combine(dayBeforeYesterday, dttime.min)
     yesterdayStart = datetime.combine(yesterday, dttime.min)
     todayStart = datetime.combine(today, dttime.min)
 
     user = User.fromUUID(user_uuid)
     (discardedScore, prevScore) = getStoredScore(user)
-    newScore = prevScore + getScore(user_uuid, yesterdayStart, todayStart)
+    # Using score from dayBeforeYesterday instead of yesterday because there is
+    # currently a significant lag in the time for e-mission to prompt for
+    # entries, so people might not confirm yesterday's trips until sometime
+    # today, which means that it won't be counted in their score
+    newScore = prevScore + getScore(user_uuid, dayBeforeYesterdayStart, yesterdayStart)
     if newScore < 0:
         newScore = 0
     stats.storeResultEntry(user_uuid, stats.STAT_GAME_SCORE, time.time(), newScore)

--- a/CFC_WebApp/tests/client_tests/TestGamified.py
+++ b/CFC_WebApp/tests/client_tests/TestGamified.py
@@ -46,12 +46,12 @@ class TestGamified(unittest.TestCase):
 
 
         self.now = datetime.now()
-        self.dayago = self.now - timedelta(days=1)
+        self.twodaysago = self.now - timedelta(days=2)
         self.weekago = self.now - timedelta(weeks = 1)
 
         for section in self.SectionsColl.find():
-            section['section_start_datetime'] = self.dayago
-            section['section_end_datetime'] = self.dayago + timedelta(hours = 1)
+            section['section_start_datetime'] = self.twodaysago
+            section['section_end_datetime'] = self.twodaysago + timedelta(hours = 1)
             section['predicted_mode'] = {'walking': 1.0}
             if section['user_id'] == 'fest@example.com':
                 logging.debug("Setting user_id for section %s, %s = %s" %


### PR DESCRIPTION
...erday

Because there is currently a significant lag in the time for e-mission to
prompt for entries, so people may not confirm yesterday's trips until sometime
today, which means that it won't be counted in their score.
