### PR TITLE
Support the new google play motion activity format

### DIFF
--- a/emission/net/usercache/formatters/android/motion_activity.py
+++ b/emission/net/usercache/formatters/android/motion_activity.py
@@ -18,13 +18,18 @@ def format(entry):
     data = ad.AttrDict()
     if 'agb' in entry.data:
         data.type = ecwa.MotionTypes(entry.data.agb).value
-    else:
+    elif 'zzaEg' in entry.data:
         data.type = ecwa.MotionTypes(entry.data.zzaEg).value
+    else:
+        data.type = ecwa.MotionTypes(entry.data.zzaKM).value
+
 
     if 'agc' in entry.data:
         data.confidence = entry.data.agc
-    else:
+    elif 'zzaEh' in entry.data:
         data.confidence = entry.data.zzaEh
+    else:
+        data.confidence = entry.data.zzaKN
 
     data.ts = formatted_entry.metadata.write_ts
     data.local_dt = formatted_entry.metadata.write_local_dt


### PR DESCRIPTION
As part of the change to slim down the apk for android,
https://github.com/e-mission/e-mission-phone/pull/46,
https://github.com/e-mission/e-mission-data-collection/pull/116
we switched from google play version from 8.1.0 to 8.3.0, which is the version
that has separate jar files, at least in my install.

But this changed the motion activity format - the field names are now `zzaKM`
and `zzaKN` instead of `zzaEg` and `zzaEh`. So we change the formatter on the
server to handle this use case as well.

Note that we should really fix
https://github.com/e-mission/e-mission-data-collection/issues/80
to stop running into this in the future