### PR TITLE
Integrate the canonical trip calculation with the rest of the recomme…

### DIFF
--- a/CFC_DataCollector/recommender/recommendation_pipeline.py
+++ b/CFC_DataCollector/recommender/recommendation_pipeline.py
@@ -4,6 +4,7 @@ from user_utility_model import UserUtilityModel
 from emissions_model import EmissionsModel
 from simple_cost_time_mode_model import SimpleCostTimeModeModel
 import tripiterator as ti
+import trip as t
 from common import get_uuid_list, get_recommender_uuid_list
 import uuid
 import alternative_trips_module as atm
@@ -15,7 +16,7 @@ class RecommendationPipeline:
         # will make usage of canonical trip class
         # returns a list of trips implementing Trip interface, could be basic E_Mission_Trips or canonical
         # TODO: Stubbed out returning all move trips in order to allow tests to pass
-        return list(ti.TripIterator(user_uuid, ["recommender", "get_improve"]))
+        return list(ti.TripIterator(user_uuid, ["recommender", "get_improve"], trip_class=t.Canonical_E_Mission_Trip))
 
     def retrieve_alternative_trips(self, trip_list):
         return []

--- a/CFC_DataCollector/recommender/tripiterator.py
+++ b/CFC_DataCollector/recommender/tripiterator.py
@@ -37,8 +37,9 @@ class TripIterator(object):
                 self.storedIter = query_function(user_uuid, option)
             else:
                 # no options
-                #print "Query function: ", query_function
+                print "Query function: ", query_function
                 self.storedIter = query_function(user_uuid)
+            print "storedIter = %s" % self.storedIter
         except TypeError as e:
             print e
             print "something went wrong, here is some info:"

--- a/CFC_DataCollector/tests/recommenderTests/TestRecommendationPipeline.py
+++ b/CFC_DataCollector/tests/recommenderTests/TestRecommendationPipeline.py
@@ -4,7 +4,7 @@ import json
 #from main import tripManager
 from pymongo import MongoClient
 import logging
-from get_database import get_db, get_mode_db, get_section_db, get_trip_db
+from get_database import get_db, get_mode_db, get_section_db, get_trip_db, get_routeCluster_db
 import re
 import sys
 import os
@@ -35,13 +35,16 @@ class TestRecommendationPipeline(unittest.TestCase):
     for row in dataJSON:
       self.ModesColl.insert(row)
 
+    get_section_db().remove({"user_id": self.testUUID})
     result = self.loadTestJSON("tests/data/missing_trip")
     collect.processResult(self.testUUID, result)
+    print get_section_db().find().count()
     self.pipeline = RecommendationPipeline()
 
   def tearDown(self):
     get_section_db().remove({"user_id": self.testUUID})
     self.ModesColl.remove()
+    get_routeCluster_db().remove()
     self.assertEquals(self.ModesColl.find().count(), 0)
 
   def loadTestJSON(self, fileName):
@@ -51,8 +54,16 @@ class TestRecommendationPipeline(unittest.TestCase):
   def testRetrieveTripsToImprove(self):
     #updated to 15, since I am filtering out places
     trip_list = self.pipeline.get_trips_to_improve(self.testUUID)
-    # self.assertEquals(len(trip_list), 5)
-    # Trip 20140407T175709-0700 has two sections
+    self.assertEquals(len(trip_list), 0)
+
+  def testRetrieveTripsToImproveWithClusters(self):
+    sectionList = list(get_section_db().find())
+    get_routeCluster_db().insert({"user": self.testUUID,
+        "clusters": 
+            {"cluster1": [s["_id"] for s in sectionList[0:10]],
+             "cluster2": [s["_id"] for s in sectionList[10:20]]}})
+    trip_list = self.pipeline.get_trips_to_improve(self.testUUID)
+    self.assertEquals(len(trip_list), 2)
 
   def testRecommendTrip(self):
     recommended_trips = self.pipeline.runPipeline()

--- a/CFC_WebApp/api/cfc_webapp.py
+++ b/CFC_WebApp/api/cfc_webapp.py
@@ -279,6 +279,7 @@ def setStats():
 @post('/compare')
 def postCarbonCompare():
   from clients.data import data
+  from clients.choice import choice
 
   if request.json == None:
     return "Waiting for user data to become available..."


### PR DESCRIPTION
…nder pipeline

The mode inference team had changed the canonical trip calculation to make it
work. However, the recommender pipeline was still returning the training trips
as canonical trips. This change hooks things up so that the recommender
pipeline returns the canonical trips

Extended the recommender pipeline test to test this case and fixed a bunch of
bugs found in testing. Notably, we should return an iterator, we should pass in
the Canonical_E_Mission_trip as a class to the iterator, we were assuming that
the input user UUID was encoded as a string?!

All tests currently PASS