### PR TITLE
Fix regression in section segmentation on iOS caused by expansion of …

### DIFF
--- a/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_with_visit_transitions.py
+++ b/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_with_visit_transitions.py
@@ -40,9 +40,9 @@ class SmoothedHighConfidenceMotionWithVisitTransitions(eaisms.SmoothedHighConfid
         new_mc = ecwm.Motionactivity({
             'type': motion_change.type,
             'confidence': motion_change.confidence,
-            'ts': location_point.ts,
-            'local_dt': location_point.local_dt,
-            'fmt_time': location_point.fmt_time
+            'ts': location_point.data.ts,
+            'local_dt': location_point.data.local_dt,
+            'fmt_time': location_point.data.fmt_time
         })
         return new_mc
 
@@ -84,9 +84,13 @@ class SmoothedHighConfidenceMotionWithVisitTransitions(eaisms.SmoothedHighConfid
         # So let us extend the first motion change to the beginning of the
         # trip, and the last motion change to the end of the trip
         motion_changes[0] = (self.extend_activity_to_location(motion_changes[0][0],
-            location_points.iloc[0]), motion_changes[0][1])
+                timeseries.df_row_to_entry("background/filtered_location",
+                                           location_points.iloc[0])),
+                             motion_changes[0][1])
         motion_changes[-1] = (motion_changes[-1][0],
-            self.extend_activity_to_location(motion_changes[-1][1], location_points.iloc[-1]))
+            self.extend_activity_to_location(motion_changes[-1][1],
+                timeseries.df_row_to_entry("background/filtered_location",
+                                           location_points.iloc[-1])))
 
         for (start_motion, end_motion) in motion_changes:
             logging.debug("Considering %s from %s -> %s" %

--- a/emission/tests/analysisTests/intakeTests/TestSectionSegmentation.py
+++ b/emission/tests/analysisTests/intakeTests/TestSectionSegmentation.py
@@ -13,6 +13,7 @@ import emission.core.wrapper.motionactivity as ecwm
 import emission.core.wrapper.entry as ecwe
 import emission.core.wrapper.rawtrip as ecwrt
 import emission.core.wrapper.rawplace as ecwrp
+import emission.core.wrapper.pipelinestate as ecwp
 
 import emission.analysis.intake.segmentation.section_segmentation_methods.smoothed_high_confidence_motion as shcm
 import emission.analysis.intake.segmentation.section_segmentation as eaiss
@@ -20,10 +21,9 @@ import emission.analysis.intake.segmentation.section_segmentation as eaiss
 import emission.analysis.intake.segmentation.trip_segmentation as eaist
 
 import emission.storage.decorations.trip_queries as esdt
-import emission.storage.decorations.section_queries as esds
 import emission.storage.decorations.analysis_timeseries_queries as esda
+import emission.storage.pipeline_queries as esp
 
-import emission.storage.timeseries.format_hacks.move_filter_field as estfm
 import emission.analysis.intake.cleaning.filter_accuracy as eaicf
 
 # Test imports
@@ -32,17 +32,24 @@ import emission.tests.common as etc
 class TestSectionSegmentation(unittest.TestCase):
     def setUp(self):
         etc.setupRealExample(self, "emission/tests/data/real_examples/shankari_2015-aug-27")
-        eaicf.filter_accuracy(self.testUUID)
+        self.androidUUID = self.testUUID
+        eaicf.filter_accuracy(self.androidUUID)
+
+        etc.setupRealExample(self, "emission/tests/data/real_examples/iphone_2015-11-06")
+        self.iosUUID = self.testUUID
+        eaicf.filter_accuracy(self.iosUUID)
 
     def tearDown(self):
         self.clearRelatedDb()
 
     def clearRelatedDb(self):
-        edb.get_timeseries_db().remove({"user_id": self.testUUID})
-        edb.get_analysis_timeseries_db().remove({"user_id": self.testUUID})
-        
+        edb.get_timeseries_db().remove({"user_id": self.androidUUID})
+        edb.get_analysis_timeseries_db().remove({"user_id": self.androidUUID})
+        edb.get_timeseries_db().remove({"user_id": self.iosUUID})
+        edb.get_analysis_timeseries_db().remove({"user_id": self.iosUUID})
+
     def testSegmentationPointsSmoothedHighConfidenceMotion(self):
-        ts = esta.TimeSeries.get_time_series(self.testUUID)
+        ts = esta.TimeSeries.get_time_series(self.androidUUID)
         tq = estt.TimeQuery("metadata.write_ts", 1440695152.989, 1440699266.669)
         shcmsm = shcm.SmoothedHighConfidenceMotion(60, [ecwm.MotionTypes.TILTING,
                                                         ecwm.MotionTypes.UNKNOWN,
@@ -60,7 +67,7 @@ class TestSectionSegmentation(unittest.TestCase):
                           [1440698066.704, 1440699234.834])
 
     def testSegmentationWrapperWithManualTrip(self):
-        ts = esta.TimeSeries.get_time_series(self.testUUID)
+        ts = esta.TimeSeries.get_time_series(self.androidUUID)
         test_trip = ecwrt.Rawtrip()
         test_trip.start_ts = 1440695152.989
         test_trip.start_fmt_time = "2015-08-27 10:05:52.989000-07:00"
@@ -99,20 +106,20 @@ class TestSectionSegmentation(unittest.TestCase):
                     37.875023
                 ]
             }
-        test_trip_id = ts.insert(ecwe.Entry.create_entry(self.testUUID,
+        test_trip_id = ts.insert(ecwe.Entry.create_entry(self.androidUUID,
             "segmentation/raw_trip", test_trip))
-        eaiss.segment_trip_into_sections(self.testUUID, test_trip_id, "DwellSegmentationTimeFilter")
+        eaiss.segment_trip_into_sections(self.androidUUID, test_trip_id, "DwellSegmentationTimeFilter")
 
-        created_stops_entries = esdt.get_raw_stops_for_trip(self.testUUID, test_trip_id)
-        created_sections_entries = esdt.get_raw_sections_for_trip(self.testUUID, test_trip_id)
+        created_stops_entries = esdt.get_raw_stops_for_trip(self.androidUUID, test_trip_id)
+        created_sections_entries = esdt.get_raw_sections_for_trip(self.androidUUID, test_trip_id)
         created_stops = [entry.data for entry in created_stops_entries]
         created_sections = [entry.data for entry in created_sections_entries]
 
         tq_stop = estt.TimeQuery("data.enter_ts", 1440658800, 1440745200)
-        queried_stops = esda.get_objects(esda.RAW_STOP_KEY, self.testUUID, tq_stop)
+        queried_stops = esda.get_objects(esda.RAW_STOP_KEY, self.androidUUID, tq_stop)
 
         tq_section = estt.TimeQuery("data.start_ts", 1440658800, 1440745200)
-        queried_sections = esda.get_objects(esda.RAW_SECTION_KEY, self.testUUID, tq_section)
+        queried_sections = esda.get_objects(esda.RAW_SECTION_KEY, self.androidUUID, tq_section)
 
         for i, stop in enumerate(created_stops):
             logging.info("Retrieved stop %s: %s -> %s" % (i, stop.enter_fmt_time, stop.exit_fmt_time))
@@ -143,30 +150,24 @@ class TestSectionSegmentation(unittest.TestCase):
         self.assertEqual(created_stops, queried_stops)
 
     def testSegmentationWrapperWithAutoTrip(self):
-        eaist.segment_current_trips(self.testUUID)
-        eaiss.segment_current_sections(self.testUUID)
+        eaist.segment_current_trips(self.androidUUID)
+        eaiss.segment_current_sections(self.androidUUID)
 
         tq_trip = estt.TimeQuery("data.start_ts", 1440658800, 1440745200)
-        created_trips = esda.get_entries(esda.RAW_TRIP_KEY, self.testUUID,
+        created_trips = esda.get_entries(esda.RAW_TRIP_KEY, self.androidUUID,
                                          tq_trip)
 
-        for i, trip in enumerate(created_trips):
-            logging.debug("current trip is %s" % trip)
-            created_stops = esdt.get_raw_stops_for_trip(self.testUUID, trip.get_id())
-            created_sections = esdt.get_raw_sections_for_trip(self.testUUID, trip.get_id())
+        self.assertEqual(len(created_trips), 8)
 
-            for j, stop in enumerate(created_stops):
-                logging.info("Retrieved stops %s: %s -> %s" %
-                             (j, stop.data.enter_fmt_time,
-                              stop.data.exit_fmt_time))
-            for j, section in enumerate(created_sections):
-                logging.info("Retrieved sections %s: %s -> %s" %
-                             (j, section.data.start_fmt_time,
-                              section.data.end_fmt_time))
-
-            # self.assertEqual(len(created_stops), 1)
-            # self.assertEqual(len(created_sections), 2)
-
+        sections_stops = [(len(esdt.get_raw_sections_for_trip(self.androidUUID, trip.get_id())),
+                           len(esdt.get_raw_stops_for_trip(self.androidUUID, trip.get_id())))
+                          for trip in created_trips]
+        logging.debug(sections_stops)
+        self.assertEqual(len(sections_stops), len(created_trips))
+        # The expected value was copy-pasted from the debug statement above
+        self.assertEqual(sections_stops,
+                         [(2, 1), (1, 0), (2, 1), (2, 1), (0, 0), (2, 1),
+                          (4, 3), (2, 1)])
 
         # tq_stop = estt.TimeQuery("data.enter_ts", 1440658800, 1440745200)
         # queried_stops = esdst.get_stops(self.testUUID, tq_stop)
@@ -176,6 +177,26 @@ class TestSectionSegmentation(unittest.TestCase):
         #
         # self.assertEqual(created_sections, queried_sections)
         # self.assertEqual(created_stops, queried_stops)
+
+    def testIOSSegmentationWrapperWithAutoTrip(self):
+        eaist.segment_current_trips(self.iosUUID)
+        eaiss.segment_current_sections(self.iosUUID)
+
+        tq_trip = estt.TimeQuery("data.start_ts", 1446700000, 1446900000)
+        created_trips = esda.get_entries(esda.RAW_TRIP_KEY, self.iosUUID,
+                                         tq_trip)
+
+        self.assertEqual(len(created_trips), 3)
+        logging.debug("created trips = %s" % created_trips)
+
+        sections_stops = [(len(esdt.get_raw_sections_for_trip(self.iosUUID, trip.get_id())),
+                           len(esdt.get_raw_stops_for_trip(self.iosUUID, trip.get_id())))
+                          for trip in created_trips]
+        logging.debug(sections_stops)
+        self.assertEqual(len(sections_stops), len(created_trips))
+        # The expected value was copy-pasted from the debug statement above
+        self.assertEqual(sections_stops,
+                         [(0, 0), (6, 5), (6, 5)])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…local_dt

In de06821e5c2a2a87bd4ac246062720d698fc5d04, we expanded the local_dt into its
constituent elements while creating the dataframe from a set of objects. We
converted all existing tests to match the specification. However, it turns out
that the segmentation tests only exercise the android code path, which is
different from the iOS code path.

In this change, we enhance the segmentation tests to work on iOS as well. As
expected, the tests failed with the same error as the server.

```
Traceback (most recent call last):
  File "/Users/shankari/e-mission/e-mission-server/emission/analysis/intake/seg
mentation/section_segmentation.py", line 42, in segment_current_sections
    segment_trip_into_sections(user_id, trip.get_id(), trip.data.source)
  File "/Users/shankari/e-mission/e-mission-server/emission/analysis/intake/seg
mentation/section_segmentation.py", line 73, in segment_trip_into_sections
    segmentation_points = shcmsm.segment_into_sections(ts, time_query)
  File "/Users/shankari/e-mission/e-mission-server/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_with_visit_transitions.py", line 87, in segment_into_sections
    location_points.iloc[0]), motion_changes[0][1])
  File "/Users/shankari/e-mission/e-mission-server/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_with_visit_transitions.py", line 44, in extend_activity_to_location
    'local_dt': location_point.local_dt,
  File "/Users/shankari/OSS/anaconda/lib/python2.7/site-packages/pandas/core/generic.py", line 2246, in __getattr__
    (type(self).__name__, name))
AttributeError: 'Series' object has no attribute 'local_dt'
```

The error is caused because we are passing in the dataframe row directly, and
etrying to set the `local_dt` for an entry from it. The solution is similar to
bce9c3425e3806e07aba8d1b6be0ff03aae5afb0, we retrieve the entry corresponding
to a row and return it.