### PR TITLE
Make saving to the usercache more performant

### DIFF
--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -133,10 +133,10 @@ def get_perturbed_trips_db():
 def get_usercache_db():
     current_db = MongoClient().Stage_database
     UserCache = current_db.Stage_usercache
-    UserCache.create_index([("user_id", pymongo.DESCENDING),
-                            ("metadata.type", pymongo.DESCENDING),
-                            ("metadata.write_ts", pymongo.DESCENDING),
-                            ("metadata.key", pymongo.DESCENDING)])
+    UserCache.create_index([("user_id", pymongo.ASCENDING),
+                            ("metadata.type", pymongo.ASCENDING),
+                            ("metadata.write_ts", pymongo.ASCENDING),
+                            ("metadata.key", pymongo.ASCENDING)])
     return UserCache
 
 def get_timeseries_db():

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -133,6 +133,10 @@ def get_perturbed_trips_db():
 def get_usercache_db():
     current_db = MongoClient().Stage_database
     UserCache = current_db.Stage_usercache
+    UserCache.create_index([("user_id", pymongo.DESCENDING),
+                            ("metadata.type", pymongo.DESCENDING),
+                            ("metadata.write_ts", pymongo.DESCENDING),
+                            ("metadata.key", pymongo.DESCENDING)])
     return UserCache
 
 def get_timeseries_db():

--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -24,9 +24,9 @@ def sync_phone_to_server(uuid, data_from_phone):
         Puts the blob from the phone into the cache
     """
     for data in data_from_phone:
-        logging.debug("About to insert %s into the database" % data)
+        # logging.debug("About to insert %s into the database" % data)
         data.update({"user_id": uuid})
-        logging.debug("After updating with UUId, we get %s" % data)
+        # logging.debug("After updating with UUId, we get %s" % data)
         document = {'$set': data}
         update_query = {'user_id': uuid,
                         'metadata.type': data["metadata"]["type"],
@@ -35,8 +35,8 @@ def sync_phone_to_server(uuid, data_from_phone):
         result = get_usercache_db().update(update_query,
                                            document,
                                            upsert=True)
-        logging.debug("Updated result for key = %s, write_ts = %s = %s" % 
-            (data["metadata"]["key"], data["metadata"]["write_ts"], result))
+        logging.debug("Updated result for user = %s, key = %s, write_ts = %s = %s" % 
+            (uuid, data["metadata"]["key"], data["metadata"]["write_ts"], result))
         if 'err' in result and result['err'] is not None:
             logging.error("In sync_phone_to_server, err = %s" % result['err'])
             raise Exception()

--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -4,6 +4,7 @@
 
 # Standard imports
 import logging
+import pymongo
 
 # Our imports
 from emission.core.get_database import get_usercache_db
@@ -14,7 +15,7 @@ def sync_server_to_phone(uuid):
         Return None if there is no data
     """
     retrievedData = list(get_usercache_db().find({"user_id": uuid, "metadata.type": "document"}, # query
-                                            {'_id': False, 'user_id': False})) # projection
+                                            {'_id': False, 'user_id': False}).sort("metadata.write_ts", pymongo.ASCENDING)) # projection, sort
     
     # logging.debug("retrievedData = %s" % retrievedData)
     return retrievedData

--- a/emission/net/usercache/builtin_usercache.py
+++ b/emission/net/usercache/builtin_usercache.py
@@ -1,6 +1,7 @@
 # Standard imports
 import logging
 import time
+import pymongo
 
 # Our imports
 import emission.net.usercache.abstract_usercache as ucauc # ucauc = usercache.abstract_usercache
@@ -134,7 +135,11 @@ class BuiltinUserCache(ucauc.UserCache):
         }
         update_result = self.db.update(combo_query, update_read)
         logging.debug("result = %s after updating read timestamp", update_result)
-        retrievedMsgs = list(self.db.find(combo_query))
+        # In the handler, we assume that the messages are processed in order of
+        # the write timestamp, because we use the last_ts_processed to mark the
+        # beginning of the entry for the next query. So let's sort by the
+        # write_ts before returning.
+        retrievedMsgs = list(self.db.find(combo_query).sort("metadata.write_ts", pymongo.ASCENDING))
         logging.debug("Found %d messages in response to query %s" % (len(retrievedMsgs), combo_query))
         return retrievedMsgs
 


### PR DESCRIPTION
The code to save data to the usercache is now more performant. Before this, we
did not have an index on the usercache. The assumption was that since the
usercache would be cleared out every hour or so, we don't need an index. But as
the load on the usercache increased, adding new values to it got slower and
slower until it started timing out the connection. Which meant that the clients
retried and flooded the usercache with even more data.

Right now, the usercache has a bunch of pending messages, and I am pretty sure
that this is the reason, although I need to verify.

At any rate, creating an index doesn't hurt, and will fix it if/when this falls
apart again. With the index, the timeouts have stopped and the data is again
flowing in smoothly.