### PR TITLE
Post deployment fixes

### DIFF
--- a/CFC_DataCollector/modeinfer/pipeline.py
+++ b/CFC_DataCollector/modeinfer/pipeline.py
@@ -1,5 +1,6 @@
 from pymongo import MongoClient
 import logging
+from datetime import datetime
 
 import sys
 import os

--- a/CFC_DataCollector/moves/collect.py
+++ b/CFC_DataCollector/moves/collect.py
@@ -167,10 +167,10 @@ def label_filtered_section(section):
 def fillTripWithMovesData(trip_from_moves, new_trip):
   # logging.debug("trip_from_moves = %s" % trip_from_moves)
   new_trip['type'] = trip_from_moves["type"] if 'type' in trip_from_moves else "unknown"
-  new_trip['trip_start_time'] = trip_from_moves["startTime"]
-  new_trip['trip_end_time'] = trip_from_moves["endTime"]
-  new_trip['trip_start_datetime'] = parser.parse(trip_from_moves["startTime"])
-  new_trip['trip_end_datetime'] = parser.parse(trip_from_moves["endTime"])
+  new_trip['trip_start_time'] = trip_from_moves["startTime"] if "startTime" in trip_from_moves else ""
+  new_trip['trip_end_time'] = trip_from_moves["endTime"] if "endTime" in trip_from_moves else "" 
+  new_trip['trip_start_datetime'] = parser.parse(trip_from_moves["startTime"]) if "startTime" in trip_from_moves else None
+  new_trip['trip_end_datetime'] = parser.parse(trip_from_moves["endTime"]) if "endTime" in trip_from_moves else None
   new_trip['place'] = {'place_id':    trip_from_moves["place"]["id"],
                       'place_type':   trip_from_moves["place"]["type"],
                       'place_location':{'type':'Point',

--- a/CFC_DataCollector/tests/TestMovesCollect.py
+++ b/CFC_DataCollector/tests/TestMovesCollect.py
@@ -266,7 +266,7 @@ class TestMovesCollect(unittest.TestCase):
     self.assertEquals(newSec['trip_end_datetime'].hour, 19)
     self.assertEquals(newSec['place']['place_location']['coordinates'][0], -122)
 
-  def testFillTripWithValidData(self):
+  def testFillTripWithInvalidData(self):
     testMovesSec = {}
     testMovesSec['type'] = 'move'
     testMovesSec['place'] = {}

--- a/CFC_DataCollector/tests/TestMovesCollect.py
+++ b/CFC_DataCollector/tests/TestMovesCollect.py
@@ -266,6 +266,24 @@ class TestMovesCollect(unittest.TestCase):
     self.assertEquals(newSec['trip_end_datetime'].hour, 19)
     self.assertEquals(newSec['place']['place_location']['coordinates'][0], -122)
 
+  def testFillTripWithValidData(self):
+    testMovesSec = {}
+    testMovesSec['type'] = 'move'
+    testMovesSec['place'] = {}
+    testMovesSec['place']['id'] = 10
+    testMovesSec['place']['type'] = 'home'
+    testMovesSec['place']['location'] = {u'lat': 37, u'lon': -122, u'time': u'20140407T083200-0700'}
+
+    newSec = {} 
+    collect.fillTripWithMovesData(testMovesSec, newSec)
+
+    self.assertEquals(newSec['type'], 'move')
+    self.assertEquals(newSec['trip_start_time'], "")
+    self.assertEquals(newSec['trip_end_time'], "")
+    self.assertEquals(newSec['trip_start_datetime'], None)
+    self.assertEquals(newSec['trip_end_datetime'], None)
+    self.assertEquals(newSec['place']['place_location']['coordinates'][0], -122)
+
   def testSectionFilterLabeling(self):
     """
     Tests that incoming section data parsed by collect.py is properly 

--- a/CFC_WebApp/clients/default/default.py
+++ b/CFC_WebApp/clients/default/default.py
@@ -1,8 +1,8 @@
 import logging
 from main import carbon, stats
 from dao.user import User
-import time
-from datetime import datetime, timedelta
+import time as systime
+from datetime import datetime, time, timedelta
 import json
 
 # BEGIN: Code to get and set client specific fields in the profile (currentScore and previousScore)
@@ -57,14 +57,15 @@ def runBackgroundTasks(user_uuid):
   runBackgroundTasksForDay(user_uuid, today)
 
 def runBackgroundTasksForDay(user_uuid, today):
+  today_dt = datetime.combine(today, time.max)
   user = User.fromUUID(user_uuid)
   # carbon compare results is a tuple. Tuples are converted to arrays
   # by mongodb
   # In [44]: testUser.setScores(('a','b', 'c', 'd'), ('s', 't', 'u', 'v'))
   # In [45]: testUser.getScore()
   # Out[45]: ([u'a', u'b', u'c', u'd'], [u's', u't', u'u', u'v'])
-  weekago = today - timedelta(days=7)
-  carbonCompareResults = carbon.getFootprintCompareForRange(user_uuid, weekago, today)
+  weekago = today_dt - timedelta(days=7)
+  carbonCompareResults = carbon.getFootprintCompareForRange(user_uuid, weekago, today_dt)
   setCarbonFootprint(user, carbonCompareResults)
 
   (myModeShareCount, avgModeShareCount,
@@ -76,7 +77,7 @@ def runBackgroundTasksForDay(user_uuid, today):
   # We only compute server stats in the background, because including them in
   # the set call means that they may be invoked when the user makes a call and
   # the cached value is None, which would potentially slow down user response time
-  msNow = time.time()
+  msNow = systime.time()
   stats.storeResultEntry(user_uuid, stats.STAT_MY_CARBON_FOOTPRINT, msNow, getCategorySum(myModeCarbonFootprint))
   stats.storeResultEntry(user_uuid, stats.STAT_MY_CARBON_FOOTPRINT_NO_AIR, msNow, getCategorySum(myModeCarbonFootprintNoLongMotorized))
   stats.storeResultEntry(user_uuid, stats.STAT_MY_OPTIMAL_FOOTPRINT, msNow, getCategorySum(myOptimalCarbonFootprint))

--- a/CFC_WebApp/front/index.html
+++ b/CFC_WebApp/front/index.html
@@ -208,21 +208,21 @@
                                     "")'>
                                     Popular routes within Cal</button>
         <button onclick='displayHeatmap("result/heatmap/pop.route/commute/cycling",
-                                    "Popular bicycle commute routes",
+                                    "Popular bicycle routes",
                                     "")'>
-                                    Popular bicycle commute routes</button>
+                                    Popular bicycle routes</button>
         <button onclick='displayHeatmap("result/heatmap/pop.route/commute/car",
-                                    "Popular car commute routes",
+                                    "Popular car routes",
                                     "")'>
-                                    Popular car commute routes</button>
+                                    Popular car routes</button>
         <button onclick='displayHeatmap("result/heatmap/pop.route/commute/bus",
-                                    "Popular bus commute routes",
+                                    "Popular bus routes",
                                     "")'>
-                                    Popular bus commute routes</button>
+                                    Popular bus routes</button>
         <button onclick='displayHeatmap("result/heatmap/pop.route/commute/train",
-                                    "Popular train commute routes",
+                                    "Popular train routes",
                                     "")'>
-                                    Popular train commute routes</button>
+                                    Popular train routes</button>
       </center></div>
 
       <div>

--- a/CFC_WebApp/main/Profile.py
+++ b/CFC_WebApp/main/Profile.py
@@ -7,8 +7,6 @@ from get_database import get_section_db,get_profile_db
 from pygeocoder import Geocoder
 from common import calDistance 
 import math
-from route_matching import update_user_routeDistanceMatrix, update_user_routeClusters
-from K_medoid_2 import kmedoids, user_route_data
 
 
 logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
@@ -50,11 +48,6 @@ def update_profiles(dummy_users=False):
             key='work'+str(day)
             Profiles.update({"$and":[{'source':'Shankari'},
                                          {'user_id':user}]},{"$set":{key:detect_daily_work_office(user,day)}})
-        ## update route clusters:
-        routes_user = user_route_data(user,get_section_db())
-        update_user_routeDistanceMatrix(user,routes_user,step1=100000,step2=100000,method='DTW')
-        clusters_user = kmedoids(routes_user,int(math.ceil(len(routes_user)/8)),user,method='DTW')
-        update_user_routeClusters(user,clusters_user[2],method='DTW')
     # print(Profiles.find().count())
     # for profile in Profiles.find():
     #     print(profile)

--- a/CFC_WebApp/main/common.py
+++ b/CFC_WebApp/main/common.py
@@ -105,11 +105,6 @@ def getDistanceForMode(spec):
   totalDist = 0
   projection = {'distance': True, '_id': False}
   for section in get_section_db().find(spec, projection):
-  #  for section in get_section_db().find(spec):
-  #    logging.debug("found section %s" % section)
-  #    logging.debug("found section with %s %s %s %s %s %s %s" %
-  #       (section['trip_id'], section['section_id'], section['confirmed_mode'],
-  #           section['user_id'], section['type'], section.get('auto_confirmed'), section.get('distance')))
     if section['distance']!=None:
         totalDist = totalDist + section['distance']
     else:

--- a/CFC_WebApp/main/common.py
+++ b/CFC_WebApp/main/common.py
@@ -61,11 +61,7 @@ def getQuerySpec(user, modeId,start,end):
   return query
 
 def getTripCountForMode(user, modeId,start,end):
-  try:
-    return get_section_db().find(getQuerySpec(user, modeId,start,end)).count()
-  except:
-    logging.error("Got BSON error while calculating distances for user %s" % user)
-    return 0
+  return get_section_db().find(getQuerySpec(user, modeId,start,end)).count()
 
 def getModeShare(user,start,end):
   displayModeList = getDisplayModes()
@@ -108,25 +104,21 @@ def getDistanceForMode(spec):
   distanceList = []
   totalDist = 0
   projection = {'distance': True, '_id': False}
-  try:
-    for section in get_section_db().find(spec, projection):
+  for section in get_section_db().find(spec, projection):
   #  for section in get_section_db().find(spec):
   #    logging.debug("found section %s" % section)
   #    logging.debug("found section with %s %s %s %s %s %s %s" %
   #       (section['trip_id'], section['section_id'], section['confirmed_mode'],
   #           section['user_id'], section['type'], section.get('auto_confirmed'), section.get('distance')))
-      if section['distance']!=None:
-          totalDist = totalDist + section['distance']
-      else:
-          logging.warning("distance key not found in projection, returning zero...")
-        # returning zero for the distance
-          pass
-    # logging.debug("for sectionList %s, distanceList = %s" % (len(sectionList), distanceList))
-    distanceForMode = totalDist
-    return distanceForMode
-  except:
-    logging.error("Got BSON error while calculating distances for spec %s" % spec)
-    return 0
+    if section['distance']!=None:
+        totalDist = totalDist + section['distance']
+    else:
+        logging.warning("distance key not found in projection, returning zero...")
+      # returning zero for the distance
+        pass
+  # logging.debug("for sectionList %s, distanceList = %s" % (len(sectionList), distanceList))
+  distanceForMode = totalDist
+  return distanceForMode
 
 def generateRandomResult(category_list):
     result = {}

--- a/CFC_WebApp/main/commute.py
+++ b/CFC_WebApp/main/commute.py
@@ -4,9 +4,8 @@ from home import detect_home
 from work_place import detect_daily_work_office
 from get_database import get_section_db
 from common import Is_date, Is_place
-from tripManager import travel_time
 from dateutil import parser
-from common import parse_time
+from common import parse_time, travel_time
 
 ########################################## morning commute ########################################################
 def get_daily_morning_commute_sections(user_id,day):

--- a/CFC_WebApp/main/route_matching.py
+++ b/CFC_WebApp/main/route_matching.py
@@ -6,7 +6,7 @@ import numpy as np
 from Frechet import Frechet
 from LCS import lcs,lcsScore
 from DTW import Dtw,dynamicTimeWarp,DtwAsym,DtwSym
-import urllib,simplejson,csv
+import urllib,json,csv
 import xml.etree.cElementTree as ET
 import urllib2
 import time
@@ -273,7 +273,7 @@ def storeCalTrainStop():
             # print(add)
             url='https://maps.googleapis.com/maps/api/geocode/json?address='+urllib.quote_plus(row[0]+' caltrain station')
             print(url)
-            geo= simplejson.load(urllib.urlopen(url))
+            geo= json.load(urllib.urlopen(url))
             result=geo['results'][0]
             print(result['geometry']['location'])
             stops.append([result['geometry']['location']['lat'],result['geometry']['location']['lng']])

--- a/CFC_WebApp/main/visualize.py
+++ b/CFC_WebApp/main/visualize.py
@@ -41,15 +41,21 @@ def Commute_pop_route(modeId,start,end):
     commuteQuery = {"$or": [{'commute': 'to'}, {'commute': 'from'}]}
     modeQuery = {"$or": [{'mode': modeId}, getConfirmationModeQuery(modeId)]}
     dateTimeQuery = {"section_start_datetime": {"$gte": start, "$lt": end}}
-    for section in Sections.find({"$and":[commuteQuery, modeQuery,dateTimeQuery,{'type':'move'}]}):
+#     for section in Sections.find({"$and":[commuteQuery, modeQuery,dateTimeQuery,{'type':'move'}]}):
+#         if len(section['track_points']) > 5:
+#           # skip routes that have less than 3 points
+#           if section['commute'] == 'to':
+#             for pnt in section['track_points'][5:]:
+#                     list_of_point.append(pnt['track_location']['coordinates'])
+#           if section['commute'] == 'from':
+#             for pnt in section['track_points'][:-5]:
+#                     list_of_point.append(pnt['track_location']['coordinates'])
+
+    for section in Sections.find({"$and":[modeQuery,dateTimeQuery,{'type':'move'}]}):
         if len(section['track_points']) > 5:
           # skip routes that have less than 3 points
-          if section['commute'] == 'to':
-            for pnt in section['track_points'][5:]:
-                    list_of_point.append(pnt['track_location']['coordinates'])
-          if section['commute'] == 'from':
-            for pnt in section['track_points'][:-5]:
-                    list_of_point.append(pnt['track_location']['coordinates'])
+          for pnt in section['track_points'][5:-5]:
+                  list_of_point.append(pnt['track_location']['coordinates'])
 
     return {"latlng": list_of_point}
 

--- a/CFC_WebApp/main/visualize.py
+++ b/CFC_WebApp/main/visualize.py
@@ -41,16 +41,6 @@ def Commute_pop_route(modeId,start,end):
     commuteQuery = {"$or": [{'commute': 'to'}, {'commute': 'from'}]}
     modeQuery = {"$or": [{'mode': modeId}, getConfirmationModeQuery(modeId)]}
     dateTimeQuery = {"section_start_datetime": {"$gte": start, "$lt": end}}
-#     for section in Sections.find({"$and":[commuteQuery, modeQuery,dateTimeQuery,{'type':'move'}]}):
-#         if len(section['track_points']) > 5:
-#           # skip routes that have less than 3 points
-#           if section['commute'] == 'to':
-#             for pnt in section['track_points'][5:]:
-#                     list_of_point.append(pnt['track_location']['coordinates'])
-#           if section['commute'] == 'from':
-#             for pnt in section['track_points'][:-5]:
-#                     list_of_point.append(pnt['track_location']['coordinates'])
-
     for section in Sections.find({"$and":[modeQuery,dateTimeQuery,{'type':'move'}]}):
         if len(section['track_points']) > 5:
           # skip routes that have less than 3 points

--- a/CFC_WebApp/tests/TestCommon.py
+++ b/CFC_WebApp/tests/TestCommon.py
@@ -1,14 +1,14 @@
 import logging
-
 import unittest
 import json
 import sys
 import os
+import mock
 from utils import load_database_json, purge_database_json
 
 sys.path.append("%s" % os.getcwd())
+import get_database
 from main import common
-from get_database import get_db, get_section_db
 from uuid import UUID
 from datetime import datetime, timedelta
 
@@ -21,7 +21,7 @@ class TestCommon(unittest.TestCase):
     self.serverName = 'localhost'
 
     # Make sure we start with a clean slate every time
-    tests.common.dropAllCollections(get_db())
+    tests.common.dropAllCollections(get_database.get_db())
     
     # Load modes, otherwise the queries won't work properly
     load_database_json.loadTable(self.serverName, "Stage_Modes", "tests/data/modes.json")
@@ -75,7 +75,6 @@ class TestCommon(unittest.TestCase):
     from dao.user import User
     from dao.client import Client
     import tests.common
-    from get_database import get_section_db
 
     fakeEmail = "fake@fake.com"
 
@@ -107,11 +106,11 @@ class TestCommon(unittest.TestCase):
     clientSetQuery = Client(user.getFirstStudy()).clientSpecificSetters(user.uuid, dummySection, dummyPredModeMap)
 
     # Apply the change
-    get_section_db().update({'_id': dummySection['_id']}, clientSetQuery)
-    retrievedSection = get_section_db().find_one({'_id': dummySection['_id']})
+    get_database.get_section_db().update({'_id': dummySection['_id']}, clientSetQuery)
+    retrievedSection = get_database.get_section_db().find_one({'_id': dummySection['_id']})
     self.assertEqual(retrievedSection['test_auto_confirmed']['mode'], 1)
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(1))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(1))
     for entry in retrieveByQuery:
       print entry
     self.assertEqual(retrieveByQuery.count(), 1)
@@ -123,18 +122,18 @@ class TestCommon(unittest.TestCase):
     clientSetQuery = Client(user.getFirstStudy()).clientSpecificSetters(user.uuid, dummySection, dummyPredModeMap)
 
     # Apply the change
-    get_section_db().update({'_id': dummySection['_id']}, clientSetQuery)
-    retrievedSection = get_section_db().find_one({'_id': dummySection['_id']})
+    get_database.get_section_db().update({'_id': dummySection['_id']}, clientSetQuery)
+    retrievedSection = get_database.get_section_db().find_one({'_id': dummySection['_id']})
     self.assertEqual(retrievedSection['test_auto_confirmed']['mode'], 1)
 
-    get_section_db().update({'_id': dummySection['_id']}, {'$set': {'confirmed_mode': 4}})
+    get_database.get_section_db().update({'_id': dummySection['_id']}, {'$set': {'confirmed_mode': 4}})
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(1))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(1))
     for entry in retrieveByQuery:
       print entry
     self.assertEqual(retrieveByQuery.count(), 0)
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(4))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(4))
     for entry in retrieveByQuery:
       print entry
     self.assertEqual(retrieveByQuery.count(), 1)
@@ -146,24 +145,24 @@ class TestCommon(unittest.TestCase):
     clientSetQuery = Client(user.getFirstStudy()).clientSpecificSetters(user.uuid, dummySection, dummyPredModeMap)
 
     # Apply the change
-    get_section_db().update({'_id': dummySection['_id']}, clientSetQuery)
-    retrievedSection = get_section_db().find_one({'_id': dummySection['_id']})
+    get_database.get_section_db().update({'_id': dummySection['_id']}, clientSetQuery)
+    retrievedSection = get_database.get_section_db().find_one({'_id': dummySection['_id']})
     self.assertEqual(retrievedSection['test_auto_confirmed']['mode'], 1)
 
-    get_section_db().update({'_id': dummySection['_id']}, {'$set': {'confirmed_mode': 4}})
-    get_section_db().update({'_id': dummySection['_id']}, {'$set': {'corrected_mode': 9}})
+    get_database.get_section_db().update({'_id': dummySection['_id']}, {'$set': {'confirmed_mode': 4}})
+    get_database.get_section_db().update({'_id': dummySection['_id']}, {'$set': {'corrected_mode': 9}})
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(1))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(1))
     for entry in retrieveByQuery:
       print entry
     self.assertEqual(retrieveByQuery.count(), 0)
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(4))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(4))
     for entry in retrieveByQuery:
       print entry
     self.assertEqual(retrieveByQuery.count(), 0)
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(9))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(9))
     for entry in retrieveByQuery:
       print entry
     self.assertEqual(retrieveByQuery.count(), 1)
@@ -172,22 +171,22 @@ class TestCommon(unittest.TestCase):
     from dao.client import Client
 
     (user, dummySection, dummyPredModeMap) = self.setupClientTest()
-    get_section_db().update({'_id': dummySection['_id']}, {'$set': {'confirmed_mode': 4}})
+    get_database.get_section_db().update({'_id': dummySection['_id']}, {'$set': {'confirmed_mode': 4}})
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(1))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(1))
     self.assertEqual(retrieveByQuery.count(), 0)
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(4))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(4))
     self.assertEqual(retrieveByQuery.count(), 1)
 
   def testConfirmationModeQueryNeither(self):
     from dao.client import Client
 
     (user, dummySection, dummyPredModeMap) = self.setupClientTest()
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(1))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(1))
     self.assertEqual(retrieveByQuery.count(), 0)
 
-    retrieveByQuery = get_section_db().find(common.getConfirmationModeQuery(4))
+    retrieveByQuery = get_database.get_section_db().find(common.getConfirmationModeQuery(4))
     self.assertEqual(retrieveByQuery.count(), 0)
 
   @staticmethod
@@ -217,7 +216,7 @@ class TestCommon(unittest.TestCase):
         predSection['type'] = 'move'
         predSection['confirmed_mode'] = "5"
         predSection['user_id'] = user.uuid
-        get_section_db().insert(predSection)
+        get_database.get_section_db().insert(predSection)
 
         noPredSection = copy(dummySection)
         noPredSection['_id'] = "%s nopred" % (i)
@@ -225,10 +224,10 @@ class TestCommon(unittest.TestCase):
         noPredSection['user_id'] = user.uuid
         del noPredSection['predicted_mode']
         self.assertIn('predicted_mode', predSection)
-        get_section_db().insert(noPredSection)
+        get_database.get_section_db().insert(noPredSection)
 
-    logging.debug("After inserting sections, count is %s" % get_section_db().find().count())
-    logging.debug("Manual query count = %s" % get_section_db().find({'$and': [{'source': 'Shankari'}, {'user_id': user.uuid}, {'predicted_mode': {'$exists': True}}, {'type': 'move'}]}).count())
+    logging.debug("After inserting sections, count is %s" % get_database.get_section_db().find().count())
+    logging.debug("Manual query count = %s" % get_database.get_section_db().find({'$and': [{'source': 'Shankari'}, {'user_id': user.uuid}, {'predicted_mode': {'$exists': True}}, {'type': 'move'}]}).count())
     self.assertEqual(common.getClassifiedRatio(user.uuid, self.dayago, self.now), 1)
 
   def testGetClassifiedRatioWithPredictions(self):
@@ -245,7 +244,7 @@ class TestCommon(unittest.TestCase):
         predSection['type'] = 'move'
         predSection['confirmed_mode'] = "5"
         predSection['user_id'] = user.uuid
-        get_section_db().insert(predSection)
+        get_database.get_section_db().insert(predSection)
 
         noPredSection = copy(dummySection)
         noPredSection['_id'] = "%s nopred" % (i)
@@ -258,15 +257,36 @@ class TestCommon(unittest.TestCase):
         self.assertIn('predicted_mode', predSection)
         self.assertIn('predicted_mode', noPredSection)
         self.assertIn('confirmed_mode', predSection)
-        get_section_db().insert(noPredSection)
+        get_database.get_section_db().insert(noPredSection)
 
-    logging.debug("After inserting sections, count is %s" % get_section_db().find().count())
-    logging.debug("Manual query count = %s" % get_section_db().find({'$and': [{'source': 'Shankari'}, {'user_id': user.uuid}, {'predicted_mode': {'$exists': True}}, {'type': 'move'}]}).count())
-    logging.debug("Manual query count classified = %s" % get_section_db().find({'$and': [{'source': 'Shankari'}, {'user_id': user.uuid}, {'predicted_mode': {'$exists': True}}, {'type': 'move'}, {'confirmed_mode': {"$ne": ''}} ]}).count())
+    logging.debug("After inserting sections, count is %s" % get_database.get_section_db().find().count())
+    logging.debug("Manual query count = %s" % get_database.get_section_db().find({'$and': [{'source': 'Shankari'}, {'user_id': user.uuid}, {'predicted_mode': {'$exists': True}}, {'type': 'move'}]}).count())
+    logging.debug("Manual query count classified = %s" % get_database.get_section_db().find({'$and': [{'source': 'Shankari'}, {'user_id': user.uuid}, {'predicted_mode': {'$exists': True}}, {'type': 'move'}, {'confirmed_mode': {"$ne": ''}} ]}).count())
 
     self.assertEqual(common.getClassifiedRatio(user.uuid, self.dayago, self.now), 3.0/6)
     two_days_ago = datetime.now() - timedelta(days=2)
     self.assertEqual(common.getClassifiedRatio(user.uuid, two_days_ago, self.dayago), 0)
+
+  def testBSONExceptionHandling(self):
+    (user, dummySection, dummyPredModeMap) = self.setupClientTest()
+    # This mock test only works if the access to the mocked function is in
+    # here, not in common. I found this entry on stackoverflow on mocking
+    # module methods, but trying the appropriate sequence in the REPL still
+    # doesn't work. I think that this might be because of the multiple copies
+    # of get_database, so that the get_database loaded from common is not the
+    # same as the get_database loaded here.
+    # So I will leave this half-baked test in here, and will return to it after
+    # fixing the mess around get_database loading
+    with mock.patch('get_database.get_section_db', side_effect=Exception("bson.errors.InvalidDocument")) as func1:
+        try:
+            get_database.get_section_db()
+        except:
+            print "Exception thrown!"
+        # We don't throw any exception
+        self.assertEquals(common.getTripCountForMode(user.uuid, 5, self.dayago, self.now), 0)
+        # although the database was called
+        self.assertEquals(func1.called, True)
+        func1.resetMock()
 
 if __name__ == '__main__':
     unittest.main()

--- a/CFC_WebApp/tests/TestCommon.py
+++ b/CFC_WebApp/tests/TestCommon.py
@@ -282,8 +282,6 @@ class TestCommon(unittest.TestCase):
             get_database.get_section_db()
         except:
             print "Exception thrown!"
-        # We don't throw any exception
-        self.assertEquals(common.getTripCountForMode(user.uuid, 5, self.dayago, self.now), 0)
         # although the database was called
         self.assertEquals(func1.called, True)
         func1.resetMock()

--- a/CFC_WebApp/tests/TestTripManager.py
+++ b/CFC_WebApp/tests/TestTripManager.py
@@ -17,21 +17,6 @@ import tests.common
 logging.basicConfig(level=logging.DEBUG)
 
 class TestTripManager(unittest.TestCase):
-  def updateSections(self):
-    """
-    Updates sections with appropriate test data
-    Should be called anytime new data is loaded into the
-    'Stage_Sections' table
-    """
-    for section in self.SectionsColl.find():
-      section['section_start_datetime'] = self.dayago
-      section['section_end_datetime'] = self.dayago + timedelta(hours = 1)
-      section['predicted_mode'] = [0, 0.4, 0.6, 0]
-      section['confirmed_mode'] = ''
-      # Replace the user email with the UUID
-      section['user_id'] = User.fromEmail(section['user_id']).uuid
-      self.SectionsColl.save(section)
-
   def setUp(self):
     self.testUsers = ["test@example.com", "best@example.com", "fest@example.com",
                       "rest@example.com", "nest@example.com"]
@@ -62,7 +47,7 @@ class TestTripManager(unittest.TestCase):
     self.now = datetime.now()
     self.dayago = self.now - timedelta(days=1)
     self.weekago = self.now - timedelta(weeks = 1)
-    self.updateSections()
+    tests.common.updateSections(self)
 
   def tearDown(self):
     for testUser in self.testUsers:
@@ -182,7 +167,7 @@ class TestTripManager(unittest.TestCase):
     # specific to filtering
     self.SectionsColl.remove()
     load_database_json.loadTable(self.serverName, "Stage_Sections", "tests/data/testFilterFile")   
-    self.updateSections() 
+    tests.common.updateSections(self) 
     # Extra updates to Sections necessary for testing filtering
     for section in self.SectionsColl.find():
       section['section_start_point'] = "filler start point"

--- a/CFC_WebApp/tests/TestVisualize.py
+++ b/CFC_WebApp/tests/TestVisualize.py
@@ -1,0 +1,68 @@
+import unittest
+import json
+from utils import load_database_json, purge_database_json
+from main import visualize
+from pymongo import MongoClient
+import logging
+from get_database import get_db, get_mode_db, get_section_db
+from datetime import datetime, timedelta
+
+logging.basicConfig(level=logging.DEBUG)
+
+class TestVisualize(unittest.TestCase):
+  def setUp(self):
+    import tests.common
+    from copy import copy
+
+    self.testUsers = ["test@example.com", "best@example.com", "fest@example.com",
+                      "rest@example.com", "nest@example.com"]
+    self.serverName = 'localhost'
+
+    # Sometimes, we may have entries left behind in the database if one of the tests failed
+    # or threw an exception, so let us start by cleaning up all entries
+    tests.common.dropAllCollections(get_db())
+    self.ModesColl = get_mode_db()
+    self.assertEquals(self.ModesColl.find().count(), 0)
+
+    load_database_json.loadTable(self.serverName, "Stage_Modes", "tests/data/modes.json")
+    load_database_json.loadTable(self.serverName, "Stage_Sections", "tests/data/testCarbonFile")
+    self.SectionsColl = get_section_db()
+
+    self.walkExpect = 1057.2524056424411
+    self.busExpect = 2162.668467546699
+    self.busCarbon = 267.0/1609
+    self.airCarbon = 217.0/1609
+    self.driveCarbon = 278.0/1609
+    self.busOptimalCarbon = 92.0/1609
+
+    self.now = datetime.now()
+    self.dayago = self.now - timedelta(days=1)
+    self.weekago = self.now - timedelta(weeks = 1)
+
+    for section in self.SectionsColl.find():
+      section['section_start_datetime'] = self.dayago
+      section['section_end_datetime'] = self.dayago + timedelta(hours = 1)
+      # Note that we currently only search by the date/time of the section, not the points.
+      # If we ever change that, this test will start failing and will need to be fixed as well
+      track_pt_array = []
+      for i in range(10):
+          track_pt_array.append({'time': '20140829T170451-0700',
+                 'track_location': {'coordinates': [-122.114642519, 37.4021455446],
+                                            'type': 'Point'}})
+          track_pt_array.append({'time': '20140829T170620-0700',
+                   'track_location': {'coordinates': [-122.1099155383, 37.399523614],
+                    'type': 'Point'}})
+      section['track_points'] = track_pt_array
+      self.SectionsColl.save(section)
+
+  def testCommutePopRoute(self):
+    points = visualize.Commute_pop_route(5, self.weekago, self.now)
+    # There are 5 sections with mode = 5 in the test data.
+    # We add 20 points to each section
+    # Then, we strip out the first 5 and last 5 points
+    # So each section contributes 10 points to this
+    # So we expect a total of 50 points
+    self.assertEquals(len(points['latlng']), 50)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/CFC_WebApp/tests/client_tests/TestDefault.py
+++ b/CFC_WebApp/tests/client_tests/TestDefault.py
@@ -6,17 +6,21 @@ import logging
 from get_database import get_db, get_mode_db, get_section_db
 from datetime import datetime, timedelta
 from dao.user import User
+import tests.common
 
 logging.basicConfig(level=logging.DEBUG)
 
 class TestDefault(unittest.TestCase):
     def setUp(self):
-        import tests.common
         # Sometimes, we may have entries left behind in the database if one of the tests failed
         # or threw an exception, so let us start by cleaning up all entries
         tests.common.dropAllCollections(get_db())
         user = User.register("fake@fake.com")
         self.uuid = user.uuid
+        self.serverName = "localhost"
+        self.now = datetime.now()
+        self.dayago = self.now - timedelta(days=1)
+        self.weekago = self.now - timedelta(weeks = 1)
 
     def testCarbonFootprintStore(self):
         user = User.fromUUID(self.uuid)
@@ -30,6 +34,28 @@ class TestDefault(unittest.TestCase):
     def testGetCategorySum(self):
         calcSum = default.getCategorySum({'walking': 1, 'cycling': 2, 'bus': 3, 'train': 4, 'car': 5})
         self.assertEqual(calcSum, 15)
+
+    def testRunBackgroundTasksForDay(self):
+        self.testUsers = ["test@example.com", "best@example.com", "fest@example.com",
+                          "rest@example.com", "nest@example.com"]
+        load_database_json.loadTable(self.serverName, "Stage_Modes", "tests/data/modes.json")
+        load_database_json.loadTable(self.serverName, "Stage_Sections", "tests/data/testCarbonFile")
+
+        # Let's make sure that the users are registered so that they have profiles
+        for userEmail in self.testUsers:
+          User.register(userEmail)
+
+        self.SectionsColl = get_section_db()
+        tests.common.updateSections(self)
+
+        self.assertNotEqual(len(self.uuid_list), 0)
+        # Can access the zeroth element because we know that then length is greater than zero
+        # (see above)
+        test_uuid = self.uuid_list[0]
+        test_user = User.fromUUID(test_uuid)
+        self.assertNotIn('carbon_footprint', test_user.getProfile().keys())
+        default.runBackgroundTasks(self.uuid_list[0])
+        self.assertIn('carbon_footprint', test_user.getProfile().keys())
 
 if __name__ == '__main__':
     unittest.main()

--- a/CFC_WebApp/tests/client_tests/TestGamified.py
+++ b/CFC_WebApp/tests/client_tests/TestGamified.py
@@ -133,5 +133,12 @@ class TestGamified(unittest.TestCase):
         self.assertEqual(gamified.getFileName(1.0, 2.0), "level_1_2.png")
         self.assertEqual(gamified.getFileName(1.055, 2), "level_1_2.png")
 
+    def testRunBackgroundTasksForDay(self):
+        self.assertEqual(gamified.getStoredScore(self.user), (0, 0))
+        components = gamified.runBackgroundTasks(self.user.uuid)
+        expectedScore = 0.75 * 50 + 30 * self.allDriveMinusMineExpect + 20 * 0.0 + \
+            10 * self.sb375DailyGoalMinusMineExpect
+        self.assertEqual(gamified.getStoredScore(self.user), (0, expectedScore))
+
 if __name__ == '__main__':
     unittest.main()

--- a/CFC_WebApp/tests/common.py
+++ b/CFC_WebApp/tests/common.py
@@ -1,6 +1,6 @@
+from datetime import datetime, timedelta
 
 def makeValid(client):
-  from datetime import datetime, timedelta
   from get_database import get_client_db
 
   client.clientJSON['start_date'] = str(datetime.now() + timedelta(days=-2))
@@ -9,7 +9,6 @@ def makeValid(client):
   client._Client__update(client.clientJSON)
 
 def makeExpired(client):
-  from datetime import datetime, timedelta
   from get_database import get_client_db
 
   client.clientJSON['start_date'] = str(datetime.now() + timedelta(days=-4))
@@ -18,7 +17,6 @@ def makeExpired(client):
   client._Client__update(client.clientJSON)
 
 def updateUserCreateTime(uuid):
-  from datetime import datetime, timedelta
   from dao.user import User
   
   user = User.fromUUID(uuid)
@@ -54,4 +52,22 @@ def createDummySection(startTime, endTime, startLoc, endLoc, predictedMode = Non
 
   get_section_db().insert(section)
   return section
-    
+
+def updateSections(testCase):
+    from dao.user import User
+    """
+    Updates sections with appropriate test data
+    Should be called anytime new data is loaded into the
+    'Stage_Sections' table
+    """
+    testCase.uuid_list = []
+    for section in testCase.SectionsColl.find():
+      section['section_start_datetime'] = testCase.dayago
+      section['section_end_datetime'] = testCase.dayago + timedelta(hours = 1)
+      section['predicted_mode'] = [0, 0.4, 0.6, 0]
+      section['confirmed_mode'] = ''
+      # Replace the user email with the UUID
+      curr_uuid = User.fromEmail(section['user_id']).uuid
+      section['user_id'] = curr_uuid
+      testCase.uuid_list.append(curr_uuid)
+      testCase.SectionsColl.save(section)


### PR DESCRIPTION
Changes to get all the auxiliary scripts to work again
    
Most of this involved fixing import statements, but here were also functionality changes for which I added the appropriate test cases.

- in the data collection, then trip start time and/or end time could be blank
- for the default carbon footprint calculation, we needed to use a datetime for the query, not just a date
- changed the heatmap visualization to reflect all trips, not just commute trips, and changed the labels to reflect the change