### PR TITLE
added oauth to verify jwt before falling back to api call

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests==2.5.1
 six==1.9.0
 utm==0.3.1
 wsgiref==0.1.2
+google-api-python-client==1.1


### PR DESCRIPTION
Uses client-side library to verify JWT instead of making an API call using the OAuth2.0Client library. 

Tested and verify that everything is working correctly. 
Tested using wrong client_key for the OAuthLibrary -- defaulted to API call. 
Tested with right client_key -- didn't make the API call. The token was verified using Oauth library. 

Note: added to requirements.txt (need to run pip install -r requirements.txt) to use the library. 
@jimmydief 