### PR TITLE
Support retrieving the timeline for a particular day

### DIFF
--- a/emission/analysis/plotting/geojson/geojson_feature_converter.py
+++ b/emission/analysis/plotting/geojson/geojson_feature_converter.py
@@ -241,10 +241,21 @@ def trip_to_geojson(trip, tl):
     trip_geojson.properties["distance"] = trip_distance
     return trip_geojson
 
-def get_geojson_for_range(user_id, start_ts, end_ts):
-    geojson_list = []
+def get_geojson_for_ts(user_id, start_ts, end_ts):
     tl = esdtl.get_timeline(user_id, start_ts, end_ts)
     tl.fill_start_end_places()
+    return get_geojson_for_timeline(user_id, tl)
+
+def get_geojson_for_dt(user_id, start_dt, end_dt):
+    tl = esdtl.get_timeline(user_id, start_dt, end_dt)
+    tl.fill_start_end_places()
+    return get_geojson_for_timeline(user_id, tl)
+
+def get_geojson_for_timeline(user_id, tl):
+    """
+    tl represents the "timeline" object that is queried for the trips and locations
+    """
+    geojson_list = []
 
     for trip in tl.trips:
         try:

--- a/emission/analysis/plotting/leaflet_osm/our_plotter.py
+++ b/emission/analysis/plotting/leaflet_osm/our_plotter.py
@@ -42,7 +42,7 @@ def df_to_string_list(df):
 
 def get_maps_for_range(user_id, start_ts, end_ts):
     map_list = []
-    geojson_list = gfc.get_geojson_for_range(user_id, start_ts, end_ts)
+    geojson_list = gfc.get_geojson_for_ts(user_id, start_ts, end_ts)
     return get_maps_for_geojson_list(geojson_list)
 
 def get_maps_for_usercache(user_id):

--- a/emission/core/common.py
+++ b/emission/core/common.py
@@ -13,6 +13,9 @@ from emission.core.get_database import get_mode_db, get_section_db, get_trip_db,
 
 skippedModeList = ["transport", "underground", "not a trip"]
 
+def isMillisecs(ts):
+  return not (ts < 10 ** 11)
+
 def getAllModes():
   Modes = get_mode_db()
   modes = []

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -255,6 +255,14 @@ def putIntoCache():
   from_phone = request.json['phone_to_server']
   return usercache.sync_phone_to_server(user_uuid, from_phone)
 
+@post('/timeline/getTrips/<day>')
+def getTrips(day):
+  logging.debug("Called timeline.getTrips/%s" % day)
+  user_uuid=getUUID(request)
+  force_refresh = request.query.get('refresh', False)
+  logging.debug("user_uuid %s" % user_uuid)
+  return timeline.get_trips_for_day(user_uuid, day, force_refresh)
+
 @post('/profile/create')
 def createUserProfile():
   logging.debug("Called createUserProfile")

--- a/emission/net/api/timeline.py
+++ b/emission/net/api/timeline.py
@@ -1,0 +1,32 @@
+# Standard imports
+import logging
+import dateutil.parser as dup
+import json
+import datetime as pydt
+import time
+
+# Our imports
+import emission.core.get_database as edb
+import emission.net.usercache.abstract_usercache as enua
+import emission.analysis.plotting.geojson.geojson_feature_converter as gfc
+
+def get_trips_for_day(user_uuid, day)
+    """
+    The day argument here is a string such as 2015-10-01 or 2016-01-01. We will
+    parse this to a datetime, which we will use to query the data in the
+    timeseries. We could also cache the timeline views in a separate collection
+    and just look up from there. The challenge is to then decide when to
+    recompute a view - we can't use the standard technique that we use for the
+    other stages because we will have to recompute the timeline for the current
+    day multiple times, for example.
+    """
+    # I was going to read from the user cache if it existed there, and recreate
+    # from scratch if it didn't. But that would involve adding a getDocument
+    # field to the usercache, which I had intentionally not added before this.
+    # The problem with adding a getDocument method is that then the usercache
+    # is no longer a cache - it is "storage" that is used internally. If we
+    # want to do that, we should really store it as a materialized view and not
+    # only in the usercache, which should be a cache of values stored elsewhere.
+    start_dt = dup.parse(day)
+    end_dt = start_dt + pydt.timedelta(days=1)
+    return gfc.get_geojson_for_dt(user_uuid, start_dt, end_dt)

--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -32,7 +32,7 @@ def sync_phone_to_server(uuid, data_from_phone):
         if ecc.isMillisecs(data["metadata"]["write_ts"]:
             data["metadata"]["write_ts"] = float(data["metadata"]["write_ts"]) / 1000
 
-        if "ts" in data["data"]:
+        if "ts" in data["data"] and ecc.isMillisecs(data["data"]["ts"]):
             data["data"]["ts"] = float(data["data"]["ts"]) / 1000
             
         # logging.debug("After updating with UUId, we get %s" % data)

--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -29,7 +29,7 @@ def sync_phone_to_server(uuid, data_from_phone):
         # logging.debug("About to insert %s into the database" % data)
         data.update({"user_id": uuid})
         # Hack to deal with milliseconds until we have moved everything over
-        if ecc.isMillisecs(data["metadata"]["write_ts"]:
+        if ecc.isMillisecs(data["metadata"]["write_ts"]):
             data["metadata"]["write_ts"] = float(data["metadata"]["write_ts"]) / 1000
 
         if "ts" in data["data"] and ecc.isMillisecs(data["data"]["ts"]):

--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -8,6 +8,7 @@ import pymongo
 
 # Our imports
 from emission.core.get_database import get_usercache_db
+import emission.core.common as ecc
 
 def sync_server_to_phone(uuid):
     """
@@ -27,6 +28,13 @@ def sync_phone_to_server(uuid, data_from_phone):
     for data in data_from_phone:
         # logging.debug("About to insert %s into the database" % data)
         data.update({"user_id": uuid})
+        # Hack to deal with milliseconds until we have moved everything over
+        if ecc.isMillisecs(data["metadata"]["write_ts"]:
+            data["metadata"]["write_ts"] = float(data["metadata"]["write_ts"]) / 1000
+
+        if "ts" in data["data"]:
+            data["data"]["ts"] = float(data["data"]["ts"]) / 1000
+            
         # logging.debug("After updating with UUId, we get %s" % data)
         document = {'$set': data}
         update_query = {'user_id': uuid,

--- a/emission/net/usercache/builtin_usercache_handler.py
+++ b/emission/net/usercache/builtin_usercache_handler.py
@@ -188,7 +188,7 @@ class BuiltinUserCacheHandler(enuah.UserCacheHandler):
         seventy_two_hours_ago_ts = self.get_oldest_valid_ts(start_ts)
         # TODO: This is not strictly accurate, since it will skip trips that were in a later timezone but within the
         # same requested date range.
-        trip_gj_list = gfc.get_geojson_for_range(self.user_id, seventy_two_hours_ago_ts, start_ts)
+        trip_gj_list = gfc.get_geojson_for_ts(self.user_id, seventy_two_hours_ago_ts, start_ts)
         logging.debug("Found %s trips in seven days starting from %s" % (len(trip_gj_list), start_ts))
         return trip_gj_list
 

--- a/emission/net/usercache/builtin_usercache_handler.py
+++ b/emission/net/usercache/builtin_usercache_handler.py
@@ -47,8 +47,7 @@ class BuiltinUserCacheHandler(enuah.UserCacheHandler):
             # esp.mark_usercache_done(None)
             return
 
-        platform = messages[0]["metadata"]["platform"]
-        time_query = esp.get_time_range_for_usercache(self.user_id, platform)
+        time_query = esp.get_time_range_for_usercache(self.user_id)
 
         ts = etsa.TimeSeries.get_time_series(self.user_id)
 

--- a/emission/net/usercache/formatters/android/location.py
+++ b/emission/net/usercache/formatters/android/location.py
@@ -20,6 +20,9 @@ def format(entry):
     else:
         return format_location_simple(entry)
 
+# TODO: Remove the RAW code since we don't really have any clients that 
+# are sending it. But while it is there, we should still convert ms to sec
+# since the old data did have that in place
 def format_location_raw(entry):
     formatted_entry = ad.AttrDict()
     formatted_entry["_id"] = entry["_id"]
@@ -55,12 +58,10 @@ def format_location_simple(entry):
     metadata = entry.metadata
     if "time_zone" not in metadata:
         metadata.time_zone = "America/Los_Angeles" 
-    metadata.write_ts = float(entry.metadata.write_ts) / 1000
     fc.expand_metadata_times(metadata)
     formatted_entry.metadata = metadata
 
     data = entry.data
-    data.ts = float(data.ts) / 1000 # convert from ms to seconds
     local_aware_dt = pydt.datetime.utcfromtimestamp(data.ts).replace(tzinfo=pytz.utc) \
                             .astimezone(pytz.timezone(formatted_entry.metadata.time_zone))
     data.local_dt = local_aware_dt.replace(tzinfo=None)

--- a/emission/net/usercache/formatters/android/motion_activity.py
+++ b/emission/net/usercache/formatters/android/motion_activity.py
@@ -12,7 +12,6 @@ def format(entry):
     metadata = entry.metadata
     if "time_zone" not in metadata:
         metadata.time_zone = "America/Los_Angeles" 
-    metadata.write_ts = float(entry.metadata.write_ts) / 1000
     fc.expand_metadata_times(metadata)
     formatted_entry.metadata = metadata
 

--- a/emission/net/usercache/formatters/android/transition.py
+++ b/emission/net/usercache/formatters/android/transition.py
@@ -27,7 +27,6 @@ def format(entry):
     m = entry.metadata
     if "time_zone" not in m:
         m.time_zone = "America/Los_Angeles" 
-    m.write_ts = float(entry.metadata.write_ts) / 1000
     logging.debug("Timestamp conversion: %s -> %s done" % (entry.metadata.write_ts, m.write_ts))
     fc.expand_metadata_times(m)
     formatted_entry.metadata = m

--- a/emission/storage/decorations/timeline.py
+++ b/emission/storage/decorations/timeline.py
@@ -1,6 +1,18 @@
 import logging
 import emission.net.usercache.abstract_usercache as enua
 
+def get_timeline_from_dt(user_id, start_dt, end_dt):
+    import emission.core.get_database as edb
+    import emission.core.wrapper.entry as ecwe
+
+    result_cursor = edb.get_timeseries_db().find({"data.local_dt": {"$gte": start_dt, "$lte": end_dt}}).sort("metadata.write_ts")
+    result_list = list(result_cursor)
+    start_ts = ecwe.Entry(result_list[0]).metadata.write_ts
+    end_ts = ecwe.Entry(result_list[-1]).metadata.write_ts
+    logging.debug("Converted datetime range %s -> %s to timestamp range %s -> %s" %
+        (start_dt, end_dt, start_ts, end_ts))
+    return get_timeline(user_id, start_ts, end_ts)
+
 def get_timeline(user_id, start_ts, end_ts):
     """
     Return a timeline of the trips and places from this start timestamp to this end timestamp.
@@ -29,7 +41,6 @@ def get_timeline(user_id, start_ts, end_ts):
         logging.debug("Considering place %s: %s -> %s " % (place.get_id(), place.enter_fmt_time, place.exit_fmt_time))
     for trip in trips:
         logging.debug("Considering trip %s: %s -> %s " % (trip.get_id(), trip.start_fmt_time, trip.end_fmt_time))
-
 
     return Timeline(places, trips)
 

--- a/emission/storage/pipeline_queries.py
+++ b/emission/storage/pipeline_queries.py
@@ -4,6 +4,7 @@ import datetime as pydt
 import emission.core.get_database as edb
 import emission.core.wrapper.pipelinestate as ps
 import emission.net.usercache.abstract_usercache as enua
+import emission.core.common
 
 import time
 
@@ -15,12 +16,8 @@ def mark_usercache_done(user_id, last_processed_ts):
     else:
         mark_stage_done(user_id, ps.PipelineStages.USERCACHE, last_processed_ts + END_FUZZ_AVOID_LTE)
 
-def get_time_range_for_usercache(user_id, platform):
+def get_time_range_for_usercache(user_id):
     tq = get_time_range_for_stage(user_id, ps.PipelineStages.USERCACHE)
-    if platform == "android":
-        if tq.startTs is not None:
-            tq.startTs = tq.startTs * 1000
-        tq.endTs = tq.endTs * 1000
     return tq
 
 def get_time_range_for_accuracy_filtering(user_id):

--- a/emission/tests/data/netTests/android.activity.txt
+++ b/emission/tests/data/netTests/android.activity.txt
@@ -4,5 +4,5 @@
   "platform": "android",
   "read_ts": 0,
   "type": "message",
-  "write_ts": 1436826360493},
+  "write_ts": 1436826360.493},
  "user_id": "0763de67-f61e-3f5d-90e7-518e69793954"}

--- a/emission/tests/data/netTests/android.location.raw.txt
+++ b/emission/tests/data/netTests/android.location.raw.txt
@@ -20,7 +20,7 @@
         "mInitialBearing": 0, 
         "mAccuracy": 52.5, 
         "mDistance": 0, 
-        "mTime": 1436826356852, 
+        "mTime": 1436826356.852, 
         "mLon1": 0, 
         "mHasSpeed": false, 
         "mProvider": "fused", 
@@ -32,6 +32,6 @@
         "read_ts": 0, 
         "type": "message", 
         "key": "background/location", 
-        "write_ts": 1436826357115
+        "write_ts": 1436826357.115
     }
 }

--- a/emission/tests/data/netTests/android.location.raw.txt
+++ b/emission/tests/data/netTests/android.location.raw.txt
@@ -20,7 +20,7 @@
         "mInitialBearing": 0, 
         "mAccuracy": 52.5, 
         "mDistance": 0, 
-        "mTime": 1436826356.852, 
+        "mTime": 1436826356852, 
         "mLon1": 0, 
         "mHasSpeed": false, 
         "mProvider": "fused", 
@@ -32,6 +32,6 @@
         "read_ts": 0, 
         "type": "message", 
         "key": "background/location", 
-        "write_ts": 1436826357.115
+        "write_ts": 1436826357115
     }
 }

--- a/emission/tests/data/netTests/android.transition.txt
+++ b/emission/tests/data/netTests/android.transition.txt
@@ -5,5 +5,5 @@
   "platform": "android",
   "read_ts": 0,
   "type": "message",
-  "write_ts": 1436821510445},
+  "write_ts": 1436821510.445},
  "user_id": "0763de67-f61e-3f5d-90e7-518e69793954"}

--- a/emission/tests/storageTests/TestTimeline.py
+++ b/emission/tests/storageTests/TestTimeline.py
@@ -2,6 +2,7 @@
 import unittest
 import logging
 import json
+import datetime as pydt
 
 # Our imports
 import emission.core.get_database as edb
@@ -31,6 +32,8 @@ class TestTimeline(unittest.TestCase):
         logging.info("After loading, timeseries db size = %s" % edb.get_timeseries_db().count())
         self.day_start_ts = 1440658800
         self.day_end_ts = 1440745200
+        self.day_start_dt = pydt.datetime(2015,8,27)
+        self.day_end_dt = pydt.datetime(2015,8,28)
 
     def tearDown(self):
         self.clearRelatedDb()
@@ -48,10 +51,7 @@ class TestTimeline(unittest.TestCase):
         logging.debug("getting type for %s" % element)
         return type(element)
 
-    def testPlaceTripTimeline(self):
-        eaist.segment_current_trips(self.testUUID)
-        tl = esdt.get_timeline(self.testUUID, self.day_start_ts, self.day_end_ts)
-
+    def checkPlaceTripConsistency(self, tl):
         prev_type = None
         prev_element = None
         checked_count = 0
@@ -69,6 +69,16 @@ class TestTimeline(unittest.TestCase):
             prev_type = curr_type
             prev_element = curr_element
         self.assertEqual(checked_count, i)
+
+    def testDatetimeTimeline(self):
+        eaist.segment_current_trips(self.testUUID)
+        tl = esdt.get_timeline_from_dt(self.testUUID, self.day_start_dt, self.day_end_dt)
+        self.checkPlaceTripConsistency(tl)
+
+    def testPlaceTripTimeline(self):
+        eaist.segment_current_trips(self.testUUID)
+        tl = esdt.get_timeline(self.testUUID, self.day_start_ts, self.day_end_ts)
+        self.checkPlaceTripConsistency(tl)
 
     def testStopSectionTimeline(self):
         eaist.segment_current_trips(self.testUUID)


### PR DESCRIPTION
Since we no longer send all the data to the phone app, we need to add a method
that can return the timeline for a particular day. We can use this method to
read the data for days that are not in the cache.

This involved some minor restructuring of the geojson code generation code and
the timeline code to support reading values by datetime instead of by
timestamp.

We might want to consider supporting only datetime going forward because it
fixes the issue with missing trips that are in a different timezone and so
don't fall within the correct timestamp range.

https://github.com/e-mission/e-mission-server/blob/master/emission/net/usercache/builtin_usercache_handler.py#L189