### PR TITLE
Clean up current implementation of the common trips

### DIFF
--- a/emission/analysis/modelling/tour_model/K_medoid.py
+++ b/emission/analysis/modelling/tour_model/K_medoid.py
@@ -1,16 +1,10 @@
 # Standard imports
 from __future__ import division
-import logging
-import numpy as np
-import math
 import random
-import time
 
 # Our imports
-from emission.core.get_database import get_routeDistanceMatrix_db,get_routeCluster_db,get_section_db
-from emission.core.common import calDistance, getDisplayModes
+from emission.core.get_database import get_routeDistanceMatrix_db,get_section_db
 from emission.analysis.modelling.tour_model.trajectory_matching.route_matching import fullMatchDistance,getRoute
-from emission.analysis.modelling.tour_model.trajectory_matching.LCS import lcsScore
 
 Sections=get_section_db()
 

--- a/emission/analysis/modelling/tour_model/create_tour_model_matrix.py
+++ b/emission/analysis/modelling/tour_model/create_tour_model_matrix.py
@@ -1,8 +1,6 @@
 import logging
 
-import emission.analysis.modelling.tour_model.tour_model_matrix as tm ##here
-import emission.core.get_database as edb
-import emission.core.wrapper.trip_old as trip
+import emission.analysis.modelling.tour_model.tour_model_matrix as tm
 import emission.analysis.modelling.tour_model.cluster_pipeline as eamtcp
 from uuid import UUID
 import random, datetime, sys

--- a/emission/analysis/modelling/tour_model/featurization.py
+++ b/emission/analysis/modelling/tour_model/featurization.py
@@ -1,18 +1,13 @@
 # Standard imports
 import logging
-import matplotlib
-# matplotlib.use('Agg')
 import matplotlib.pyplot as plt
-import math
 import numpy
 from sklearn.cluster import KMeans
 from sklearn import metrics
 import sys
 
 # our imports
-from emission.core.wrapper.trip_old import Trip, Coordinate
 from kmedoid import kmedoids
-import emission.storage.decorations.trip_queries as esdtq
 
 
 """
@@ -25,9 +20,8 @@ This class is run by cluster_pipeline.py
 """
 class featurization:
 
-    def __init__(self, data, old=True):
+    def __init__(self, data):
         self.data = data
-        self.is_old = old
         if not self.data:
             self.data = []
         self.calculate_points()
@@ -41,21 +35,14 @@ class featurization:
         if not self.data:
             return
         for trip in self.data:
-            if self.is_old:
-                start = trip.trip_start_location
-                end = trip.trip_end_location
-            else:
-                try:
-                    start = trip.data.start_loc["coordinates"]
-                    end = trip.data.end_loc["coordinates"]
-                except:
-                    continue
+            try:
+                start = trip.data.start_loc["coordinates"]
+                end = trip.data.end_loc["coordinates"]
+            except:
+                continue
             if not (start and end):
                 raise AttributeError('each trip must have valid start and end locations')
-            if self.is_old:
-                self.points.append([start.lon, start.lat, end.lon, end.lat])
-            else:
-                self.points.append([start[0], start[1], end[0], end[1]])
+            self.points.append([start[0], start[1], end[0], end[1]])
 
     #cluster the data. input options:
     # - name (optional): the clustering algorithm to use. Options are 'kmeans' or 'kmedoids'. Default is kmeans.
@@ -68,7 +55,7 @@ class featurization:
             logging.debug("min_clusters < 2, setting min_clusters = 2")
             min_clusters = 2
         if min_clusters > len(self.points):
-            sys.stderr.write('Maximum number of clusters is the number of data points.\n')
+            sys.stderr.write('Minimum number of clusters %d is greater than the number of data points %d.\n' % (min_clusters, len(self.points)))
             min_clusters = len(self.points)-1
         if max_clusters == None:
             logging.debug("max_clusters is None, setting max_clusters = %d" % (len(self.points) - 1))
@@ -138,8 +125,8 @@ class featurization:
         if not self.labels:
             logging.debug('Please cluster before analyzing clusters.')
             return
-        logging.debug('number of clusters is %d' % str(self.clusters))
-        logging.debug('silhouette score is %d' % str(self.sil))
+        logging.debug('number of clusters is %d' % self.clusters)
+        logging.debug('silhouette score is %s' % self.sil)
 
     #map the clusters
     #TODO - move this to a file in emission.analysis.plotting to map clusters from the database

--- a/emission/analysis/modelling/tour_model/similarity.py
+++ b/emission/analysis/modelling/tour_model/similarity.py
@@ -6,11 +6,7 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy
 from sklearn import metrics
-import sys
-from numpy import cross
 from numpy.linalg import norm
-import emission.storage.decorations.trip_queries as esdtq
-import emission.storage.decorations.section_queries as esdsq
 import emission.storage.decorations.analysis_timeseries_queries as esda
 
 """
@@ -30,41 +26,30 @@ This is called by cluster_pipeline.py.
 """
 class similarity:
     
-    def __init__(self, data, radius, old=True):
+    def __init__(self, data, radius):
         self.data = data
         if not data:
             self.data = []
         self.bins = []
         self.radius = float(radius)
-        self.old = old
-        if not old:
-            for a in self.data:
-                # print "a is %s" % a
-                t = a
-                try:
-                    start_place = esda.get_entry(esda.CLEANED_PLACE_KEY,
-                                                 t.data.start_place)
-                    end_place = esda.get_entry(esda.CLEANED_PLACE_KEY,
-                                                 t.data.end_place)
-                    start_lon = start_place.data.location["coordinates"][0]
-                    start_lat = start_place.data.location["coordinates"][1]
-                    end_lon = end_place.data.location["coordinates"][0]
-                    end_lat = end_place.data.location["coordinates"][1]
-                    logging.debug("endpoints are = (%s, %s) and (%s, %s)" %
-                                  (start_lon, start_lat, end_lon, end_lat))
-                    if self.distance(start_lat, start_lon, end_lat, end_lon):
-                        self.data.remove(a)
-                except:
-                    logging.exception("exception while getting start and end places for %s" % t)
-                    self.data.remove(a)
-        else:
-            for a in range(len(self.data)-1, -1, -1):
-                start_lat = self.data[a].trip_start_location.lat
-                start_lon = self.data[a].trip_start_location.lon
-                end_lat = self.data[a].trip_end_location.lat
-                end_lon = self.data[a].trip_end_location.lon
+        for t in self.data:
+            logging.debug("Considering trip %s" % t)
+            try:
+                start_place = esda.get_entry(esda.CLEANED_PLACE_KEY,
+                                             t.data.start_place)
+                end_place = esda.get_entry(esda.CLEANED_PLACE_KEY,
+                                             t.data.end_place)
+                start_lon = start_place.data.location["coordinates"][0]
+                start_lat = start_place.data.location["coordinates"][1]
+                end_lon = end_place.data.location["coordinates"][0]
+                end_lat = end_place.data.location["coordinates"][1]
+                logging.debug("endpoints are = (%s, %s) and (%s, %s)" %
+                              (start_lon, start_lat, end_lon, end_lat))
                 if self.distance(start_lat, start_lon, end_lat, end_lon):
-                    self.data.pop(a)
+                    self.data.remove(t)
+            except:
+                logging.exception("exception while getting start and end places for %s" % t)
+                self.data.remove(t)
 
         logging.debug('After removing trips that are points, there are %s data points' % len(self.data))
         self.size = len(self.data)
@@ -146,12 +131,8 @@ class similarity:
     #check if two trips match
     def match(self,a,bin):
         for b in bin:
-            if not self.old:
-                if not self.distance_helper_new(a,b):
-                    return False
-            else:
-                if not self.distance_helper(a,b):
-                    return False
+            if not self.distance_helper(a, b):
+                return False
         return True
 
     #create the histogram
@@ -187,12 +168,19 @@ class similarity:
         points = []
         for bin in self.bins:
             for b in bin:
-                start_lat = self.data[b].trip_start_location.lat
-                start_lon = self.data[b].trip_start_location.lon
-                end_lat = self.data[b].trip_end_location.lat
-                end_lon = self.data[b].trip_end_location.lon
+                tb = self.data[b]
+                start_place = esda.get_entry(esda.CLEANED_PLACE_KEY,
+                                             tb.data.start_place)
+                end_place = esda.get_entry(esda.CLEANED_PLACE_KEY,
+                                           tb.data.end_place)
+                start_lon = start_place.data.location["coordinates"][0]
+                start_lat = start_place.data.location["coordinates"][1]
+                end_lon = end_place.data.location["coordinates"][0]
+                end_lat = end_place.data.location["coordinates"][1]
                 path = [start_lat, start_lon, end_lat, end_lon]
                 points.append(path)
+        logging.debug("number of labels are %d, number of points are = %d" %
+                      (len(labels), len(points)))
         a = metrics.silhouette_score(numpy.array(points), labels)
         logging.debug('number of bins is %d' % len(self.bins))
         logging.debug('silhouette score is %d' % a)
@@ -200,20 +188,8 @@ class similarity:
 
     #calculate the distance between two trips
     def distance_helper(self, a, b):
-        starta = self.data[a].trip_start_location
-        startb = self.data[b].trip_start_location
-        enda = self.data[a].trip_end_location
-        endb = self.data[b].trip_end_location
-
-        start = self.distance(starta.lat, starta.lon, startb.lat, startb.lon)
-        end = self.distance(enda.lat, enda.lon, endb.lat, endb.lon)
-        if start and end:
-            return True
-        return False
-
-    def distance_helper_new(self, a, b):
-        tripa = self.data[a]
-        tripb = self.data[b]
+        tripa = self.data[a].data
+        tripb = self.data[b].data
 
         starta = tripa.start_loc["coordinates"]
         startb = tripb.start_loc["coordinates"]

--- a/emission/analysis/modelling/tour_model/tour_model_matrix.py
+++ b/emission/analysis/modelling/tour_model/tour_model_matrix.py
@@ -5,7 +5,7 @@ from emission.core.our_geocoder import Geocoder
 
 # Standard imports
 import numpy as np
-import math, datetime, heapq
+import datetime, heapq
 import networkx as nx
 import matplotlib.pyplot as plt
 

--- a/emission/storage/decorations/common_place_queries.py
+++ b/emission/storage/decorations/common_place_queries.py
@@ -42,17 +42,6 @@ def clear_existing_places(user_id):
     db = edb.get_common_place_db()
     db.remove({'user_id': user_id})
 
-def get_all_place_objs(common_place):
-    trip.trips = [unc_trip.get_id() for unc_trip in dct["sections"]]
-    place_db = edb.get_place_db()
-    start_places = []
-    end_places = []
-    for t in trip.trips:
-        start = place_db.find_one({"_id" : t.start_place})
-        end = place_db.find_one({"_id" : t.end_place})
-        start_places.append(start)
-        end_places.append(end)
-
 ################################################################################
 
 def create_places(list_of_cluster_data, user_id):
@@ -60,10 +49,11 @@ def create_places(list_of_cluster_data, user_id):
     places_dct = {}
     logging.debug("About to create places for %d clusters" % len(list_of_cluster_data))
     for dct in list_of_cluster_data:
+        logging.debug("Current coords = %s" % dct)
         start_name = dct['start']
         end_name = dct['end']
-        start_loc = gj.Point(dct['start_coords'].coordinate_list())
-        end_loc = gj.Point(dct['end_coords'].coordinate_list())
+        start_loc = gj.Point(dct['start_coords'])
+        end_loc = gj.Point(dct['end_coords'])
         start_loc_str = gj.dumps(start_loc, sort_keys=True)
         end_loc_str = gj.dumps(end_loc, sort_keys=True)
         if start_loc_str not in places_to_successors:

--- a/emission/storage/decorations/common_trip_queries.py
+++ b/emission/storage/decorations/common_trip_queries.py
@@ -103,8 +103,8 @@ def set_up_trips(list_of_cluster_data, user_id):
     for dct in list_of_cluster_data:
         start_times = []
         durations = []
-        start_loc = gj.Point(dct['start_coords'].coordinate_list())
-        end_loc = gj.Point(dct['end_coords'].coordinate_list())
+        start_loc = gj.Point(dct['start_coords'])
+        end_loc = gj.Point(dct['end_coords'])
         start_place_id = esdcpq.get_common_place_at_location(start_loc).get_id()
         end_place_id = esdcpq.get_common_place_at_location(end_loc).get_id()
         #print 'dct["sections"].trip_id %s is' % dct["sections"][0]

--- a/emission/storage/decorations/tour_model_queries.py
+++ b/emission/storage/decorations/tour_model_queries.py
@@ -47,7 +47,7 @@ def get_common_trips(user_id):
 
 def make_tour_model_from_raw_user_data(user_id):
     try:
-        list_of_cluster_data = eamtmcp.main(user_id, False)
+        list_of_cluster_data = eamtmcp.main(user_id)
         esdcpq.create_places(list_of_cluster_data, user_id)
         esdctq.set_up_trips(list_of_cluster_data, user_id)
     except ValueError as e:

--- a/emission/tests/analysisTests/TestClusterPipeline.py
+++ b/emission/tests/analysisTests/TestClusterPipeline.py
@@ -32,59 +32,59 @@ class ClusterPipelineTests(unittest.TestCase):
 	eaicr.clean_and_resample(self.testUUID)
 
     def testSanity(self):
-	cp.main(self.testUUID, False)
+		cp.main(self.testUUID)
 
     def testReadData(self): 
-	data = cp.read_data(uuid=self.testUUID, old=False)
+	data = cp.read_data(uuid=self.testUUID)
 	
 	# Test to make sure something is happening
 	self.assertTrue(len(data) > 5)
 
 	# Test to make sure that the trips are mapped to the correct uuid
-	bad_data = cp.read_data(uuid="FakeUUID", old=False)
+	bad_data = cp.read_data(uuid="FakeUUID")
 	self.assertEqual(len(bad_data), 0)
 
     def testRemoveNoise(self):
-	data = cp.read_data(uuid=self.testUUID, old=False)
+	data = cp.read_data(uuid=self.testUUID)
 
 	# Test to make sure the code doesn't break on an empty dataset
-	new_data, bins = cp.remove_noise(None, self.RADIUS, False)
+	new_data, bins = cp.remove_noise(None, self.RADIUS)
 	self.assertTrue(len(new_data) == len(bins) == 0)	
 	
 	#Test to make sure some or no data was filtered out, but that nothing was added after filtering
-	new_data, bins = cp.remove_noise(None, self.RADIUS, False)
+	new_data, bins = cp.remove_noise(None, self.RADIUS)
 	self.assertTrue(len(new_data) <= len(data))
 	
 	# Make sure there are not more bins than data; that wouldnt make sense
 	self.assertTrue(len(bins) <= len(data))
 
     def testCluster(self):
-	data = cp.read_data(uuid=self.testUUID, old=False)
+	data = cp.read_data(uuid=self.testUUID)
 
 	# Test to make sure empty dataset doesn't crash the program
-	clusters, labels, new_data = cp.cluster([], 10, False)
+	clusters, labels, new_data = cp.cluster([], 10)
 	self.assertTrue(len(new_data) == clusters == len(labels) == 0)
 
 	# Test to make sure clustering with noise works
-	clusters, labels, new_data = cp.cluster(data, 10, False)
+	clusters, labels, new_data = cp.cluster(data, 10)
 	self.assertEqual(len(labels), len(new_data))
 	self.assertEqual(cmp(new_data, data), 0)
 	
 	# Test to make sure clustering without noise works
-	data, bins = cp.remove_noise(data, self.RADIUS, False)
-	clusters, labels, new_data = cp.cluster(data, len(bins), False)
+	data, bins = cp.remove_noise(data, self.RADIUS)
+	clusters, labels, new_data = cp.cluster(data, len(bins))
 	self.assertTrue(clusters == 0 or len(bins) <= clusters <= len(bins) + 10)
 	
     def testClusterToTourModel(self):
 	# Test to make sure it doesn't crash on a empty dataset
-	data = cp.cluster_to_tour_model(None, None, False)
+	data = cp.cluster_to_tour_model(None, None)
 	self.assertFalse(data)
 	
 	# Test with the real dataset
-	data = cp.read_data(uuid=self.testUUID, old=False)
-	data, bins = cp.remove_noise(data, self.RADIUS, False)
-	n, labels, data = cp.cluster(data, len(bins), False)
-	tour_dict = cp.main(uuid=self.testUUID, old=False)
+	data = cp.read_data(uuid=self.testUUID)
+	data, bins = cp.remove_noise(data, self.RADIUS)
+	n, labels, data = cp.cluster(data, len(bins))
+	tour_dict = cp.main(uuid=self.testUUID)
 	self.assertTrue(len(tour_dict) <= n)
 
 

--- a/emission/tests/analysisTests/TestRepresentatives.py
+++ b/emission/tests/analysisTests/TestRepresentatives.py
@@ -1,25 +1,24 @@
 import unittest
-import emission.core.get_database as edb
+import time
+import logging
+
 import emission.analysis.modelling.tour_model.representatives as rep
-import emission.simulation.trip_gen as tg
 import emission.analysis.modelling.tour_model.featurization as feat
-import emission.analysis.modelling.tour_model.cluster_pipeline as cp
-from emission.core.wrapper.trip_old import Trip, Coordinate
+
+import emission.tests.analysisTests.tourModelTests.common as etatc
 
 class RepresentativesTests(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         super(RepresentativesTests, self).__init__(*args, **kwargs)
-        self.data = cp.read_data(size=100)
-        #if len(self.data) == 0:
-        #    tg.create_fake_trips()
-        #    self.data = cp.read_data(size=100)
-        print 'there are ' + str(len(self.data))
+
+    def setUp(self):
+        etatc._setup(self)
         n = len(self.data)/5
-        self.labels = feat.featurization(self.data).cluster(min_clusters=n, max_clusters=n)        
+        self.labels = feat.featurization(self.data).cluster(min_clusters=n, max_clusters=n)
 
     def tearDown(self):
-        pass
+        etatc._tearDown(self)
 
     def testInit(self):
         repy = rep.representatives(None, None)
@@ -55,18 +54,20 @@ class RepresentativesTests(unittest.TestCase):
         repy.get_reps()
         self.assertTrue(len(repy.reps) == len(repy.clusters))
         clusters = [0]
-        tripa = Trip(None, None, None, None, None, None, Coordinate(1,2), Coordinate(3,4))
-        tripb = Trip(None, None, None, None, None, None, Coordinate(9,10), Coordinate(5,8))
-        tripc = Trip(None, None, None, None, None, None, Coordinate(5,6), Coordinate(4,6))
+        now = time.time()
+        tripa = etatc._createTripEntry(self, now, now, [1,2], [3,4])
+        tripb = etatc._createTripEntry(self, now, now, [9,10], [5,8])
+        tripc = etatc._createTripEntry(self, now, now, [5,6], [4,6])
         data = [tripa, tripb, tripc]
         labels = [0,0,0]
         repy = rep.representatives(data, labels)
         repy.list_clusters()
         repy.get_reps()
-        self.assertTrue(repy.reps[0].trip_start_location.lat == 5)
-        self.assertTrue(repy.reps[0].trip_start_location.lon == 6)
-        self.assertTrue(repy.reps[0].trip_end_location.lat == 4)
-        self.assertTrue(repy.reps[0].trip_end_location.lon == 6)
+        logging.debug("repy.reps[0].data.start_loc = %s" % repy.reps[0].data.start_loc)
+        self.assertEqual(repy.reps[0].data.start_loc.coordinates[0], 5)
+        self.assertEqual(repy.reps[0].data.start_loc.coordinates[1], 6)
+        self.assertEqual(repy.reps[0].data.end_loc.coordinates[0], 4)
+        self.assertEqual(repy.reps[0].data.end_loc.coordinates[1], 6)
 
     def testLocations(self):
         repy = rep.representatives(self.data, self.labels)
@@ -78,16 +79,17 @@ class RepresentativesTests(unittest.TestCase):
             for i in range(len(bin)):
                 b = bin[i]
                 if b[0] == 'start':
-                    a = repy.reps[b[1]].trip_start_location
+                    a = repy.reps[b[1]].data.start_loc
                 if b[0] == 'end':
-                    a = repy.reps[b[1]].trip_end_location
+                    a = repy.reps[b[1]].data.end_loc
                 for j in range(i):
                     c = bin[j]
                     if c[0] == 'start':
-                        d = repy.reps[c[1]].trip_start_location
+                        d = repy.reps[c[1]].data.start_loc
                     if c[0] == 'end':
-                        d = repy.reps[c[1]].trip_end_location
-                    self.assertTrue(repy.distance(a.lat, a.lon, d.lat, d.lon) < 300)
+                        d = repy.reps[c[1]].data.end_loc
+                    self.assertTrue(repy.distance(a.coordinates[1], a.coordinates[0],
+                                                  d.coordinates[1], d.coordinates[0]) < 300)
             total += len(bin)
         self.assertTrue(total == 2 * repy.num_clusters)
         for i in range(repy.num_clusters):
@@ -95,24 +97,25 @@ class RepresentativesTests(unittest.TestCase):
             self.assertTrue(sum(bin.count(('end',i)) for bin in repy.bins) == 1)
         self.assertTrue(len(repy.locs) == len(repy.bins))
 
-        tripa = Trip(None, None, None, None, None, None, Coordinate(1,2), Coordinate(30,40))
-        tripb = Trip(None, None, None, None, None, None, Coordinate(1.0000002,2.0000002), Coordinate(55.0000002,85.0000002))
-        tripc = Trip(None, None, None, None, None, None, Coordinate(30.0000002,40.0000002), Coordinate(55,85))
+        now = time.time()
+        tripa = etatc._createTripEntry(self, now, now, [1,2], [30,40])
+        tripb = etatc._createTripEntry(self, now, now, [1.0000002,2.0000002], [55.0000002,85.0000002])
+        tripc = etatc._createTripEntry(self, now, now, [30.0000002,40.0000002], [55,85])
         data = [tripa, tripb, tripc]
         labels = [0,1,2]
         repy = rep.representatives(data, labels)
         repy.list_clusters()
         repy.get_reps()
         repy.locations()
-        self.assertTrue(repy.bins[0] == [('start', 0), ('start', 1)])
-        self.assertTrue(repy.bins[1] == [('end', 0), ('start', 2)])
-        self.assertTrue(repy.bins[2] == [('end', 1), ('end', 2)])
-        self.assertTrue(round(repy.locs[0].lat,7) == 1.0000001)
-        self.assertTrue(round(repy.locs[0].lon,7) == 2.0000001)
-        self.assertTrue(round(repy.locs[1].lat,7) == 30.0000001)
-        self.assertTrue(round(repy.locs[1].lon,7) == 40.0000001)
-        self.assertTrue(round(repy.locs[2].lat,7) == 55.0000001)
-        self.assertTrue(round(repy.locs[2].lon,7) == 85.0000001)
+        self.assertEqual(repy.bins[0], [('start', 0), ('start', 1)])
+        self.assertEqual(repy.bins[1], [('end', 0), ('start', 2)])
+        self.assertEqual(repy.bins[2], [('end', 1), ('end', 2)])
+        self.assertAlmostEqual(repy.locs[0][0], 1.0000001, places=7)
+        self.assertAlmostEqual(repy.locs[0][1], 2.0000001, places=7)
+        self.assertAlmostEqual(repy.locs[1][0], 30.0000001, places=7)
+        self.assertAlmostEqual(repy.locs[1][1], 40.0000001, places=7)
+        self.assertAlmostEqual(repy.locs[2][0], 55.0000001, places=7)
+        self.assertAlmostEqual(repy.locs[2][1], 85.0000001, places=7)
 
     def testClusterDict(self):
         repy = rep.representatives(self.data, self.labels)
@@ -127,19 +130,20 @@ class RepresentativesTests(unittest.TestCase):
             self.assertTrue(('start', i) in repy.bins[cluster['start']])
             self.assertTrue(('end', i) in repy.bins[cluster['end']])
             for d in repy.clusters[i]:
-                tripid = d.trip_id
-                tripy = next((x for x in cluster['sections'] if x.trip_id == tripid), None)
+                tripid = d.get_id()
+                tripy = next((x for x in cluster['sections'] if x.get_id() == tripid), None)
                 self.assertTrue(tripy)
-                self.assertTrue(sum(sum(t.trip_id == tripid for t in cluster['sections']) for cluster in repy.self_loops_tour_dict) == 1)
+                self.assertTrue(sum(sum(t.get_id() == tripid for t in cluster['sections']) for cluster in repy.self_loops_tour_dict) == 1)
         
         for c in repy.tour_dict:
             self.assertTrue(c['start'] != c['end'])
 
 
     def testMatch(self):
-        tripa = Trip(None, None, None, None, None, None, Coordinate(1,2), Coordinate(3,4))
-        tripb = Trip(None, None, None, None, None, None, Coordinate(3,4), Coordinate(1,2))
-        tripc = Trip(None, None, None, None, None, None, Coordinate(1,2), Coordinate(9,10))
+        now = time.time()
+        tripa = etatc._createTripEntry(self, now, now, [1,2], [3,4])
+        tripb = etatc._createTripEntry(self, now, now, [3,4], [1,2])
+        tripc = etatc._createTripEntry(self, now, now, [1,2], [9,10])
 
         data = [tripa, tripb, tripc]
         labels = [0,1,2]
@@ -155,4 +159,5 @@ class RepresentativesTests(unittest.TestCase):
         self.assertTrue(not repy.match('end', 2, bin))
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main()

--- a/emission/tests/analysisTests/TestSimilarity.py
+++ b/emission/tests/analysisTests/TestSimilarity.py
@@ -1,29 +1,36 @@
+import logging
 import unittest
-import emission.core.get_database as edb
-import emission.analysis.modelling.tour_model.similarity as similarity
-import emission.simulation.trip_gen as tg
-import math
-from emission.core.wrapper.trip_old import Trip, Coordinate
-import emission.analysis.modelling.tour_model.cluster_pipeline as cp
+import uuid
+import time
 import datetime 
 import os, os.path
 
+import emission.tests.analysisTests.tourModelTests.common as etatc
+
+import emission.core.get_database as edb
+
+import emission.analysis.modelling.tour_model.similarity as similarity
+import emission.analysis.modelling.tour_model.cluster_pipeline as cp
+
+import emission.storage.timeseries.abstract_timeseries as esta
+
 class SimilarityTests(unittest.TestCase):
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self,  *args, **kwargs):
         super(SimilarityTests, self).__init__(*args, **kwargs)
-        self.data = cp.read_data(size=100)
+
+    def setUp(self):
+        self.testUUID = uuid.uuid4()
+        self.data = cp.read_data()
         #if len(self.data) == 0:
         #    tg.create_fake_trips()
         #    self.data = cp.read_data(size=100)
-        print 'there are ' + str(len(self.data))
-
-    def setUp(self):
-        pass
+        logging.info("Found %s trips" % len(self.data))
+        self.ts = esta.TimeSeries.get_time_series(self.testUUID)
 
     def tearDown(self):
-        return
-
+        edb.get_timeseries_db().remove({'user_id': self.testUUID})
+        edb.get_analysis_timeseries_db().remove({'user_id': self.testUUID})
 
     def testInit(self):
         try:
@@ -33,15 +40,18 @@ class SimilarityTests(unittest.TestCase):
         except Exception:
             self.assertTrue(False)
 
+        logging.debug("STARTING init test")
         sim = similarity.similarity([], 100)
         self.assertTrue(len(sim.data) == 0)
-        now = datetime.datetime.now()
-        start = Coordinate(47,-122)
-        end = Coordinate(47,-123)
-        t1 = Trip(None, None, None, None, now, now, start, start)
-        t2 = Trip(None, None, None, None, now, now, start, end)
+        now = time.time()
+        start = [-122,47]
+        end = [-123,47]
+        t1 = etatc._createTripEntry(self, now, now, start, start)
+        t2 = etatc._createTripEntry(self, now, now, start, end)
         sim = similarity.similarity([t1, t2], 100)
+        logging.debug("sim.data = %s" % sim.data)
         simmy = similarity.similarity([t2], 100)
+        logging.debug("simmy.data = %s" % simmy.data)
         self.assertTrue(sim.data == simmy.data)
 
     def testBinData(self):
@@ -62,17 +72,15 @@ class SimilarityTests(unittest.TestCase):
             self.assertTrue(len(sim.bins[i]) >= len(sim.bins[i+1]))
 
         data = []
-        now = datetime.datetime.now()
-        start = Coordinate(47,-122)
-        end = Coordinate(47,-123)
+        now = time.time()
+        start = [-122, 47]
+        end = [-123, 47]
         for i in range(10):
-            a = Trip(None, None, None, None, now, now, start, end)
-            data.append(a)
-        start = Coordinate(41,-74)
-        end = Coordinate(42, -74)
+            data.append(etatc._createTripEntry(self, now, now, start, end))
+        start = [-74, 41]
+        end = [-74, 42]
         for i in range(10):
-            a = Trip(None, None, None, None, now, now, start, end)
-            data.append(a)
+            data.append(etatc._createTripEntry(self, now, now, start, end))
         sim = similarity.similarity(data, 300)
         sim.bin_data()
         self.assertTrue(len(sim.bins) == 2)
@@ -86,10 +94,10 @@ class SimilarityTests(unittest.TestCase):
             self.assertTrue(b == sim.num)
 
     def testElbowDistance(self):
-        start = Coordinate(47,-122)
-        end = Coordinate(47,-123)
-        now = datetime.datetime.now()
-        t = Trip(None, None, None, None, now, now, start, end)
+        start = [-122,47]
+        end = [-133,47]
+        now = time.time()
+        t = etatc._createTripEntry(self, now, now, start, end)
         data = [t] * 11
         bins = [[1,2,3,4], [5,6,10], [7], [8], [9], [0]]
         sim = similarity.similarity(data, 300)
@@ -106,15 +114,15 @@ class SimilarityTests(unittest.TestCase):
                     self.assertTrue(sim.distance_helper(b,c))
 
     def testDistance(self):
-        start = Coordinate(-122.259447, 37.875174)
-        end1 = Coordinate(-122.259279, 37.875479)
-        end2 = Coordinate(-122.252287, 37.869569)
-        now = datetime.datetime.now()
-        t1 = Trip(None, None, None, None, now, now, start, end1)
-        t2 = Trip(None, None, None, None, now, now, start, end2)
+        start = [-122.259447, 37.875174]
+        end1 = [-122.259279, 37.875479]
+        end2 = [-122.252287, 37.869569]
+        now = time.time()
+        t1 = etatc._createTripEntry(self, now, now, start, end1)
+        t2 = etatc._createTripEntry(self, now, now, start, end2)
         sim = similarity.similarity(self.data, 300)
-        self.assertTrue(sim.distance(start.lat, start.lon, end1.lat, end1.lon))
-        self.assertTrue(not sim.distance(start.lat, start.lon, end2.lat, end2.lon))
+        self.assertTrue(sim.distance(start[1], start[0], end1[1], end1[0]))
+        self.assertTrue(not sim.distance(start[1], start[0], end2[1], end2[0]))
 
     def testGraph(self):
         if os.path.isfile('./histogram.png'):
@@ -136,12 +144,11 @@ class SimilarityTests(unittest.TestCase):
         a = sim.evaluate_bins()
         self.assertTrue(not a)
         sim = similarity.similarity(self.data, 300)
-        b = sim.evaluate_bins()
-        self.assertTrue(not b)
         sim.bin_data()
         c = sim.evaluate_bins()
         if sim.data:
             self.assertTrue(c)
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main()

--- a/emission/tests/analysisTests/TestSimilarity.py
+++ b/emission/tests/analysisTests/TestSimilarity.py
@@ -95,7 +95,7 @@ class SimilarityTests(unittest.TestCase):
 
     def testElbowDistance(self):
         start = [-122,47]
-        end = [-133,47]
+        end = [-123,47]
         now = time.time()
         t = etatc._createTripEntry(self, now, now, start, end)
         data = [t] * 11

--- a/emission/tests/analysisTests/TestUserModel.py
+++ b/emission/tests/analysisTests/TestUserModel.py
@@ -1,10 +1,6 @@
 import unittest
 import emission.user_model_josh.utility_model as eum
-import googlemaps
 import emission.net.ext_service.otp.otp as otp
-import emission.net.ext_service.gmaps.googlemaps as gmaps
-import emission.net.ext_service.gmaps.common as gmcommon
-import emission.net.api.utility_model_api as umapi
 import datetime
 
 

--- a/emission/tests/analysisTests/tourModelTests/common.py
+++ b/emission/tests/analysisTests/tourModelTests/common.py
@@ -1,0 +1,46 @@
+import logging
+import geojson as gj
+import uuid
+
+import emission.core.wrapper.cleanedtrip as ecwct
+import emission.core.wrapper.entry as ecwe
+import emission.core.wrapper.cleanedplace as ecwcp
+import emission.core.get_database as edb
+
+import emission.analysis.modelling.tour_model.cluster_pipeline as cp
+import emission.storage.timeseries.abstract_timeseries as esta
+
+def _createTripEntry(self, start_ts, end_ts, start_loc, end_loc):
+    t = ecwct.Cleanedtrip()
+    t.start_ts = start_ts
+    t.end_ts = end_ts
+    t.start_loc = gj.Point(start_loc)
+    t.end_loc = gj.Point(end_loc)
+    sp = ecwcp.Cleanedplace()
+    sp.location = t.start_loc
+    sp.exit_ts = start_ts
+    ep = ecwcp.Cleanedplace()
+    ep.location = t.end_loc
+    ep.enter_ts = end_ts
+    spe = ecwe.Entry.create_entry(self.testUUID, "analysis/cleaned_place", sp, create_id=True)
+    epe = ecwe.Entry.create_entry(self.testUUID, "analysis/cleaned_place", ep, create_id=True)
+    t.start_place = spe.get_id()
+    t.end_place = epe.get_id()
+    te = ecwe.Entry.create_entry(self.testUUID, "analysis/cleaned_trip", t, create_id=True)
+    self.ts.insert(spe)
+    self.ts.insert(epe)
+    self.ts.insert(te)
+    return te
+
+def _setup(self):
+    self.data = cp.read_data()
+    #if len(self.data) == 0:
+    #    tg.create_fake_trips()
+    #    self.data = cp.read_data(size=100)
+    print 'there are ' + str(len(self.data))
+    self.testUUID = uuid.uuid4()
+    self.ts = esta.TimeSeries.get_time_series(self.testUUID)
+
+def _tearDown(self):
+    edb.get_timeseries_db().remove({'user_id': self.testUUID})
+    edb.get_analysis_timeseries_db().remove({'user_id': self.testUUID})

--- a/emission/tests/storageTests/TestCommonPlaceQueries.py
+++ b/emission/tests/storageTests/TestCommonPlaceQueries.py
@@ -52,7 +52,7 @@ class TestCommonPlaceQueries(unittest.TestCase):
         estfm.move_all_filters_to_data()
         eaist.segment_current_trips(self.testUUID)
         eaiss.segment_current_sections(self.testUUID)
-        data = eamtcp.main(self.testUUID, False)
+        data = eamtcp.main(self.testUUID)
         esdcpq.create_places(data, self.testUUID)
         places = esdcpq.get_all_common_places_for_user(self.testUUID)
         places_list = []

--- a/emission/tests/storageTests/TestCommonTripQueries.py
+++ b/emission/tests/storageTests/TestCommonTripQueries.py
@@ -106,7 +106,7 @@ class TestCommonTripQueries(unittest.TestCase):
 def get_fake_data(user_name):
     # Call with a username unique to your database
     tg.create_fake_trips(user_name, True)
-    return eamtcp.main(user_name, old=False)
+    return eamtcp.main(user_name)
 
 
 if __name__ == "__main__":

--- a/emission/user_model_josh/utility_model.py
+++ b/emission/user_model_josh/utility_model.py
@@ -504,9 +504,9 @@ def get_elevation_change(trip, testing=False):
         down = random.randint(1, 100)
         return (up, down)
     time.sleep(1) # so we dont run out calls
-    c = googlemaps.client.Client(GOOGLE_MAPS_KEY)
+    c = gmaps.client.Client(GOOGLE_MAPS_KEY)
     print get_route(trip)
-    jsn = googlemaps.elevation.elevation_along_path(c, get_route(trip), 200)
+    jsn = gmaps.elevation.elevation_along_path(c, get_route(trip), 200)
     up, down = 0, 0
     prev = None
     for item in jsn:

--- a/emission/user_model_josh/utility_model.py
+++ b/emission/user_model_josh/utility_model.py
@@ -13,7 +13,6 @@ import urllib2
 import json
 import heapq
 import time
-import googlemaps
 import requests
 import random
 
@@ -127,7 +126,7 @@ class UserModel:
         return self.get_top_choices_lat_lng(start, end)
 
     def get_all_trips(self, start, end, curr_time=None):
-        c = googlemaps.client.Client(GOOGLE_MAPS_KEY)
+        c = gmaps.client.Client(GOOGLE_MAPS_KEY)
         if curr_time is None:
             curr_time = datetime.datetime.now()
         curr_month = curr_time.month


### PR DESCRIPTION
It is useless to try and debug the code unless it is actually understandable.
Therefore, we remove the old, obsolete code to improve code clarity.
This reveals that the tests had not been fixed to work with the new code and so were testing currently unused code.
Ended up fixing the tests as well.

Check out commit messages for more details.