### PR TITLE
Add a POST API method for habiticaRegister

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -443,7 +443,7 @@ def habiticaRegister():
                 (request.json, request))
   user_uuid = getUUID(request)
   assert(user_uuid is not None)
-  username = request.json['username']
+  username = request.json['regConfig']['username']
   # This is the second place we use the email, since we need to pass
   # it to habitica to complete registration. I'm not even refactoring
   # this into a method - hopefully this makes it less likely to be reused

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -30,6 +30,7 @@ import bson.json_util
 import modeshare, zipcode, distance, tripManager, \
                  Berkeley, visualize, stats, usercache, timeline
 import emission.net.ext_service.moves.register as auth
+import emission.net.ext_service.habitica.register as habitreg
 import emission.analysis.result.carbon as carbon
 import emission.analysis.classification.inference.commute as commute
 import emission.analysis.modelling.work_time as work_time
@@ -435,6 +436,21 @@ def movesCallback():
   code = request.json['code']
   state = request.json['state']
   return auth.movesCallback(code, state, user_uuid)
+
+@post('/habiticaRegister')
+def habiticaRegister():
+  logging.debug("habitica registration request %s from user = %s" %
+                (request.json, request))
+  user_uuid = getUUID(request)
+  assert(user_uuid is not None)
+  user = User.fromUUID(user_uuid)
+  username = request.json['username']
+  # TODO: Figure out whether this should be the same as the email
+  # used to register the user, or whether we should allow the user
+  # to override
+  email = request.json['email']
+  password = "autogenerate_me"
+  return habitreg.habiticaRegister(username, email, password, user_uuid)
 # Data source integration END
 
 @app.hook('before_request')
@@ -521,7 +537,7 @@ def getUUID(request, inHeader=False):
     else:
         # Return a random user to make it easy to experiment without having to specify a user
         # TODO: Remove this if it is not actually used
-        from get_database import get_uuid_db
+        from emission.core.get_database import get_uuid_db
         user_uuid = get_uuid_db().find_one()['uuid']
         retUUID = user_uuid
         logging.debug("skipAuth = %s, returning arbitrary UUID %s" % (skipAuth, retUUID))

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -443,14 +443,18 @@ def habiticaRegister():
                 (request.json, request))
   user_uuid = getUUID(request)
   assert(user_uuid is not None)
-  user = User.fromUUID(user_uuid)
   username = request.json['username']
-  # TODO: Figure out whether this should be the same as the email
-  # used to register the user, or whether we should allow the user
-  # to override
-  email = request.json['email']
-  password = "autogenerate_me"
-  return habitreg.habiticaRegister(username, email, password, user_uuid)
+  # This is the second place we use the email, since we need to pass
+  # it to habitica to complete registration. I'm not even refactoring
+  # this into a method - hopefully this makes it less likely to be reused
+  userToken = request.json['user']
+  if skipAuth:
+      userEmail = userToken
+  else:
+      userEmail = verifyUserToken(userToken)
+  autogen_password = "autogenerate_me"
+  return habitreg.habiticaRegister(username, userEmail,
+                                   autogen_password, user_uuid)
 # Data source integration END
 
 @app.hook('before_request')


### PR DESCRIPTION
This is an exemplar to show how to add an externally invocable POST API method
to the e-mission server.

For further explanation and examples, please consult the documentation for bottle.
http://bottlepy.org/docs/dev/index.html

@juemura, @sunil07t, @yw374cornell: this might be helpful to you as you
consider adding other methods.

This method would be invoked by sending a HTTP POST

`$http.post()`
or
`requests.post()`

with data {'username': ..., 'email': ....}

While calling this from the emission app, you should use a helper function
defined in `CommHelper` so that the JWT is inserted correctly into the HTTP
POST message.