### PR TITLE
Move all logging to the main function

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,14 @@ note that the data is accessible by AWS admins by directly looking at the disk.
 In order to avoid this, you want to encrypt the disk. You can do this by:
 - using an encrypted EBS store, but this doesn't appear to allow you to specify
   your own encryption key
-- using a normal drive that is encrypted using cryptfs (http://sleepyhead.de/howto/?href=cryptpart, https://wiki.archlinux.org/index.php/Dm-crypt/Encrypting_a_non-root_file_system)
+- using a normal drive that is encrypted using cryptfs (http://sleepyhead.de/howto/?href=cryptpart, https://wiki.archlinux.org/index.php/Dm-crypt/Encrypting_a_non-root_file_system). The standard AWS ubuntu AMI appears to have LUKS enabled, so you can follow the instructions with LUKS.
+
+```
+ubuntu@ip-10-203-173-119:/home/e-mission$ cryptsetup --help | grep luks
+                                      for luksFormat
+  -M, --type=STRING                   Type of device metadata: luks, plain,
+...
+```
 
 In either of these cases, you need to reconfigure mongod.conf to point to data
 and log directories in the encrypted volume.

--- a/bin/historical/migrations/move_carbon_footprint_to_own_field.py
+++ b/bin/historical/migrations/move_carbon_footprint_to_own_field.py
@@ -15,20 +15,21 @@ from dao.user import User
 from clients.default import default
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
 
-for user_uuid_dict in get_uuid_db().find({}, {'uuid': 1, '_id': 0}):
-    currUUID = user_uuid_dict['uuid']
-    logging.info("Fixing results for %s" % currUUID)
-    currUser = User.fromUUID(currUUID)
-    if currUser.getFirstStudy() is None:
-        currFootprint = currUser.getProfile().get("currentScore", None)
-        default.setCarbonFootprint(currUser, currFootprint)
-        get_profile_db().update({'user_id': currUUID}, {'$unset': {'previousScore': "",
-                                                                    'currentScore': ""}})
-        logging.debug("After change, currentScore = %s, currFootprint = %s" % (
-            currUser.getProfile().get("currentScore"),
-            default.getCarbonFootprint(currUser)))
+    for user_uuid_dict in get_uuid_db().find({}, {'uuid': 1, '_id': 0}):
+        currUUID = user_uuid_dict['uuid']
+        logging.info("Fixing results for %s" % currUUID)
+        currUser = User.fromUUID(currUUID)
+        if currUser.getFirstStudy() is None:
+            currFootprint = currUser.getProfile().get("currentScore", None)
+            default.setCarbonFootprint(currUser, currFootprint)
+            get_profile_db().update({'user_id': currUUID}, {'$unset': {'previousScore': "",
+                                                                        'currentScore': ""}})
+            logging.debug("After change, currentScore = %s, currFootprint = %s" % (
+                currUser.getProfile().get("currentScore"),
+                default.getCarbonFootprint(currUser)))
 
 # Informal testing from the command line since this is a one-time script
 # Can be pulled out into a unit test if reworked

--- a/bin/intake_stage.py
+++ b/bin/intake_stage.py
@@ -1,8 +1,5 @@
 import sys
 import logging
-logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
-    level=logging.DEBUG)
-
 import emission.net.usercache.abstract_usercache_handler as euah
 import emission.net.usercache.abstract_usercache as enua
 import emission.storage.timeseries.abstract_timeseries as esta
@@ -16,6 +13,9 @@ import emission.analysis.intake.cleaning.clean_and_resample as eaicr
 
 
 if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
+                        level=logging.DEBUG)
+
     cache_uuid_list = enua.UserCache.get_uuid_list()
     logging.info("cache UUID list = %s" % cache_uuid_list)
 

--- a/bin/reset_pipeline.py
+++ b/bin/reset_pipeline.py
@@ -3,7 +3,6 @@
 # As history begins to accumulate, we may want to specify a point to reset the
 # pipeline to instead of deleting everything
 import logging
-logging.basicConfig(level=logging.DEBUG)
 
 import argparse
 import uuid
@@ -100,6 +99,8 @@ def reset_pipeline(args):
         reset_pipeline_for_stage(stage, user_id, day_ts)
 
 if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
     parser = argparse.ArgumentParser()
     parser.add_argument("user_id",
         help="user to reset the pipeline for. use 'all' for all users")

--- a/emission/analysis/intake/cleaning/cleaning_methods/jump_smoothing.py
+++ b/emission/analysis/intake/cleaning/cleaning_methods/jump_smoothing.py
@@ -14,7 +14,7 @@ from enum import Enum
 
 import emission.analysis.point_features as pf
 import emission.core.common as ec
-logging.basicConfig(level=logging.DEBUG)
+# logging.basicConfig(level=logging.DEBUG)
 
 class SmoothBoundary(object):
     def __init__(self, maxSpeed = 100):

--- a/emission/analysis/intake/cleaning/cleaning_methods/speed_outlier_detection.py
+++ b/emission/analysis/intake/cleaning/cleaning_methods/speed_outlier_detection.py
@@ -4,8 +4,6 @@
 # Standard imports
 import logging
 
-logging.basicConfig(level=logging.DEBUG)
-
 class BoxplotOutlier(object):
     MINOR = 1.5
     MAJOR = 3

--- a/emission/analysis/result/metrics/simple_metrics.py
+++ b/emission/analysis/result/metrics/simple_metrics.py
@@ -1,4 +1,6 @@
 import numpy as np
+import logging
+import pandas as pd
 
 def get_summary_fn(key):
     summary_fn_map = {
@@ -30,7 +32,11 @@ def get_duration(mode_section_grouped_df):
 def get_median_speed(mode_section_grouped_df):
     ret_dict = {}
     for (mode, mode_section_df) in mode_section_grouped_df:
-        median_speeds = [np.median(sl) for sl
+        median_speeds = [pd.Series(sl).dropna().median() for sl
                             in mode_section_df.speeds]
-        ret_dict[mode] = np.median(median_speeds)
+        mode_median = pd.Series(median_speeds).dropna().median()
+        if np.isnan(mode_median):
+            logging.debug("still found nan for mode %s, skipping")
+        else:
+            ret_dict[mode] = mode_median
     return ret_dict

--- a/emission/core/wrapper/filter_modules.py
+++ b/emission/core/wrapper/filter_modules.py
@@ -10,7 +10,7 @@ import os
 import math
 import datetime
 import logging
-logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
+# logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
 import random
 from uuid import UUID
 

--- a/emission/incomplete_tests/TestApiCalls.py
+++ b/emission/incomplete_tests/TestApiCalls.py
@@ -17,5 +17,3 @@ class TestCarbon(unittest.TestCase):
         self.server_port = config_data["server"]["port"]
         self.log_base_dir = config_data["paths"]["log_base_dir"]
 
-    def testStoreSensedTrips(self):
-        

--- a/emission/net/api/Profile.py
+++ b/emission/net/api/Profile.py
@@ -14,6 +14,8 @@ from emission.analysis.modelling.tour_model.trajectory_matching.route_matching i
 from emission.analysis.modelling.tour_model.K_medoid import kmedoids, user_route_data
 import emission.analysis.modelling.tour_model.cluster_pipeline as cp
 
+TOLERANCE = 200 #How much movement we allow before updating zip codes again. Should be pretty large.. this is conservative
+
 def update_profiles(dummy_users=False):
     if dummy_users:
         user_list = ['1']
@@ -81,7 +83,5 @@ def _check_zip_validity(user_home, user):
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
     Profiles=get_profile_db()
-    TOLERANCE = 200 #How much movement we allow before updating zip codes again. Should be pretty large.. this is conservative
-
     update_profiles()
 

--- a/emission/net/api/Profile.py
+++ b/emission/net/api/Profile.py
@@ -15,6 +15,7 @@ from emission.analysis.modelling.tour_model.K_medoid import kmedoids, user_route
 import emission.analysis.modelling.tour_model.cluster_pipeline as cp
 
 TOLERANCE = 200 #How much movement we allow before updating zip codes again. Should be pretty large.. this is conservative
+Profiles=get_profile_db()
 
 def update_profiles(dummy_users=False):
     if dummy_users:
@@ -82,6 +83,5 @@ def _check_zip_validity(user_home, user):
 
 if __name__ == '__main__':
     logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
-    Profiles=get_profile_db()
     update_profiles()
 

--- a/emission/net/api/Profile.py
+++ b/emission/net/api/Profile.py
@@ -14,10 +14,6 @@ from emission.analysis.modelling.tour_model.trajectory_matching.route_matching i
 from emission.analysis.modelling.tour_model.K_medoid import kmedoids, user_route_data
 import emission.analysis.modelling.tour_model.cluster_pipeline as cp
 
-logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
-Profiles=get_profile_db()
-TOLERANCE = 200 #How much movement we allow before updating zip codes again. Should be pretty large.. this is conservative
-
 def update_profiles(dummy_users=False):
     if dummy_users:
         user_list = ['1']
@@ -83,5 +79,9 @@ def _check_zip_validity(user_home, user):
     return False
 
 if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s', level=logging.DEBUG)
+    Profiles=get_profile_db()
+    TOLERANCE = 200 #How much movement we allow before updating zip codes again. Should be pretty large.. this is conservative
+
     update_profiles()
 

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -379,7 +379,10 @@ def getCarbonCompare():
 
 @post('/result/metrics/<time_type>')
 def summarize_metrics(time_type):
-    user_uuid = getUUID(request)
+    if 'user' in request.json:
+        user_uuid = getUUID(request)
+    else:
+        user_uuid = None
     start_time = request.json['start_time']
     end_time = request.json['end_time']
     freq_name = request.json['freq']
@@ -389,9 +392,11 @@ def summarize_metrics(time_type):
         'local_date': metrics.summarize_by_local_date
     }
     metric_fn = time_type_map[time_type]
-    return metric_fn(user_uuid,
+    ret_val = metric_fn(user_uuid,
               start_time, end_time,
               freq_name, metric_name)
+    # logging.debug("ret_val = %s" % bson.json_util.dumps(ret_val))
+    return ret_val
 
 # Client related code START
 @post("/client/<clientname>/<method>")

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -7,9 +7,6 @@ import bottle as bt
 import sys
 import os
 import logging
-logging.basicConfig(format='%(asctime)s:%(levelname)s:%(thread)d:%(message)s',
-                  filename='webserver_debug.log', level=logging.DEBUG)
-logging.debug("This should go to the log file")
 
 from datetime import datetime
 import time
@@ -581,35 +578,40 @@ def getUUID(request, inHeader=False):
   return retUUID
 # Auth helpers END
 
-# We have see the sockets hang in practice. Let's set the socket timeout = 1
-# hour to be on the safe side, and see if it is hit.
-socket.setdefaulttimeout(float(socket_timeout))
+if __name__ == '__main__':
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(thread)d:%(message)s',
+                        filename='webserver_debug.log', level=logging.DEBUG)
+    logging.debug("This should go to the log file")
 
-for plugin in app.plugins:
-    if isinstance(plugin, JSONPlugin):
-        print("Replaced json_dumps in plugin with the one from bson")
-        plugin.json_dumps = bson.json_util.dumps
+    # We have see the sockets hang in practice. Let's set the socket timeout = 1
+    # hour to be on the safe side, and see if it is hit.
+    socket.setdefaulttimeout(float(socket_timeout))
 
-print("Changing bt.json_loads from %s to %s" % (bt.json_loads, bson.json_util.loads))
-bt.json_loads = bson.json_util.loads
+    for plugin in app.plugins:
+        if isinstance(plugin, JSONPlugin):
+            print("Replaced json_dumps in plugin with the one from bson")
+            plugin.json_dumps = bson.json_util.dumps
 
-# The selection of SSL versus non-SSL should really be done through a config
-# option and not through editing source code, so let's make this keyed off the
-# port number
-if server_port == "443":
-  # We support SSL and want to use it
-  run(host=server_host, port=server_port, server='cherrypy', debug=True,
-      certfile=ssl_cert, keyfile=private_key, ssl_module='builtin')
-else:
-  # Non SSL option for testing on localhost
-  # We can theoretically use a separate skipAuth flag specified in the config file,
-  # but then we have to define the behavior if SSL is true and we are not
-  # running on localhost but still want to run without authentication. That is
-  # not really an important use case now, and it makes people have to change
-  # two values and increases the chance of bugs. So let's key the auth skipping from this as well.
-  skipAuth = True
-  print "Running with HTTPS turned OFF, skipAuth = True"
+    print("Changing bt.json_loads from %s to %s" % (bt.json_loads, bson.json_util.loads))
+    bt.json_loads = bson.json_util.loads
 
-  run(host=server_host, port=server_port, server='cherrypy', debug=True)
+    # The selection of SSL versus non-SSL should really be done through a config
+    # option and not through editing source code, so let's make this keyed off the
+    # port number
+    if server_port == "443":
+      # We support SSL and want to use it
+      run(host=server_host, port=server_port, server='cherrypy', debug=True,
+          certfile=ssl_cert, keyfile=private_key, ssl_module='builtin')
+    else:
+      # Non SSL option for testing on localhost
+      # We can theoretically use a separate skipAuth flag specified in the config file,
+      # but then we have to define the behavior if SSL is true and we are not
+      # running on localhost but still want to run without authentication. That is
+      # not really an important use case now, and it makes people have to change
+      # two values and increases the chance of bugs. So let's key the auth skipping from this as well.
+      skipAuth = True
+      print "Running with HTTPS turned OFF, skipAuth = True"
 
-# run(host="0.0.0.0", port=server_port, server='cherrypy', debug=True)
+      run(host=server_host, port=server_port, server='cherrypy', debug=True)
+
+    # run(host="0.0.0.0", port=server_port, server='cherrypy', debug=True)

--- a/emission/net/ext_service/moves/collect.py
+++ b/emission/net/ext_service/moves/collect.py
@@ -14,11 +14,6 @@ import math
 from sdk import Moves
 from emission.core.get_database import get_mode_db, get_section_db, get_trip_db, get_moves_db
 
-config_data = json.load(open('conf/net/api/webserver.conf'))
-log_base_dir = config_data['paths']['log_base_dir']
-logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
-                    filename="%s/moves_collect.log" % log_base_dir, level=logging.DEBUG)
-
 def collect():
   key_file = open('keys.json')
   key_data = json.load(key_file)
@@ -308,5 +303,10 @@ def _cleanGPSData(old_points):
     return old_points
 
 if __name__ == "__main__":
-  collect()
+    config_data = json.load(open('conf/net/api/webserver.conf'))
+    log_base_dir = config_data['paths']['log_base_dir']
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
+                    filename="%s/moves_collect.log" % log_base_dir, level=logging.DEBUG)
+
+    collect()
 

--- a/emission/storage/timeseries/format_hacks/move_filter_field.py
+++ b/emission/storage/timeseries/format_hacks/move_filter_field.py
@@ -20,7 +20,8 @@ def is_location_entry(entry):
     return curr_key == "background/location" or curr_key == "background/filtered_location"
 
 def move_all_filters_to_data():
-    for entry in edb.get_timeseries_db().find():
+    tsdb = edb.get_timeseries_db()
+    for entry in tsdb.find():
         if "filter" in entry["metadata"]:
             curr_filter = entry["metadata"]["filter"]
             if is_location_entry(entry):
@@ -30,7 +31,7 @@ def move_all_filters_to_data():
 
             # For all cases, including the location one, we want to delete the filter from metadata
             del entry["metadata"]["filter"]
-            edb.get_timeseries_db().save(entry)
+            tsdb.save(entry)
             logging.debug("for entry %s, for key %s, deleted filter %s from metadata" % 
                             (entry["_id"], get_curr_key(entry), curr_filter))
         else:
@@ -43,4 +44,4 @@ def move_all_filters_to_data():
             # so set it to time in this case
             entry["data"]["filter"] = "time"
             logging.debug("No entry found in either data or metadata, for key %s setting to 'time'" % entry["metadata"]["key"])
-            edb.get_timeseries_db().save(entry)
+            tsdb.save(entry)

--- a/emission/tests/analysisTests/TestAlternativeTripPipeline.py
+++ b/emission/tests/analysisTests/TestAlternativeTripPipeline.py
@@ -17,8 +17,7 @@ from emission.net.ext_service.moves import collect
 # from emission.net.ext_services.gmaps.common import *
 import emission.core.get_database as edb
 from crontab import CronTab
-
-logging.basicConfig(level=logging.DEBUG)
+import emission.tests.common as etc
 
 class TestAlternativeTripPipeline(unittest.TestCase):
   def setUp(self):
@@ -172,4 +171,5 @@ class TestAlternativeTripPipeline(unittest.TestCase):
    '''
 
 if __name__ == '__main__':
-    unittest.main()
+  etc.configLogging()
+  unittest.main()

--- a/emission/tests/analysisTests/TestCarbon.py
+++ b/emission/tests/analysisTests/TestCarbon.py
@@ -8,10 +8,8 @@ from datetime import datetime, timedelta
 # Our imports
 from emission.analysis.result import carbon
 from emission.core.get_database import get_db, get_mode_db, get_section_db
-import emission.tests.common
+import emission.tests.common as etc
 from emission.core import common
-
-logging.basicConfig(level=logging.DEBUG)
 
 class TestCarbon(unittest.TestCase):
   def setUp(self):
@@ -23,12 +21,12 @@ class TestCarbon(unittest.TestCase):
 
     # Sometimes, we may have entries left behind in the database if one of the tests failed
     # or threw an exception, so let us start by cleaning up all entries
-    emission.tests.common.dropAllCollections(get_db())
+    etc.dropAllCollections(get_db())
     self.ModesColl = get_mode_db()
     self.assertEquals(self.ModesColl.find().count(), 0)
 
-    emission.tests.common.loadTable(self.serverName, "Stage_Modes", "emission/tests/data/modes.json")
-    emission.tests.common.loadTable(self.serverName, "Stage_Sections", "emission/tests/data/testCarbonFile")
+    etc.loadTable(self.serverName, "Stage_Modes", "emission/tests/data/modes.json")
+    etc.loadTable(self.serverName, "Stage_Sections", "emission/tests/data/testCarbonFile")
     self.SectionsColl = get_section_db()
 
     self.walkExpect = 1057.2524056424411
@@ -57,7 +55,7 @@ class TestCarbon(unittest.TestCase):
 
   def tearDown(self):
     for testUser in self.testUsers:
-      emission.tests.common.purgeSectionData(self.SectionsColl, testUser)
+      etc.purgeSectionData(self.SectionsColl, testUser)
     self.ModesColl.remove()
     self.assertEquals(self.ModesColl.find().count(), 0)
 
@@ -261,4 +259,5 @@ class TestCarbon(unittest.TestCase):
     self.assertEquals(avgTestMap['f'], 2.6)
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/TestFeaturization.py
+++ b/emission/tests/analysisTests/TestFeaturization.py
@@ -9,6 +9,7 @@ import emission.analysis.modelling.tour_model.cluster_pipeline as cp
 import emission.storage.timeseries.abstract_timeseries as esta
 
 import emission.tests.analysisTests.tourModelTests.common as etatc
+import emission.tests.common as etc
 
 class FeaturizationTests(unittest.TestCase):
 
@@ -92,5 +93,5 @@ class FeaturizationTests(unittest.TestCase):
             self.assertTrue(False)
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/TestRecommendationPipeline.py
+++ b/emission/tests/analysisTests/TestRecommendationPipeline.py
@@ -14,7 +14,7 @@ from emission.core.wrapper.client import Client
 from emission.net.ext_service.moves import collect
 from emission.core.wrapper.tripiterator import TripIterator
 
-logging.basicConfig(level=logging.DEBUG)
+import emission.tests.common as etc
 
 class TestRecommendationPipeline(unittest.TestCase):
   def setUp(self):
@@ -73,4 +73,5 @@ class TestRecommendationPipeline(unittest.TestCase):
     self.pipeline.runPipeline()
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/TestRepresentatives.py
+++ b/emission/tests/analysisTests/TestRepresentatives.py
@@ -7,6 +7,8 @@ import emission.analysis.modelling.tour_model.featurization as feat
 
 import emission.tests.analysisTests.tourModelTests.common as etatc
 
+import emission.tests.common as etc
+
 class RepresentativesTests(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
@@ -159,5 +161,5 @@ class RepresentativesTests(unittest.TestCase):
         self.assertTrue(not repy.match('end', 2, bin))
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/TestSimilarity.py
+++ b/emission/tests/analysisTests/TestSimilarity.py
@@ -6,6 +6,7 @@ import datetime
 import os, os.path
 
 import emission.tests.analysisTests.tourModelTests.common as etatc
+import emission.tests.common as etc
 
 import emission.core.get_database as edb
 
@@ -150,5 +151,5 @@ class SimilarityTests(unittest.TestCase):
             self.assertTrue(c)
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/TestUtilityModelPipeline.py
+++ b/emission/tests/analysisTests/TestUtilityModelPipeline.py
@@ -14,7 +14,7 @@ from emission.core.wrapper.user import User
 from emission.core.wrapper.client import Client
 from emission.net.ext_service.moves import collect
 
-logging.basicConfig(level=logging.DEBUG)
+import emission.tests.common as etc
 
 class TestUtilityModelPipeline(unittest.TestCase):
   def setUp(self):

--- a/emission/tests/analysisTests/configTests/TestSaveAllConfigs.py
+++ b/emission/tests/analysisTests/configTests/TestSaveAllConfigs.py
@@ -15,6 +15,8 @@ import emission.storage.timeseries.format_hacks.move_filter_field as estfm
 import emission.analysis.intake.cleaning.filter_accuracy as eaicf
 import emission.core.get_database as edb
 
+import emission.tests.common as etc
+
 class TestSaveAllConfigs(unittest.TestCase):
     def setUp(self):
         self.androidUUID = uuid.uuid4()
@@ -86,5 +88,5 @@ class TestSaveAllConfigs(unittest.TestCase):
         self.assertEqual(len(saved_entries), 0)
         
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/intakeTests/TestFilterAccuracy.py
+++ b/emission/tests/analysisTests/intakeTests/TestFilterAccuracy.py
@@ -12,6 +12,8 @@ import emission.analysis.intake.cleaning.filter_accuracy as eaicf
 import emission.storage.timeseries.abstract_timeseries as esta
 import emission.storage.pipeline_queries as epq
 
+import emission.tests.common as etc
+
 class TestFilterAccuracy(unittest.TestCase):
     def setUp(self):
         # We need to access the database directly sometimes in order to
@@ -23,9 +25,10 @@ class TestFilterAccuracy(unittest.TestCase):
         self.testUUID = uuid.uuid4()
         self.entries = json.load(open("emission/tests/data/smoothing_data/tablet_2015-11-03"),
                                  object_hook=bju.object_hook)
+        tsdb = edb.get_timeseries_db()
         for entry in self.entries:
             entry["user_id"] = self.testUUID
-            edb.get_timeseries_db().save(entry)
+            tsdb.save(entry)
         self.ts = esta.TimeSeries.get_time_series(self.testUUID)
 
     def tearDown(self):
@@ -99,5 +102,5 @@ class TestFilterAccuracy(unittest.TestCase):
         self.assertEqual(len(filtered_points_df), 124)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/intakeTests/TestLocationSmoothing.py
+++ b/emission/tests/analysisTests/intakeTests/TestLocationSmoothing.py
@@ -25,6 +25,8 @@ import emission.storage.decorations.section_queries as esds
 import emission.storage.decorations.trip_queries as esdt
 import emission.storage.decorations.analysis_timeseries_queries as esda
 
+import emission.tests.common as etc
+
 class TestLocationSmoothing(unittest.TestCase):
     def setUp(self):
         # We need to access the database directly sometimes in order to
@@ -62,9 +64,10 @@ class TestLocationSmoothing(unittest.TestCase):
 
         entries = json.load(open("emission/tests/data/smoothing_data/%s" % trip_id),
                                  object_hook=bju.object_hook)
+        tsdb = edb.get_timeseries_db()
         for entry in entries:
             entry["user_id"] = self.testUUID
-            edb.get_timeseries_db().save(entry)
+            tsdb.save(entry)
 
     def testPointFilteringShanghaiJump(self):
         classicJumpTrip1 = self.trip_entries[0]
@@ -244,7 +247,7 @@ class TestLocationSmoothing(unittest.TestCase):
                     self.assertEqual(len(filtered_points_entry.data.deleted_points), 0)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()
 
 

--- a/emission/tests/analysisTests/intakeTests/TestSectionSegmentation.py
+++ b/emission/tests/analysisTests/intakeTests/TestSectionSegmentation.py
@@ -179,5 +179,5 @@ class TestSectionSegmentation(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/intakeTests/TestTripSegmentation.py
+++ b/emission/tests/analysisTests/intakeTests/TestTripSegmentation.py
@@ -165,10 +165,11 @@ class TestTripSegmentation(unittest.TestCase):
     
     def testSegmentationWrapperCombined(self):
         # Change iOS entries to have the android UUID
+        tsdb = edb.get_timeseries_db()
         for entry in esta.TimeSeries.get_time_series(
                 self.iosUUID).find_entries():
             entry["user_id"] = self.androidUUID
-            edb.get_timeseries_db().save(entry)
+            tsdb.save(entry)
         
         # Now, segment the data for the combined UUID, which will include both
         # android and ios
@@ -230,5 +231,5 @@ class TestTripSegmentation(unittest.TestCase):
         
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/modeinferTests/TestPipeline.py
+++ b/emission/tests/analysisTests/modeinferTests/TestPipeline.py
@@ -10,9 +10,7 @@ from emission.core.get_database import get_db, get_mode_db, get_section_db
 import emission.analysis.classification.inference.mode as pipeline
 from emission.core.wrapper.user import User
 from emission.core.wrapper.client import Client
-import emission.tests.common
-
-logging.basicConfig(level=logging.DEBUG)
+import emission.tests.common as etc
 
 class TestPipeline(unittest.TestCase):
   def setUp(self):
@@ -22,7 +20,7 @@ class TestPipeline(unittest.TestCase):
 
     # Sometimes, we may have entries left behind in the database if one of the tests failed
     # or threw an exception, so let us start by cleaning up all entries
-    emission.tests.common.dropAllCollections(get_db())
+    etc.dropAllCollections(get_db())
 
     self.ModesColl = get_mode_db()
     self.assertEquals(self.ModesColl.find().count(), 0)
@@ -30,8 +28,8 @@ class TestPipeline(unittest.TestCase):
     self.SectionsColl = get_section_db()
     self.assertEquals(self.SectionsColl.find().count(), 0)
 
-    emission.tests.common.loadTable(self.serverName, "Stage_Modes", "emission/tests/data/modes.json")
-    emission.tests.common.loadTable(self.serverName, "Stage_Sections", "emission/tests/data/testModeInferFile")
+    etc.loadTable(self.serverName, "Stage_Modes", "emission/tests/data/modes.json")
+    etc.loadTable(self.serverName, "Stage_Sections", "emission/tests/data/testModeInferFile")
 
     # Let's make sure that the users are registered so that they have profiles
     for userEmail in self.testUsers:
@@ -60,7 +58,7 @@ class TestPipeline(unittest.TestCase):
 
   def tearDown(self):
     for testUser in self.testUsers:
-      emission.tests.common.purgeSectionData(self.SectionsColl, testUser)
+      etc.purgeSectionData(self.SectionsColl, testUser)
     logging.debug("Number of sections after purge is %d" % self.SectionsColl.find().count())
     self.ModesColl.remove()
     self.assertEquals(self.ModesColl.find().count(), 0)
@@ -238,7 +236,7 @@ class TestPipeline(unittest.TestCase):
 
     client = Client("testclient")
     client.update(createKey = False)
-    emission.tests.common.makeValid(client)
+    etc.makeValid(client)
 
     (resultPre, resultReg) = client.preRegister("this_is_the_super_secret_id", fakeEmail)
     self.assertEqual(resultPre, 0)
@@ -282,4 +280,5 @@ class TestPipeline(unittest.TestCase):
     self.assertIsNotNone(test_id_1_sec['distance'])
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/plottingTests/TestGeojsonFeatureConverter.py
+++ b/emission/tests/analysisTests/plottingTests/TestGeojsonFeatureConverter.py
@@ -71,5 +71,5 @@ class TestGeojsonFeatureConverter(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/resultTests/TestTimeGrouping.py
+++ b/emission/tests/analysisTests/resultTests/TestTimeGrouping.py
@@ -23,6 +23,8 @@ import emission.storage.timeseries.abstract_timeseries as esta
 import emission.storage.decorations.analysis_timeseries_queries as esda
 import emission.storage.decorations.local_date_queries as esdl
 
+import emission.tests.common as etc
+
 PST = "America/Los_Angeles"
 EST = "America/New_York"
 IST = "Asia/Calcutta"
@@ -496,5 +498,5 @@ class TestTimeGrouping(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/analysisTests/result_precompute/TestPrecomputeResults.py
+++ b/emission/tests/analysisTests/result_precompute/TestPrecomputeResults.py
@@ -13,7 +13,7 @@ import emission.tests.common
 from emission.clients.testclient import testclient
 from emission.clients.data import data
 
-logging.basicConfig(level=logging.DEBUG)
+import emission.tests.common as etc
 
 class TestPrecomputeResults(unittest.TestCase):
     def setUp(self):
@@ -87,4 +87,5 @@ class TestPrecomputeResults(unittest.TestCase):
                 self.assertEqual(len(carbonFootprint), 12)
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/client_tests/TestChoice.py
+++ b/emission/tests/client_tests/TestChoice.py
@@ -9,7 +9,7 @@ from emission.clients.choice import choice
 from emission.core.get_database import get_db, get_mode_db, get_section_db
 from emission.core.wrapper.user import User
 
-logging.basicConfig(level=logging.DEBUG)
+import emission.tests.common as etc
 
 class TestChoice(unittest.TestCase):
     def setUp(self):
@@ -36,4 +36,5 @@ class TestChoice(unittest.TestCase):
         self.assertEquals(choice.getCurrView(self.uuid), "game")
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/client_tests/TestData.py
+++ b/emission/tests/client_tests/TestData.py
@@ -10,7 +10,7 @@ from emission.core.wrapper.user import User
 import emission.tests.common
 from emission.clients.data import data
 
-logging.basicConfig(level=logging.DEBUG)
+import emission.tests.common as etc
 
 class TestDefault(unittest.TestCase):
     def setUp(self):
@@ -60,4 +60,5 @@ class TestDefault(unittest.TestCase):
         self.assertIn('carbon_footprint', test_user.getProfile().keys())
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/client_tests/TestGamified.py
+++ b/emission/tests/client_tests/TestGamified.py
@@ -9,9 +9,8 @@ from emission.clients.gamified import gamified
 from emission.core.get_database import get_db, get_mode_db, get_section_db
 from emission.core.wrapper.user import User
 from emission.core.wrapper.client import Client
-import emission.tests.common
+import emission.tests.common as etc
 
-logging.basicConfig(level=logging.DEBUG)
 
 class TestGamified(unittest.TestCase):
     def setUp(self):
@@ -82,7 +81,7 @@ class TestGamified(unittest.TestCase):
 
         client = Client("gamified")
         client.update(createKey = False)
-        emission.tests.common.makeValid(client)
+        etc.makeValid(client)
 
         (resultPre, resultReg) = client.preRegister("this_is_the_super_secret_id", fakeEmail)
         studyList = Client.getPendingClientRegs(fakeEmail)
@@ -146,4 +145,5 @@ class TestGamified(unittest.TestCase):
         self.assertAlmostEqual(storedScore[1], expectedScore, 6)
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -99,11 +99,12 @@ def setupRealExample(testObj, dump_file):
     logging.info("Before loading, timeseries db size = %s" % edb.get_timeseries_db().count())
     testObj.entries = json.load(open(dump_file), object_hook = bju.object_hook)
     testObj.testUUID = uuid.uuid4()
+    tsdb = edb.get_timeseries_db()
     for entry in testObj.entries:
         entry["user_id"] = testObj.testUUID
         # print "Saving entry with write_ts = %s and ts = %s" % (entry["metadata"]["write_fmt_time"],
         #                                                        entry["data"]["fmt_time"])
-        edb.get_timeseries_db().save(entry)
+        tsdb.save(entry)
         
     logging.info("After loading, timeseries db size = %s" % edb.get_timeseries_db().count())
     logging.debug("First few entries = %s" % 
@@ -116,3 +117,18 @@ def runIntakePipeline(uuid):
     eaist.segment_current_trips(uuid)
     eaiss.segment_current_sections(uuid)
     eaicr.clean_and_resample(uuid)
+
+def configLogging():
+    """
+    Standard function to be called from the test cases to turn on logging.
+    We really want the tests to configure logging in their main method so
+    that individual tests can be run when they fail. But we also want a standard
+    method that we can change quickly and easily.
+
+    This is a simple way to meet both requirements.
+
+    :return: None
+    """
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(thread)d:%(message)s',
+                    level=logging.DEBUG)
+

--- a/emission/tests/coreTests/TestCommon.py
+++ b/emission/tests/coreTests/TestCommon.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 from emission.core.wrapper.user import User
 from emission.core.wrapper.client import Client
 
-logging.basicConfig(level=logging.DEBUG)
+import emission.tests.common as etc
 
 class TestCommon(unittest.TestCase):
   def setUp(self):
@@ -275,4 +275,5 @@ class TestCommon(unittest.TestCase):
         func1.resetMock()
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/coreTests/TestEntry.py
+++ b/emission/tests/coreTests/TestEntry.py
@@ -13,6 +13,8 @@ import emission.core.wrapper.entry as ecwe
 import emission.core.wrapper.motionactivity as ecwm
 import emission.core.wrapper.trip as ecwt
 
+import emission.tests.common as etc
+
 class TestEntry(unittest.TestCase):
     def testWrapLocation(self):
         testEntryJSON = {'_id': '55a4418c7d65cb39ee9737cf',
@@ -88,5 +90,5 @@ class TestEntry(unittest.TestCase):
         self.assertTrue(isinstance(trip.start_loc, gj.Point))
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/coreTests/wrapperTests/TestClient.py
+++ b/emission/tests/coreTests/wrapperTests/TestClient.py
@@ -4,13 +4,14 @@ import sys
 import os
 from datetime import datetime, timedelta
 import logging
-logging.basicConfig(level=logging.DEBUG)
 
 # Our imports
 from emission.core.get_database import get_db, get_client_db, get_profile_db, get_uuid_db, get_pending_signup_db, get_section_db
 from emission.core.wrapper.client import Client
 from emission.tests import common
 from emission.core.wrapper.user import User
+
+import emission.tests.common as etc
 
 class TestClient(unittest.TestCase):
   def setUp(self):
@@ -217,4 +218,5 @@ class TestClient(unittest.TestCase):
     self.assertEqual(client.getClientConfirmedModeQuery(4), {'test_auto_confirmed.mode': 4})
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/coreTests/wrapperTests/TestUser.py
+++ b/emission/tests/coreTests/wrapperTests/TestUser.py
@@ -4,7 +4,6 @@ import sys
 import os
 from datetime import datetime, timedelta
 import logging
-logging.basicConfig(level=logging.DEBUG)
 
 # Our imports
 from emission.core.wrapper.user import User
@@ -14,9 +13,11 @@ from emission.analysis.result import userclient
 import emission.tests.common as etc
 import emission.core.get_database as edb
 
+import emission.tests.common as etc
+
 class TestUser(unittest.TestCase):
   def setUp(self):
-    etc.dropAllCollections(edb.get_db());
+    etc.dropAllCollections(edb.get_db())
 
   def testIsNotRegistered(self):
     self.assertFalse(User.isRegistered('fake@fake.com'))
@@ -189,4 +190,5 @@ class TestUser(unittest.TestCase):
     self.assertTrue(user.getProfile().get('test_field', 'blank'), {'something': 'beautiful'})
     
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/coreTests/wrapperTests/TestUserClient.py
+++ b/emission/tests/coreTests/wrapperTests/TestUserClient.py
@@ -4,13 +4,14 @@ import sys
 import os
 from datetime import datetime, timedelta
 import logging
-logging.basicConfig(level=logging.DEBUG)
 
 # Our imports
 from emission.core.wrapper.user import User
 from emission.core.wrapper.client import Client
 from emission.tests import common
 from emission.analysis.result import userclient
+
+import emission.tests.common as etc
 
 class TestUserClient(unittest.TestCase):
   def setUp(self):
@@ -39,4 +40,5 @@ class TestUserClient(unittest.TestCase):
     self.assertEquals(userclient.getClientQuery('testclient'), {'study_list': {'$in': ['testclient']}});
 
 if __name__ == '__main__':
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/netTests/TestBuiltinUserCache.py
+++ b/emission/tests/netTests/TestBuiltinUserCache.py
@@ -366,5 +366,7 @@ class TestBuiltinUserCache(unittest.TestCase):
     self.assertEquals(uuid_list, [self.testUserUUID])
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/netTests/TestBuiltinUserCacheHandlerInput.py
+++ b/emission/tests/netTests/TestBuiltinUserCacheHandlerInput.py
@@ -185,5 +185,7 @@ class TestBuiltinUserCacheHandlerInput(unittest.TestCase):
         self.assertEqual(edb.get_timeseries_error_db().find().count(), 0)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
+++ b/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
@@ -138,5 +138,7 @@ class TestBuiltinUserCacheHandlerOutput(unittest.TestCase):
             "config/sensor_config"])
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/netTests/TestFormatters.py
+++ b/emission/tests/netTests/TestFormatters.py
@@ -107,5 +107,7 @@ class TestFormatters(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/netTests/TestGilesArchiver.py
+++ b/emission/tests/netTests/TestGilesArchiver.py
@@ -7,8 +7,6 @@ import time
 # Our imports
 from emission.net.int_service.giles import archiver
 
-logging.basicConfig(level=logging.DEBUG)
-
 class TestArchiver(unittest.TestCase):
   def setUp(self):
     self.archiver = archiver.StatArchiver('test')
@@ -93,5 +91,8 @@ class TestArchiver(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    import emission.tests.common as etc
+
+    etc.configLogging()
     unittest.main()
 

--- a/emission/tests/netTests/TestHabiticaRegister.py
+++ b/emission/tests/netTests/TestHabiticaRegister.py
@@ -90,5 +90,7 @@ def randomGen():
     return string
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/netTests/TestMetrics.py
+++ b/emission/tests/netTests/TestMetrics.py
@@ -63,7 +63,14 @@ class TestMetrics(unittest.TestCase):
         # must be at least that much larger than the original data.
         self.assertEqual(len(agg_met_result), 8)
         # no overlap between users at the daily level
+        # bunch of intermediate entries with no users since this binning works
+        # by range
         self.assertEqual([m.nUsers for m in agg_met_result], [1,1,0,0,0,0,1,1])
+        # If there are no users, there are no values for any of the fields
+        # since these are never negative, it implies that their sum is zero
+        self.assertTrue('ON_FOOT' not in agg_met_result[2] and
+                         'BICYCLING' not in agg_met_result[2] and
+                         'IN_VEHICLE' not in agg_met_result[2])
 
 
     def testCountLocalDateMetrics(self):
@@ -116,5 +123,6 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(met_result_ts['user_metrics'], [])
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/netTests/TestMovesCollect.py
+++ b/emission/tests/netTests/TestMovesCollect.py
@@ -3,7 +3,6 @@ import unittest
 import logging
 import json
 import re
-logging.basicConfig(level=logging.DEBUG)
 
 # Our imports
 import emission.tests.common
@@ -317,4 +316,7 @@ class TestMovesCollect(unittest.TestCase):
     self.assertEquals(newSec['retained'], False)
 
 if __name__ == '__main__':
+    import emission.tests.common as etc
+
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/netTests/TestProfile.py
+++ b/emission/tests/netTests/TestProfile.py
@@ -13,8 +13,6 @@ from emission.core.wrapper.user import User
 from emission.core.wrapper.client import Client
 import emission.tests.common
 
-logging.basicConfig(level=logging.DEBUG)
-
 class TestProfile(unittest.TestCase):
   def setUp(self):
     self.testUsers = ["test@example.com", "best@example.com", "fest@example.com",
@@ -104,4 +102,7 @@ class TestProfile(unittest.TestCase):
                     self.assertEquals(prof_1['zip'],  '94720')
 
 if __name__ == '__main__':
+    import emission.tests.common as etc
+    etc.configLogging()
+
     unittest.main()

--- a/emission/tests/netTests/TestStats.py
+++ b/emission/tests/netTests/TestStats.py
@@ -8,8 +8,6 @@ import time
 from emission.core.get_database import get_client_stats_db, get_server_stats_db, get_result_stats_db
 from emission.net.api import stats
 
-logging.basicConfig(level=logging.DEBUG)
-
 class TestStats(unittest.TestCase):
   def setUp(self):
     get_client_stats_db().remove()
@@ -92,4 +90,7 @@ class TestStats(unittest.TestCase):
     self.assertEquals(stats.getClientMeasurementCount(self.testInputJSON['Readings']), 6)
 
 if __name__ == '__main__':
+    import emission.tests.common as etc
+    etc.configLogging()
+
     unittest.main()

--- a/emission/tests/netTests/TestTripManager.py
+++ b/emission/tests/netTests/TestTripManager.py
@@ -12,8 +12,6 @@ from emission.core.get_database import get_db, get_mode_db, get_section_db, get_
 from emission.net.api import tripManager
 from emission.core.wrapper.user import User
 
-logging.basicConfig(level=logging.DEBUG)
-
 class TestTripManager(unittest.TestCase):
   def setUp(self):
     self.testUsers = ["test@example.com", "best@example.com", "fest@example.com",
@@ -193,4 +191,7 @@ class TestTripManager(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main()
+  import emission.tests.common as etc
+  etc.configLogging()
+
+  unittest.main()

--- a/emission/tests/netTests/TestVisualize.py
+++ b/emission/tests/netTests/TestVisualize.py
@@ -17,9 +17,6 @@ import emission.storage.timeseries.format_hacks.move_filter_field as estfm
 import emission.core.wrapper.motionactivity as ecwm
 import emission.storage.decorations.local_date_queries as esdldq
 
-logging.basicConfig(level=logging.DEBUG)
-
-
 
 class TestVisualize(unittest.TestCase):
     def setUp(self):
@@ -57,4 +54,7 @@ class TestVisualize(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    import emission.tests.common as etc
+    etc.configLogging()
+
     unittest.main()

--- a/emission/tests/storageTests/TestAnalysisTimeseries.py
+++ b/emission/tests/storageTests/TestAnalysisTimeseries.py
@@ -49,5 +49,6 @@ class TestAnalysisTimeseriesQueries(unittest.TestCase):
         etsa.queryPlaceLike(self, esda.RAW_STOP_KEY, ecws.Stop)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestCommonTripQueries.py
+++ b/emission/tests/storageTests/TestCommonTripQueries.py
@@ -43,11 +43,6 @@ class TestCommonTripQueries(unittest.TestCase):
         edb.get_analysis_timeseries_db().remove({'user_id': self.testUserId})
         edb.get_common_place_db().remove({'user_id': self.testUserId})
 
-    def clearRelatedDb(self):
-        edb.get_timeseries_db().drop()
-        edb.get_analysis_timeseries_db().drop()
-        edb.get_common_place_db().drop()
-
     def testCreation(self):
         common_trip = esdctp.make_new_common_trip()
         common_trip.user_id = self.testUserId
@@ -104,5 +99,6 @@ def get_fake_data(user_name):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestLocalDateQueries.py
+++ b/emission/tests/storageTests/TestLocalDateQueries.py
@@ -107,5 +107,6 @@ class TestLocalDateQueries(unittest.TestCase):
         self.assertEquals(last_entry.data.local_dt.hour, 17)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestMoveFilterField.py
+++ b/emission/tests/storageTests/TestMoveFilterField.py
@@ -23,12 +23,13 @@ class TestMoveFilterField(unittest.TestCase):
         edb.get_timeseries_db().remove({"user_id": self.testUUID,
                                         "metadata.key": "background/filtered_location"})
 
+        tsdb = edb.get_timeseries_db()
         for entry in edb.get_timeseries_db().find({'user_id': self.testUUID,
             'metadata.filter': 'time',
             "metadata.key": "background/location"}):
             del entry["_id"]
             entry["metadata"]["key"] = "background/filtered_location"
-            edb.get_timeseries_db().insert(entry)
+            tsdb.insert(entry)
 
         self.assertEquals(edb.get_timeseries_db().find({'user_id': self.testUUID,
             'metadata.filter': 'time',
@@ -87,13 +88,14 @@ class TestMoveFilterField(unittest.TestCase):
     def testInsertFilters(self):
         edb.get_timeseries_db().remove({"user_id": self.testUUID,
                                         "metadata.key": "background/filtered_location"})
+        tsdb = edb.get_timeseries_db()
         for entry in edb.get_timeseries_db().find({'user_id': self.testUUID,
             'metadata.filter': 'time',
             "metadata.key": "background/location"}):
             del entry["_id"]
             del entry["metadata"]["filter"]
             entry["metadata"]["key"] = "background/filtered_location"
-            edb.get_timeseries_db().insert(entry)
+            tsdb.insert(entry)
 
         # At this point, all the filtered_location entries will not have any filters
         self.assertEquals(edb.get_timeseries_db().find({'user_id': self.testUUID,
@@ -118,5 +120,6 @@ class TestMoveFilterField(unittest.TestCase):
             "metadata.key": "background/filtered_location"}).count(), 738)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestPipelineQueries.py
+++ b/emission/tests/storageTests/TestPipelineQueries.py
@@ -63,5 +63,6 @@ class TestPipelineQueries(unittest.TestCase):
         self.assertIsNotNone(new_state.last_ts_run)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestPlaceQueries.py
+++ b/emission/tests/storageTests/TestPlaceQueries.py
@@ -44,5 +44,6 @@ class TestPlaceQueries(unittest.TestCase):
         self.assertIsNone(last_place_entry)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestSectionQueries.py
+++ b/emission/tests/storageTests/TestSectionQueries.py
@@ -41,5 +41,6 @@ class TestSectionQueries(unittest.TestCase):
         self.assertEqual([entry.data for entry in ret_arr_list], ret_arr_time)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestStopQueries.py
+++ b/emission/tests/storageTests/TestStopQueries.py
@@ -38,5 +38,6 @@ class TestStopQueries(unittest.TestCase):
         self.assertEqual([entry.data for entry in ret_arr_list], ret_arr_time)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestTimeSeries.py
+++ b/emission/tests/storageTests/TestTimeSeries.py
@@ -69,5 +69,6 @@ class TestTimeSeries(unittest.TestCase):
             list(ts.find_entries(time_query=tq, extra_query_list=[ignored_phones]))
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestTimeline.py
+++ b/emission/tests/storageTests/TestTimeline.py
@@ -113,5 +113,6 @@ class TestTimeline(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestTourModelQueries.py
+++ b/emission/tests/storageTests/TestTourModelQueries.py
@@ -43,5 +43,6 @@ class TestTourModelQueries(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestTripQueries.py
+++ b/emission/tests/storageTests/TestTripQueries.py
@@ -57,5 +57,6 @@ class TestTripQueries(unittest.TestCase):
         self.assertEqual([entry.data for entry in ret_entries], [new_stop])
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()

--- a/emission/tests/storageTests/TestUsefulQueries.py
+++ b/emission/tests/storageTests/TestUsefulQueries.py
@@ -107,5 +107,6 @@ class UsefulQueriesTests(unittest.TestCase):
         self.assertEqual(bounds[1].lon, 11)
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    import emission.tests.common as etc
+    etc.configLogging()
     unittest.main()


### PR DESCRIPTION
Before this change, we logged the message, but did not log any timestamps, which makes it harder to see how long various operations took, correlate wi th logs on other servers, etc.
    
The logs were also configured individually in each test and some non-test modules, making it hard to change the log format easily. Finally, the logs were occasionally configured globally on module load. This meant that they would override any configurations in main.
    
I went through and unified the logging module configuration.

- modules do not have module level logging configurations. no exceptions.
  (scripts in `bin` are exceptions because they are intended to be more l ike
    scripts)
- modules that are invoked directly by the user (e.g intake, webapp) have
  existing configurations
- tests have a standard logging configuration defined in `emission.tests.common`
- all tests configure their logging in main using the standard logging configuration
