### PR TITLE
Add server support for the sync config

### DIFF
--- a/bin/remotePush.py
+++ b/bin/remotePush.py
@@ -1,11 +1,18 @@
 import json,httplib
+import sys
 
 config_data = json.load(open('conf/net/ext_service/parse.json'))
+
+interval = sys.argv[1]
+print "pushing for interval %s" % interval
 
 silent_push_msg = {
    "where": {
      "deviceType": "ios"
    },
+   "channels": [
+     interval
+   ],
    "data": {
      # "alert": "The Mets scored! The game is now tied 1-1.",
      "content-available": 1,
@@ -26,4 +33,5 @@ connection.request('POST', '/1/push', json.dumps(silent_push_msg), parse_headers
 
 result = json.loads(connection.getresponse().read())
 print result
+
 

--- a/emission/analysis/configs/config.py
+++ b/emission/analysis/configs/config.py
@@ -3,12 +3,20 @@ import importlib
 
 import emission.net.usercache.abstract_usercache as enua
 
-config_list = ["sensor_config"]
+config_list = ["sensor_config", "sync_config"]
 
 def save_all_configs(user_id, time_query):
     uc = enua.UserCache.getUserCache(user_id)
-    config_name = config_list[0]
-    return save_config(user_id, uc, time_query, config_name)
+    # This is tricky to extend to beyond one type of config because it is not
+    # clear which ts we should return. We cannot return two values because only
+    # one of them can be stored in our current pipeline states.  We should be
+    # able to return the max of them, since these are all from the same user,
+    # so if we have received a later config, we know that we have processed all 
+    # prior configs
+    # Let's test it out and see if it works!
+    last_processed_ts_list = [save_config(user_id, uc, time_query, config_name) 
+        for config_name in config_list]
+    return max(last_processed_ts_list)
 
 def save_config(user_id, uc, time_query, module_name):
     config_fn = get_configurator("emission.analysis.configs.%s" % module_name)

--- a/emission/analysis/configs/config_utils.py
+++ b/emission/analysis/configs/config_utils.py
@@ -6,8 +6,9 @@ import emission.core.wrapper.entry as ecwe
 def get_last_entry(user_id, time_query, config_key):
     user_ts = esta.TimeSeries.get_time_series(user_id)
     
-    # get the max write_ts for this stream, which corresponds to the last entry
-    # We expect this to be small, unless users are continuously overriding values
+    # get the list of overrides for this time range. This should be non zero
+    # only if there has been an override since the last run, which needs to be
+    # saved back into the cache.
     config_overrides = list(user_ts.find_entries([config_key], time_query))
     logging.debug("Found %d user overrides for user %s" % (len(config_overrides), user_id))
     if len(config_overrides) == 0:

--- a/emission/analysis/configs/sync_config.py
+++ b/emission/analysis/configs/sync_config.py
@@ -1,0 +1,8 @@
+import logging
+import emission.analysis.configs.config_utils as eacc
+
+def get_config(user_id, time_query):
+    # right now, we are not doing any server side overrides, so we pick the
+    # last user defined configuration for this user
+    SYNC_CONFIG_KEY = "config/sync_config"
+    return eacc.get_last_entry(user_id, time_query, SYNC_CONFIG_KEY)

--- a/emission/core/wrapper/entry.py
+++ b/emission/core/wrapper/entry.py
@@ -31,6 +31,7 @@ class Entry(ecwb.WrapperBase):
             "background/battery": "battery",
             "statemachine/transition": "transition",
             "config/sensor_config": "sensorconfig",
+            "config/sync_config": "syncconfig",
             "segmentation/raw_trip": "rawtrip",
             "segmentation/raw_place": "rawplace",
             "segmentation/raw_section": "section",

--- a/emission/core/wrapper/syncconfig.py
+++ b/emission/core/wrapper/syncconfig.py
@@ -1,0 +1,13 @@
+import logging
+import emission.core.wrapper.wrapperbase as ecwb
+
+class Syncconfig(ecwb.WrapperBase):
+    props = {"sync_interval": ecwb.WrapperBase.Access.RO,  # the interval at which data is synced and the battery level is read
+             "ios_device_token": ecwb.WrapperBase.Access.RO} # device_token for ios, used for registering the device to the appropriate channel
+    enums = {}
+    geojson = []
+    nullable = []
+    local_dates = []
+
+    def _populateDependencies(self):
+        pass

--- a/emission/net/usercache/formatters/android/sync_config.py
+++ b/emission/net/usercache/formatters/android/sync_config.py
@@ -1,0 +1,29 @@
+import logging
+import pytz
+import attrdict as ad
+import copy
+
+import emission.core.wrapper.syncconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = ad.AttrDict()
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+
+    formatted_entry.data = entry.data
+
+    return formatted_entry;

--- a/emission/net/usercache/formatters/ios/sync_config.py
+++ b/emission/net/usercache/formatters/ios/sync_config.py
@@ -1,0 +1,26 @@
+import copy
+
+import emission.core.wrapper.syncconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+
+    formatted_entry.data = entry.data
+
+    return formatted_entry;

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -23,6 +23,7 @@ class BuiltinTimeSeries(esta.TimeSeries):
                 "background/battery": self.timeseries_db,
                 "statemachine/transition": self.timeseries_db,
                 "config/sensor_config": self.timeseries_db,
+                "config/sync_config": self.timeseries_db,
                 "segmentation/raw_trip": self.analysis_timeseries_db,
                 "segmentation/raw_place": self.analysis_timeseries_db,
                 "segmentation/raw_section": self.analysis_timeseries_db,


### PR DESCRIPTION
Might want to consider streamlining this, but that's a low priority now.
The first two commits of this PR should include everything needed to store another config.