### PR TITLE
Change the heatmap template slightly to account for the presence of t…

### DIFF
--- a/webapp/www/templates/tab-heatmap.html
+++ b/webapp/www/templates/tab-heatmap.html
@@ -1,21 +1,14 @@
 <ion-view view-title="Heatmap">
-  <ion-nav-bar class="bar-stable">
-    <ion-nav-back-button></ion-nav-back-button>
-    <ion-nav-buttons side="right">
-      <button class="button button-assertive button-block"
-              ng-click="getPopRoute()">Get!</button>
-    </ion-nav-buttons>
-  </ion-nav-bar>
   <ion-content class="has-header padding">
     <div class="row">
-      <div class="col-30">
+      <div class="col col-25">
       <button class="button button-stable button-block row"
                 ng-click="changeMode()">{{selectCtrl.modeString}}</button>
       </div>
-      <div class="col">
+      <div class="col col-66">
         <div class="row">
           <div class="col">
-          <button class="button button-small" ng-disabled="true">From:</button>
+          <button class="button button-small" ng-disabled="true" style="text-align:right">From:</button>
           </div><div class="col">
           <input type="text" placeholder="year" ng-model="selectCtrl.fromDate.year">
           </div><div class="col">
@@ -31,7 +24,7 @@
         </div>
         <div class="row">
           <div class="col">
-          <button class="button button-small" ng-disabled="true" class="col" >To:</button>
+          <button class="button button-small" ng-disabled="true" class="col" style="text-align:right">&nbsp;&nbsp;&nbsp;To:</button>
           </div><div class="col">
           <input type="text" placeholder="year" ng-model="selectCtrl.toDate.year">
           </div><div class="col">
@@ -43,15 +36,13 @@
                   ng-click="changeToWeekday()">{{selectCtrl.toDateWeekdayString}}</button>
           </div><div class="col">
           <input type="text" placeholder="hour" ng-model="selectCtrl.toDate.hour">
-          </div>
-        </div>
+          </div> <!-- col-->
+        </div> <!-- row -->
+      </div> <!-- col -->
+      <div class="col col-10">
+        <button class="button button-assertive"
+                ng-click="getPopRoute()">Get!</button>
       </div>
-      <!--
-      <div class="col">
-        <button class="button button-assertive button-block col"
-              ng-click="getPopRoute()">Get!</button>
-      </div>
-      -->
 
       <!--
       <em-local-date date="selectCtrl.fromDate"></em-local-date>
@@ -60,7 +51,7 @@
       <!--
         <button style="" class="button button-stable button-block  icon ion-checkmark">Valid</button>
       -->
-    </div>
+    </div> <!-- row -->
     <leaflet id='heatmap' width="100%" height="480px" defaults="mapCtrl.defaults"></leaflet>
   </ion-content>
 </ion-view>


### PR DESCRIPTION
…he secondary notification

After this, the webapp is not identical to the phone app, although the
differences are all in layout
- Remove the "Get!" button from the header. There's plenty of room on the
  desktop, and if we put it there, it overrides the other buttons for home and
  analysis. We can ensure that this nav bar also copies over the button bar,
  and I can confirm that it works. But duplicating code is never good for
  maintainability, and there doesn't appear to be a way to specify a template
  for a nav-view-header, so let's just change the layout a bit to make my life
  easier.

- Change around the col proportions to make the display look pleasing again.