### PR TITLE
Sometimes the document is in the error database because of operations…

### DIFF
--- a/emission/net/usercache/builtin_usercache_handler.py
+++ b/emission/net/usercache/builtin_usercache_handler.py
@@ -1,5 +1,7 @@
 import logging
 import attrdict as ad
+# This is only to allow us to catch the DuplicateKeyError
+import pymongo
 
 import emission.net.usercache.abstract_usercache_handler as enuah
 import emission.net.usercache.abstract_usercache as enua
@@ -52,6 +54,8 @@ class BuiltinUserCacheHandler(enuah.UserCacheHandler):
                 unified_entry = enuf.convert_to_common_format(entry)
                 ts.insert(unified_entry)
                 last_ts_processed = ecwe.Entry(unified_entry).metadata.write_ts
+            except pymongo.errors.DuplicateKeyError as e:
+                logging.info("document already present in timeseries, skipping since read-only")
             except Exception as e:
                 logging.exception("Backtrace time")
                 logging.warn("Got error %s while saving entry %s -> %s"% (e, entry, unified_entry))


### PR DESCRIPTION
… after the formatting

This means that it has already been saved to the timeseries database, which
means that when we try to fix the error database, the insert will fail with a
DuplicateKeyError, which will again put it into the error database and so on,
ad infinitum.

We want to keep the timeseries database as read-only, so we ignore the entry if
it was already in the timeseries database.