### PR TITLE
Fix usercache test to match reality

### DIFF
--- a/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
+++ b/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
@@ -111,7 +111,7 @@ class TestBuiltinUserCacheHandlerOutput(unittest.TestCase):
         uc.putDocument("2015-12-28", {"a": 1})
         uc.putDocument("2015-12-27", {"a": 1})
         uc.putDocument("2015-12-26", {"a": 1})
-        uch.delete_obsolete_entries(uc, valid_bins.iterkeys())
+        uch.delete_obsolete_entries(uc, list(valid_bins.iterkeys()))
         # the result should include entries that are in the past (28,27,26), but should 
         # NOT include newly added entries
         self.assertEqual(uc.getDocumentKeyList(), ["2015-12-30", "2015-12-29"])

--- a/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
+++ b/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
@@ -116,6 +116,24 @@ class TestBuiltinUserCacheHandlerOutput(unittest.TestCase):
         # NOT include newly added entries
         self.assertEqual(uc.getDocumentKeyList(), ["2015-12-30", "2015-12-29"])
 
+    def testRetainSetConfig(self):
+        valid_bins = {"2015-12-30":[{"b": 2}],
+                      "2015-12-29":[{"b": 2}],
+                      "2015-12-31":[{"b": 2}]}
+        uc = enua.UserCache.getUserCache(self.testUserUUID1)
+        uch = enuah.UserCacheHandler.getUserCacheHandler(self.testUserUUID1)
+        uc.putDocument("2015-12-30", {"a": 1})
+        uc.putDocument("2015-12-29", {"a": 1})
+        uc.putDocument("2015-12-28", {"a": 1})
+        uc.putDocument("2015-12-27", {"a": 1})
+        uc.putDocument("2015-12-26", {"a": 1})
+        uc.putDocument("config/sensor_config", {"a": 1})
+        uch.delete_obsolete_entries(uc, list(valid_bins.iterkeys()))
+        # the result should include entries that are in the past (28,27,26), but should 
+        # NOT include newly added entries
+        self.assertEqual(uc.getDocumentKeyList(), ["2015-12-30", "2015-12-29",
+            "config/sensor_config"])
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
This fixes the broken build. The build was broken when I committed
https://github.com/e-mission/e-mission-server/pull/254

While we know that all tests except the last one passed, I merged without
waiting for the last set of tests to complete, since I wanted to deploy the
solution.

This broke one of the tests, but in this case, the fault was with the test and
not the code. The code passes in a list to delete_obsolete_entries, but the test
passed in the keys of a dict, which is an iterator.