### PR TITLE
Bunch of fixes encountered while pushing to production

### DIFF
--- a/CFC_WebApp/clients/choice/front/ionic-tabs-myapp.js
+++ b/CFC_WebApp/clients/choice/front/ionic-tabs-myapp.js
@@ -138,11 +138,11 @@ angular.module('e-mission-choice', ['ionic'])
   }
 })
 
-.controller('CommonTripsCtrl', function($scope, $ionicModal) {
+.controller('FooCtrl', function($scope, $ionicModal) {
   // alert("GameCtrl called");
 
   $scope.onCommonTripsClicked = function() {
-    $scope.setCurrChoice("commontrips")
+    $scope.setCurrChoice("commontrips");
   }
 
   $scope.onCommonTripsSelected = function() {
@@ -178,3 +178,4 @@ angular.module('e-mission-choice', ['ionic'])
     }, 1000);
   }
 });
+

--- a/CFC_WebApp/clients/choice/result_template.html
+++ b/CFC_WebApp/clients/choice/result_template.html
@@ -73,7 +73,7 @@
             icon="ion-map"
             on-select="onCommonTripsSelected()"
             ng-click="onCommonTripsClicked()"
-            ng-controller="CommonTripsCtrl">
+            ng-controller="FooCtrl">
         <ion-content has-tabs="true" on-refresh="onRefresh()">
            <div id="commontrips-div">
             <iframe inline-result src='data:text/html;base64,{{commonTripsResult}}' height="100%" width="100%" seamless>

--- a/CFC_WebApp/clients/commontrips/commontrips.py
+++ b/CFC_WebApp/clients/commontrips/commontrips.py
@@ -33,6 +33,7 @@ def generate_tour_map(user_uuid):
     """
     Generates tour map and saves it to result_template.html 
     """
+    sys.path.append("%s/../../CFC_WebApp/" % os.getcwd())
     import main.pygmaps_modified as pygmaps
     from main.gmap_display import drawSection
     from get_database import get_section_db, get_routeCluster_db
@@ -48,12 +49,13 @@ def generate_tour_map(user_uuid):
     except OSError:
         pass
     gmap.draw('clients/commontrips/result_template.html')
+    sys.path.remove("%s/../../CFC_WebApp/" % os.getcwd())
 
 def getResult(user_uuid):
   # This is in here, as opposed to the top level as recommended by the PEP
   # because then we don't have to worry about loading bottle in the unit tests
   from bottle import template
-  print "getResult UUID: %s" % user_uuid
+  print "common trips getResult UUID: %s" % user_uuid
   generate_tour_map(user_uuid)
   renderedTemplate = template("clients/commontrips/result_template.html")
   return renderedTemplate

--- a/CFC_WebApp/clients/recommendation/recommendation.py
+++ b/CFC_WebApp/clients/recommendation/recommendation.py
@@ -13,10 +13,7 @@ def getResult(user_uuid):
   # because then we don't have to worry about loading bottle in the unit tests
   from bottle import template
 
-  user_uuid = "6433c8cf-c4c5-3741-9144-5905379ece6e"
-  user = User.fromUUID(user_uuid)
-
-  original_trip = get_trip_db().find_one({'user_id': UUID(user.uuid), 'recommended_alternative': {'$exists': True}})
+  original_trip = get_trip_db().find_one({'user_id': user_uuid, 'recommended_alternative': {'$exists': True}})
 
   if original_trip is None:
       return template("clients/recommendation/no_recommendation.html")


### PR DESCRIPTION
- Add pygmaps to the path just before and after generating the map
- Remove some hardcoded stuff in recommender that appears to have been
  (re)introduced as part of a merge conflict
- Fix a totally bizarre issue in which, on android, the webview is unable to
  correctly parse the CommonTripsCtrl if it is named anything other than
  "FooCtrl". Even "CooCtrl" doesn't work. I've only tried this in the emulator -
  maybe it works on a real phone. However, people might want to test in the
  emulator, so renamed to FooCtrl. At this point, I can see all the options on
  both emulators and my physical phone.