### PR TITLE
Server changes to simplify development by skipping authorization

### DIFF
--- a/CFC_WebApp/dao/client.py
+++ b/CFC_WebApp/dao/client.py
@@ -96,6 +96,8 @@ class Client:
     return method(request)
 
   def getClientKey(self):
+    if self.clientJSON is None:
+        return None
     logging.debug("About to return %s from JSON %s" % (self.clientJSON['key'], self.clientJSON))
     return self.clientJSON['key']
 


### PR DESCRIPTION
When we are connected to a development server, skip the creation of the JWT and
just send the unencrypted email address instead. This makes it much easier to
start end to end development.