### PR TITLE
Finally check in the script to generate remote pushes from the server

### DIFF
--- a/bin/remotePush.py
+++ b/bin/remotePush.py
@@ -1,0 +1,29 @@
+import json,httplib
+
+config_file = open('conf/net/ext_service/parse.json')
+
+silent_push_msg = {
+   "where": {
+     "deviceType": "ios"
+   },
+   "data": {
+     # "alert": "The Mets scored! The game is now tied 1-1.",
+     "content-available": 1,
+     "sound": "",
+   }
+}
+
+parse_headers = {
+   "X-Parse-Application-Id": config_file["emission_id"],
+   "X-Parse-REST-API-Key": config_file["emission_key"],
+   "Content-Type": "application/json"
+}
+
+connection = httplib.HTTPSConnection('api.parse.com', 443)
+connection.connect()
+
+connection.request('POST', '/1/push', json.dumps(silent_push_msg), parse_headers)
+
+result = json.loads(connection.getresponse().read())
+print result
+

--- a/bin/remotePush.py
+++ b/bin/remotePush.py
@@ -1,6 +1,6 @@
 import json,httplib
 
-config_file = open('conf/net/ext_service/parse.json')
+config_data = json.load(open('conf/net/ext_service/parse.json'))
 
 silent_push_msg = {
    "where": {
@@ -14,8 +14,8 @@ silent_push_msg = {
 }
 
 parse_headers = {
-   "X-Parse-Application-Id": config_file["emission_id"],
-   "X-Parse-REST-API-Key": config_file["emission_key"],
+   "X-Parse-Application-Id": config_data["emission_id"],
+   "X-Parse-REST-API-Key": config_data["emission_key"],
    "Content-Type": "application/json"
 }
 

--- a/conf/net/ext_service/parse.json.sample
+++ b/conf/net/ext_service/parse.json.sample
@@ -1,0 +1,4 @@
+{
+    "emission_id": "Get from https://www.parse.com",
+    "emission_key": "Get from https://www.parse.com"
+}


### PR DESCRIPTION
This assumes that we are generating remote pushes for only one application
(emission), whose keys are stored in the parse.json file. It also assumes that
the script is run from the e-mission server repo base directory.

```
$ git clone https://github.com/.../e-mission-server.git
$ cd e-mission-server
$ ./e-mission-py.bash bin/remotePush.py
```