### PR TITLE
Add support for a new DATA_PUSHED transition on iOS

### DIFF
--- a/emission/core/wrapper/transition.py
+++ b/emission/core/wrapper/transition.py
@@ -27,6 +27,7 @@ class TransitionType(enum.Enum):
     VISIT_STARTED = 13
     VISIT_ENDED = 14
     NONE = 15
+    DATA_PUSHED = 16
 
 class Transition(ecwb.WrapperBase):
     props = {"curr_state": ecwb.WrapperBase.Access.RO,

--- a/emission/net/usercache/formatters/ios/transition.py
+++ b/emission/net/usercache/formatters/ios/transition.py
@@ -20,6 +20,7 @@ transition_map = {
     "T_TRIP_END_DETECTED": et.TransitionType.TRIP_END_DETECTED,
     "T_TRIP_RESTARTED": et.TransitionType.TRIP_RESTARTED,
     "T_END_TRIP_TRACKING": et.TransitionType.END_TRIP_TRACKING,
+    "T_DATA_PUSHED": et.TransitionType.DATA_PUSHED,
     "T_TRIP_ENDED": et.TransitionType.STOPPED_MOVING,
     "T_FORCE_STOP_TRACKING": et.TransitionType.STOP_TRACKING,
     "T_TRACKING_STOPPED": et.TransitionType.TRACKING_STOPPED,


### PR DESCRIPTION
Since we push data asynchronously, and we are retaining the remote push option,
we need to know when the data push is complete so that we can return call the
completion handler. So we add a new transition to the client, which means that
we need to support the transition on the server.