### PR TITLE
Fixes to the production code made directly to the server

### DIFF
--- a/bin/remotePush.py
+++ b/bin/remotePush.py
@@ -3,13 +3,10 @@ import sys
 
 config_data = json.load(open('conf/net/ext_service/parse.json'))
 
-interval = sys.argv[1]
+interval = "interval_%s" % sys.argv[1]
 print "pushing for interval %s" % interval
 
 silent_push_msg = {
-   "where": {
-     "deviceType": "ios"
-   },
    "channels": [
      interval
    ],

--- a/emission/net/usercache/builtin_usercache_handler.py
+++ b/emission/net/usercache/builtin_usercache_handler.py
@@ -76,7 +76,10 @@ class BuiltinUserCacheHandler(enuah.UserCacheHandler):
             except Exception as e:
                 logging.exception("Backtrace time")
                 logging.warn("Got error %s while saving entry %s -> %s"% (e, entry, unified_entry))
-                ts.insert_error(entry_doc)
+                try:
+                    ts.insert_error(entry_doc)
+                except pymongo.errors.DuplicateKeyError as e:
+                    logging.info("document already present in error timeseries, skipping since read-only")
         logging.debug("Deleting all entries for query %s" % time_query)
         uc.clearProcessedMessages(time_query)
         esp.mark_usercache_done(self.user_id, last_ts_processed)


### PR DESCRIPTION
    - If we are using a channel, we cannot use a where search
    - If an error has been previous handled, and we get a duplicate error message,
      we should ignore and continue. This is what we do when we get an error while
      inserting the original message