### PR TITLE
Add a version to the javascript to force download of the file

### DIFF
--- a/CFC_WebApp/clients/choice/result_template.html
+++ b/CFC_WebApp/clients/choice/result_template.html
@@ -5,7 +5,7 @@
     <title>Inline Tabs</title>
 
     <script src="clients/choice/front/ionic.bundle.js" charset="utf-8"></script>
-    <script src="clients/choice/front/ionic-tabs-myapp.js"></script>
+    <script src="clients/choice/front/ionic-tabs-myapp.js?v=1"></script>
 
     <link rel="stylesheet" href="clients/choice/front/ionic.min.css">
   </head>


### PR DESCRIPTION
This is moderately bizarre, but basically, the version currently deployed to
the app store appears to aggressively cache the supporting javascript files.
That means that it doesn't find the controllers that we added later. So I'm
using a trick that I found on stackoverflow - adding a version tag forces the
javascript to be retrieved again.

With this change, the existing production version also show all the new tabs