### PR TITLE
Alternative api endpoint for /compare that utilizes get request with custom auth header

### DIFF
--- a/CFC_WebApp/api/cfc_webapp.py
+++ b/CFC_WebApp/api/cfc_webapp.py
@@ -34,7 +34,7 @@ hack_client_key = key_data["ios_client_key"]
 BaseRequest.MEMFILE_MAX = 1024 * 1024 * 1024 # Allow the request size to be 1G
 # to accomodate large section sizes
 
-skipAuth = True
+skipAuth = False
 
 app = app()
 

--- a/CFC_WebApp/api/cfc_webapp.py
+++ b/CFC_WebApp/api/cfc_webapp.py
@@ -34,7 +34,7 @@ hack_client_key = key_data["ios_client_key"]
 BaseRequest.MEMFILE_MAX = 1024 * 1024 * 1024 # Allow the request size to be 1G
 # to accomodate large section sizes
 
-skipAuth = False
+skipAuth = True
 
 app = app()
 
@@ -262,16 +262,18 @@ def setStats():
   inStats = request.json['stats']
   stats.setClientMeasurements(user_uuid, inStats)
 
-@post('/compare')
-# @get('/compare')
+# @post('/compare')
+@get('/compare')
 def getCarbonCompare():
+  for key, val in request.headers.items():
+    print("  %s: %s" % (key, val))
+  # token = request.headers.get('Authorization')
+  # print token
+
   from clients.default import default
-
-  if request.json == None:
-    return "Waiting for user data to become available..."
-
-  if 'user' not in request.json:
-    return "Waiting for user data to be become available.."
+  
+  # if token is None or 'Bearer' not in token:
+  #   return "Waiting for user data to become available..."
 
   user_uuid = getUUID(request)
   clientResult = userclient.getClientSpecificResult(user_uuid)
@@ -382,7 +384,8 @@ def getUUID(request):
     retUUID = user_uuid
     logging.debug("skipAuth = %s, returning fake UUID %s" % (skipAuth, user_uuid))
   else:
-    userToken = request.json['user']
+    userToken = request.headers.get('Authorization').split()[1]
+    # userToken = request.json['user']
     retUUID = getUUIDFromToken(userToken)
   request.params.user_uuid = retUUID
   return retUUID

--- a/CFC_WebApp/api/cfc_webapp.py
+++ b/CFC_WebApp/api/cfc_webapp.py
@@ -262,20 +262,37 @@ def setStats():
   inStats = request.json['stats']
   stats.setClientMeasurements(user_uuid, inStats)
 
-# @post('/compare')
+@post('/compare')
+def postCarbonCompare():
+  from clients.default import default
+
+  if request.json == None:
+    return "Waiting for user data to become available..."
+
+  if 'user' not in request.json:
+    return "Waiting for user data to be become available.."
+
+  user_uuid = getUUID(request)
+  clientResult = userclient.getClientSpecificResult(user_uuid)
+  if clientResult != None:
+    logging.debug("Found overriding client result for user %s, returning it" % user_uuid)
+    return clientResult
+  else:
+    logging.debug("No overriding client result for user %s, returning default" % user_uuid)
+  return default.getResult(user_uuid)
+
 @get('/compare')
 def getCarbonCompare():
   for key, val in request.headers.items():
     print("  %s: %s" % (key, val))
-  # token = request.headers.get('Authorization')
-  # print token
 
   from clients.default import default
   
-  # if token is None or 'Bearer' not in token:
-  #   return "Waiting for user data to become available..."
+  if 'User' not in request.headers or request.headers.get('User') == '':
+    return "Waiting for user data to become available..."
 
-  user_uuid = getUUID(request)
+  user_uuid = getUUID(request, inHeader=True)
+  print ('UUID', user_uuid)
   clientResult = userclient.getClientSpecificResult(user_uuid)
   if clientResult != None:
     logging.debug("Found overriding client result for user %s, returning it" % user_uuid)
@@ -371,7 +388,7 @@ def getUUIDFromToken(token):
     user_uuid=user.uuid
     return user_uuid
 
-def getUUID(request):
+def getUUID(request, inHeader=False):
   retUUID = None
   if skipAuth:
     from uuid import UUID
@@ -384,8 +401,10 @@ def getUUID(request):
     retUUID = user_uuid
     logging.debug("skipAuth = %s, returning fake UUID %s" % (skipAuth, user_uuid))
   else:
-    userToken = request.headers.get('Authorization').split()[1]
-    # userToken = request.json['user']
+    if inHeader:
+      userToken = request.headers.get('Authorization').split()[1]
+    else:
+      userToken = request.json['user']
     retUUID = getUUIDFromToken(userToken)
   request.params.user_uuid = retUUID
   return retUUID

--- a/CFC_WebApp/api/cfc_webapp.py
+++ b/CFC_WebApp/api/cfc_webapp.py
@@ -288,7 +288,7 @@ def getCarbonCompare():
 
   from clients.default import default
   
-  if 'User' not in request.headers or request.headers.get('User') == '':
+  if 'user' not in request.headers or request.headers.get('user') == '':
     return "Waiting for user data to become available..."
 
   user_uuid = getUUID(request, inHeader=True)
@@ -402,7 +402,7 @@ def getUUID(request, inHeader=False):
     logging.debug("skipAuth = %s, returning fake UUID %s" % (skipAuth, user_uuid))
   else:
     if inHeader:
-      userToken = request.headers.get('Authorization').split()[1]
+      userToken = request.headers.get('user').split()[1]
     else:
       userToken = request.json['user']
     retUUID = getUUIDFromToken(userToken)


### PR DESCRIPTION
Used for making caching of the results summary page possible.