### PR TITLE
Pass around trip objects in the new version of the cluster pipeline a…

### DIFF
--- a/emission/analysis/modelling/tour_model/cluster_pipeline.py
+++ b/emission/analysis/modelling/tour_model/cluster_pipeline.py
@@ -63,7 +63,7 @@ def read_data(uuid=None, size=None, old=True):
                 if len(data) == size:
                     break
         return data
-    return [trip["_id"] for trip in trips]
+    return [ecwt.Trip(trip) for trip in trips]
 
 #put the data into bins and cut off the lower portion of the bins
 def remove_noise(data, radius, old=True):

--- a/emission/analysis/modelling/tour_model/featurization.py
+++ b/emission/analysis/modelling/tour_model/featurization.py
@@ -45,7 +45,6 @@ class featurization:
                 start = trip.trip_start_location
                 end = trip.trip_end_location
             else:
-                trip = esdtq.get_trip(trip)
                 try:
                     start = trip.start_loc["coordinates"]
                     end = trip.end_loc["coordinates"]

--- a/emission/analysis/modelling/tour_model/representatives.py
+++ b/emission/analysis/modelling/tour_model/representatives.py
@@ -64,7 +64,6 @@ class representatives:
                     points[2].append(c.trip_end_location.lat)
                     points[3].append(c.trip_end_location.lon)
                 else:
-                    c = esdtq.get_trip(c)
                     # We want (lat, lon) to be consistent with old above.
                     # But in the new, our data is in geojson so it is (lon, lat).
                     # Fix it by flipping the order of the indices

--- a/emission/analysis/modelling/tour_model/similarity.py
+++ b/emission/analysis/modelling/tour_model/similarity.py
@@ -39,7 +39,7 @@ class similarity:
         if not old:
             for a in self.data:
                 # print "a is %s" % a
-                t = esdtq.get_trip(a)
+                t = a
                 try:
                     start_lon = t.start_loc["coordinates"][0]
                     start_lat = t.start_loc["coordinates"][1]
@@ -204,8 +204,8 @@ class similarity:
         return False
 
     def distance_helper_new(self, a, b):
-        tripa = esdtq.get_trip(self.data[a])
-        tripb = esdtq.get_trip(self.data[b])
+        tripa = self.data[a]
+        tripb = self.data[b]
 
         starta = tripa.start_loc["coordinates"]
         startb = tripb.start_loc["coordinates"]

--- a/emission/storage/decorations/common_trip_queries.py
+++ b/emission/storage/decorations/common_trip_queries.py
@@ -103,7 +103,6 @@ def set_up_trips(list_of_cluster_data, user_id):
         #print 'dct["sections"].trip_id %s is' % dct["sections"][0]
         probabilites = np.zeros((DAYS_IN_WEEK, HOURS_IN_DAY))
         for sec in dct["sections"]:
-            sec = esdtq.get_trip(sec)
             probabilites[get_day(sec), get_start_hour(sec)] += 1
 
         trip = make_new_common_trip()

--- a/emission/storage/decorations/common_trip_queries.py
+++ b/emission/storage/decorations/common_trip_queries.py
@@ -112,6 +112,6 @@ def set_up_trips(list_of_cluster_data, user_id):
         trip.start_loc = start_loc
         trip.end_loc = end_loc
         trip.probabilites = probabilites
-        trip.trips = dct["sections"]
+        trip.trips = [unc_trip.get_id() for unc_trip in dct["sections"]]
 
         save_common_trip(trip)


### PR DESCRIPTION
…s well

In the old version of the cluster pipeline, we used to read the trip objects
and pass them around. In the new version of the cluster pipeline, this was
changed so that we passed around the IDs instead. This meant that we had to go
back to the database to read the trips over and over as we can see from this
pull request.

This was a particular concern while reading many trips in quick succession in
the featurization step. Since we do not have an index on the trip collection,
this caused the database to be very slow and basically stop responding.

So I went back to passing trip objects around. Now it runs fine, even for
people with a large number of trips, like me and Tom.

This is a fix for https://github.com/e-mission/e-mission-server/issues/247