### PR TITLE
Support the User header correctly

### DIFF
--- a/CFC_WebApp/api/cfc_webapp.py
+++ b/CFC_WebApp/api/cfc_webapp.py
@@ -300,7 +300,7 @@ def getCarbonCompare():
 
   from clients.default import default
   
-  if 'user' not in request.headers or request.headers.get('user') == '':
+  if 'User' not in request.headers or request.headers.get('User') == '':
     return "Waiting for user data to become available..."
 
   user_uuid = getUUID(request, inHeader=True)
@@ -430,7 +430,7 @@ def getUUID(request, inHeader=False):
     logging.debug("skipAuth = %s, returning fake UUID %s" % (skipAuth, user_uuid))
   else:
     if inHeader:
-      userToken = request.headers.get('user').split()[1]
+      userToken = request.headers.get('User').split()[1]
     else:
       userToken = request.json['user']
     retUUID = getUUIDFromToken(userToken)

--- a/CFC_WebApp/views/compare.html
+++ b/CFC_WebApp/views/compare.html
@@ -7,6 +7,11 @@
     <link href="front/nv.d3.css" rel="stylesheet" type="text/css">
     <link href="front/cfc.display.css" rel="stylesheet" type="text/css">
 
+    <!--
+        Now that we have caching turned on in the client, we need to version
+        all the javascript files here if we want to ensure that updates to them are
+        visible to the client. This includes our supporting javascript files.
+    -->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/d3/3.4.2/d3.js" charset="utf-8"></script>
     <script src="front/nv.d3.min.js" charset="utf-8"></script>


### PR DESCRIPTION
And also experiment to see when changed files are made available to the client.
The answer is that we need to include versioning of the javascript files in
order to bypass all the caches.