### PR TITLE
Handle corner cases in the feature matrix creation

### DIFF
--- a/CFC_DataCollector/modeinfer/featurecalc.py
+++ b/CFC_DataCollector/modeinfer/featurecalc.py
@@ -178,7 +178,7 @@ def calAccels(segment):
   speeds = calSpeeds(segment)
   trackpoints = segment['track_points']
 
-  if speeds == None:
+  if speeds is None or len(speeds) == 0:
     return None
 
   accel = np.zeros(len(speeds) - 1)

--- a/CFC_DataCollector/modeinfer/pipeline.py
+++ b/CFC_DataCollector/modeinfer/pipeline.py
@@ -176,7 +176,7 @@ class ModeInferencePipeline:
     featureMatrix[i, 3] = section['section_id']
     featureMatrix[i, 4] = calAvgSpeed(section)
     speeds = calSpeeds(section)
-    if speeds != None:
+    if speeds != None and len(speeds) > 0:
         featureMatrix[i, 5] = np.mean(speeds)
         featureMatrix[i, 6] = np.std(speeds)
         featureMatrix[i, 7] = np.max(speeds)
@@ -205,9 +205,16 @@ class ModeInferencePipeline:
     
     featureMatrix[i, 17] = section['section_start_datetime'].time().hour
     featureMatrix[i, 18] = section['section_end_datetime'].time().hour
-    
-    featureMatrix[i, 19] = mode_start_end_coverage(section, self.bus_cluster,105)
-    featureMatrix[i, 20] = mode_start_end_coverage(section, self.train_cluster,600)
+   
+    if (hasattr(self, "bus_cluster")): 
+        featureMatrix[i, 19] = mode_start_end_coverage(section, self.bus_cluster,105)
+    if (hasattr(self, "train_cluster")): 
+        featureMatrix[i, 20] = mode_start_end_coverage(section, self.train_cluster,600)
+    if (hasattr(self, "air_cluster")): 
+        featureMatrix[i, 21] = mode_start_end_coverage(section, self.air_cluster,600)
+
+    # Replace NaN and inf by zeros so that it doesn't crash later
+    featureMatrix[i] = np.nan_to_num(featureMatrix[i])
 
   def cleanDataStep(self):
     runIndices = self.resultVector == 2

--- a/CFC_DataCollector/tests/modeinfer/TestFeatureCalc.py
+++ b/CFC_DataCollector/tests/modeinfer/TestFeatureCalc.py
@@ -1,0 +1,39 @@
+import unittest
+import modeinfer.featurecalc as fc
+
+class TestFeatureCalc(unittest.TestCase):
+  def testCalSpeedWithZeroTime(self):
+    trackpoint1 = {"track_location": {"coordinates": [-122.0861645, 37.3910201]},
+                   "time" : "20150127T203305-0800"}
+    trackpoint2 = {"track_location": {"coordinates": [-122.0858963, 37.3933358]},
+                   "time" : "20150127T203305-0800"}
+    self.assertEqual(fc.calSpeed(trackpoint1, trackpoint2), None)
+
+  def testCalSpeedsWithZeroTime(self):
+    trackpoint1 = {"track_location": {"coordinates": [-122.0861645, 37.3910201]},
+                   "time" : "20150127T203305-0800"}
+    trackpoint2 = {"track_location": {"coordinates": [-122.0858963, 37.3933358]},
+                   "time" : "20150127T203305-0800"}
+    testSeg = {"track_points": [trackpoint1, trackpoint2]}
+    self.assertEqual(fc.calSpeeds(testSeg), [0])
+
+  def testCalSpeedsWithOnePoint(self):
+    trackpoint1 = {"track_location": {"coordinates": [-122.0861645, 37.3910201]},
+                   "time" : "20150127T203305-0800"}
+    testSeg = {"track_points": [trackpoint1]}
+    self.assertEqual(len(fc.calSpeeds(testSeg)), 0)
+
+  def testCalAccelsWithOnePoint(self):
+    trackpoint1 = {"track_location": {"coordinates": [-122.0861645, 37.3910201]},
+                   "time" : "20150127T203305-0800"}
+    testSeg = {"track_points": [trackpoint1]}
+    self.assertEqual(fc.calAccels(testSeg), None)
+
+  def testCalSpeedsWithOnePoint(self):
+    trackpoint1 = {"track_location": {"coordinates": [-122.0861645, 37.3910201]},
+                   "time" : "20150127T203305-0800"}
+    testSeg = {"track_points": [trackpoint1]}
+    self.assertEqual(len(fc.calSpeeds(testSeg)), 0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/CFC_DataCollector/tests/modeinfer/TestPipeline.py
+++ b/CFC_DataCollector/tests/modeinfer/TestPipeline.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 import logging
+import numpy as np
 from get_database import get_db, get_mode_db, get_section_db
 import modeinfer
 from modeinfer import pipeline
@@ -83,6 +84,26 @@ class TestPipeline(unittest.TestCase):
     # So we expect to have to cluster points - one for start and one for end
     self.assertEquals(len(self.pipeline.train_cluster), 0)
     self.assertEquals(len(self.pipeline.bus_cluster), 2)
+
+  def testFeatureGenWithOnePoint(self):
+    trackpoint1 = {"track_location": {"coordinates": [-122.0861645, 37.3910201]},
+                   "time" : "20150127T203305-0800"}
+    now = datetime.now()
+
+    # ensure that the start and end datetimes are the same, since the average calculation uses
+    # the total distance and the total duration
+    testSeg = {"track_points": [trackpoint1],
+               "distance": 500,
+               "section_start_datetime": now,
+               "section_end_datetime": now,
+               "mode": 1,
+               "section_id": 2}
+
+    featureMatrix = np.zeros([1, len(self.pipeline.featureLabels)])
+    resultVector = np.zeros(1)
+    self.pipeline.updateFeatureMatrixRowWithSection(featureMatrix, 0, testSeg)
+    self.assertEqual(np.count_nonzero(featureMatrix[0][4:16]), 0)
+    self.assertEqual(np.count_nonzero(featureMatrix[0][19:21]), 0)
 
   def testGenerateTrainingSet(self):
     self.testLoadTrainingData()


### PR DESCRIPTION
@bellettif - here's one more pull request for you to review. With this, I think that all the changes in my tree have been submitted as pull requests to the repo.

When we switched to our own data collection, we initially had some weird trips
generated, for example:
- trips with zero time, or
- trips with only one point

These exposed several corner cases where feature matrix creation failed.

While these trips were clearly incorrect and have since been fixed, it is also
good to handle the corner cases so that we fail gracefully.

This change fixes the corner cases and adds new test cases to avoid regressions
in the future.