### PR TITLE
Add server side support for storing the "consent" rw document

### DIFF
--- a/emission/analysis/configs/config.py
+++ b/emission/analysis/configs/config.py
@@ -3,7 +3,7 @@ import importlib
 
 import emission.net.usercache.abstract_usercache as enua
 
-config_list = ["sensor_config", "sync_config"]
+config_list = ["sensor_config", "sync_config", "consent"]
 
 def save_all_configs(user_id, time_query):
     uc = enua.UserCache.getUserCache(user_id)

--- a/emission/analysis/configs/consent.py
+++ b/emission/analysis/configs/consent.py
@@ -1,0 +1,8 @@
+import logging
+import emission.analysis.configs.config_utils as eacc
+
+def get_config(user_id, time_query):
+    # right now, we are not doing any server side overrides, so we pick the
+    # last user defined configuration for this user
+    CONSENT_CONFIG_KEY = "config/consent"
+    return eacc.get_last_entry(user_id, time_query, CONSENT_CONFIG_KEY)

--- a/emission/core/wrapper/consentconfig.py
+++ b/emission/core/wrapper/consentconfig.py
@@ -1,0 +1,14 @@
+import logging
+import emission.core.wrapper.wrapperbase as ecwb
+
+class Consentconfig(ecwb.WrapperBase):
+    props = {"category": ecwb.WrapperBase.Access.RO,  # the category of data collection for which the user has consented
+             "protocol_id": ecwb.WrapperBase.Access.RO,
+             "approval_date": ecwb.WrapperBase.Access.RO} # the data on which the protocol was approved by the IRB
+    enums = {}
+    geojson = []
+    nullable = []
+    local_dates = []
+
+    def _populateDependencies(self):
+        pass

--- a/emission/core/wrapper/entry.py
+++ b/emission/core/wrapper/entry.py
@@ -32,6 +32,7 @@ class Entry(ecwb.WrapperBase):
             "statemachine/transition": "transition",
             "config/sensor_config": "sensorconfig",
             "config/sync_config": "syncconfig",
+            "config/consent": "consentconfig",
             "segmentation/raw_trip": "rawtrip",
             "segmentation/raw_place": "rawplace",
             "segmentation/raw_section": "section",

--- a/emission/net/usercache/formatters/android/consent.py
+++ b/emission/net/usercache/formatters/android/consent.py
@@ -15,7 +15,7 @@ def format(entry):
     metadata = entry.metadata
     try:
         valid_tz = pytz.timezone(entry.metadata.time_zone)
-    except UnknownTimeZoneError, e:
+    except pytz.UnknownTimeZoneError, e:
         logging.warn("Got error %s while checking format validity" % e)
         # Default timezone in for the Bay Area, which is probably a fairly safe
         # assumption for now

--- a/emission/net/usercache/formatters/android/consent.py
+++ b/emission/net/usercache/formatters/android/consent.py
@@ -1,0 +1,29 @@
+import logging
+import pytz
+import attrdict as ad
+import copy
+
+import emission.core.wrapper.syncconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = ad.AttrDict()
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+
+    formatted_entry.data = entry.data
+
+    return formatted_entry;

--- a/emission/net/usercache/formatters/android/sensor_config.py
+++ b/emission/net/usercache/formatters/android/sensor_config.py
@@ -15,7 +15,7 @@ def format(entry):
     metadata = entry.metadata
     try:
         valid_tz = pytz.timezone(entry.metadata.time_zone)
-    except UnknownTimeZoneError, e:
+    except pytz.UnknownTimeZoneError, e:
         logging.warn("Got error %s while checking format validity" % e)
         # Default timezone in for the Bay Area, which is probably a fairly safe
         # assumption for now

--- a/emission/net/usercache/formatters/android/sync_config.py
+++ b/emission/net/usercache/formatters/android/sync_config.py
@@ -15,7 +15,7 @@ def format(entry):
     metadata = entry.metadata
     try:
         valid_tz = pytz.timezone(entry.metadata.time_zone)
-    except UnknownTimeZoneError, e:
+    except pytz.UnknownTimeZoneError, e:
         logging.warn("Got error %s while checking format validity" % e)
         # Default timezone in for the Bay Area, which is probably a fairly safe
         # assumption for now

--- a/emission/net/usercache/formatters/ios/consent.py
+++ b/emission/net/usercache/formatters/ios/consent.py
@@ -1,0 +1,26 @@
+import copy
+
+import emission.core.wrapper.syncconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+
+    formatted_entry.data = entry.data
+
+    return formatted_entry;

--- a/emission/net/usercache/formatters/ios/consent.py
+++ b/emission/net/usercache/formatters/ios/consent.py
@@ -1,6 +1,8 @@
+import logging
 import copy
+import pytz
 
-import emission.core.wrapper.syncconfig as ecws
+import emission.core.wrapper.consentconfig as ecws
 import emission.net.usercache.formatters.common as fc
 
 # Currently, we just reflect this back to the user, so not much editing to do
@@ -12,7 +14,7 @@ def format(entry):
     metadata = entry.metadata
     try:
         valid_tz = pytz.timezone(entry.metadata.time_zone)
-    except UnknownTimeZoneError, e:
+    except pytz.UnknownTimeZoneError, e:
         logging.warn("Got error %s while checking format validity" % e)
         # Default timezone in for the Bay Area, which is probably a fairly safe
         # assumption for now

--- a/emission/net/usercache/formatters/ios/sensor_config.py
+++ b/emission/net/usercache/formatters/ios/sensor_config.py
@@ -15,7 +15,7 @@ def format(entry):
     metadata = entry.metadata
     try:
         valid_tz = pytz.timezone(entry.metadata.time_zone)
-    except UnknownTimeZoneError, e:
+    except pytz.UnknownTimeZoneError, e:
         logging.warn("Got error %s while checking format validity" % e)
         # Default timezone in for the Bay Area, which is probably a fairly safe
         # assumption for now

--- a/emission/net/usercache/formatters/ios/sync_config.py
+++ b/emission/net/usercache/formatters/ios/sync_config.py
@@ -1,4 +1,6 @@
+import logging
 import copy
+import pytz
 
 import emission.core.wrapper.syncconfig as ecws
 import emission.net.usercache.formatters.common as fc
@@ -12,7 +14,7 @@ def format(entry):
     metadata = entry.metadata
     try:
         valid_tz = pytz.timezone(entry.metadata.time_zone)
-    except UnknownTimeZoneError, e:
+    except pytz.UnknownTimeZoneError, e:
         logging.warn("Got error %s while checking format validity" % e)
         # Default timezone in for the Bay Area, which is probably a fairly safe
         # assumption for now

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -24,6 +24,7 @@ class BuiltinTimeSeries(esta.TimeSeries):
                 "statemachine/transition": self.timeseries_db,
                 "config/sensor_config": self.timeseries_db,
                 "config/sync_config": self.timeseries_db,
+                "config/consent": self.timeseries_db,
                 "segmentation/raw_trip": self.analysis_timeseries_db,
                 "segmentation/raw_place": self.analysis_timeseries_db,
                 "segmentation/raw_section": self.analysis_timeseries_db,

--- a/webapp/www/docs/consent.html
+++ b/webapp/www/docs/consent.html
@@ -5,92 +5,81 @@
 </center>
 
 <h3>Introduction and Purpose</h3>
-This app is designed to collect information for a research study at the
-University of California, Berkeley. The study is being led by <a
+This app is part of a travel behavior research platform developed at the
+University of California, Berkeley. The platform development is being led by <a
 href="http://www.cs.berkeley.edu/~shankari">K. Shankari</a> under the
 supervision of <a href="http://www.cs.berkeley.edu/~culler/">Prof. David
-Culler</a>.
-The goal of the study is to understand people's travel behavior and mode usage
-as people commute to trip generators. We will use this information to make
-recommendations for changes that can reduce emissions.
+Culler</a>. Our goal is to collect information from users about travel behavior
+across all modes, and use the aggregate information for better transportation
+infrastructure planning.
 
-<h3>Benefits</h3>
-There are no direct benefits to you for enrolling in the study. However, we
-will use this information to provide you with a personalized carbon footprint
-for travel that can be compared with the average carbon footprint of our users,
-and with statewide goals for emission reduction. In addition, we will use the
-aggregate data to recommend structural changes and incentives for more energy
-efficient transportation. If we ask for your demographic information as part of
-the study, we may compensate you for your time. The compensation will be
-specified as part of the initial survey screen, before you are asked to
-identify yourself.
+<h3>What we collect</h3>
+We automatically track your location, accelerometer, device-generated activity
+recognition, and battery usage. We also allow you to optionally enter your
+experiences and feedback during travel through the app. Since our code is
+open source, you can inspect the data that we collect in the background at
+<a
+href="https://github.com/e-mission/e-mission-data-collection.git">https://github.com/e-mission/e-mission-data-collection.git</a>,
+explore the prompts for optional sentiment reporting at <a
+href="https://github.com/e-mission/e-mission-phone.git">https://github.com/e-mission/e-mission-phone.git</a>,
+and see the analysis that we perform at <a
+href="https://github.com/e-mission/e-mission-server.git">https://github.com/e-mission/e-mission-server.git</a>
 
-<h3>Procedures</h3>
-We will automatically track your location and use it to generate a list of
-trips that you made, and the route for the trip. We will attempt to
-automatically determine the mode (walk/bike/car/train/bus/air) for the trip,
-and prompt you for confirmation. You confirm trips directly from your phone -
-confirming a trip should take no more than a couple of seconds. Since this is a
-long-term, longitudinal study, we will continue to collect data as long as the
-apps are installed. In order to withdraw from the study temporarily, you can
-turn off data collection in Moves. In order to withdraw permanently, you can
-uninstall both the Moves and E-Mission apps. In addition, we may sometimes ask
-you to fill out a separate survey for demographic information. We will collect
-your email address as part of the survey, but will store the information with
-the email address replaced with a unique userID.
+<h3>How we associate it with you</h3>
+You log in to the app using a valid gmail address. We map the gmail address to
+a unique UUID and associate all collected data with the UUID. In general, the
+mapping between the email address and the UUID will only be made available to
+the lead researcher for the platform (Shankari). If you are not comfortable
+sharing your real gmail adress, you can create a fake one to use for this
+platform. The only reason we use an email address is so that we can ensure that
+your data is only available to somebody logged in as you, and remains available
+even if you switch phones.
 
-<h3>Risks/Discomforts</h3>
-As with all research, there is a chance that confidentiality could be
-compromised; however, we are taking precautions to minimize this risk as
-described below. The biggest complaint that we have had from our beta testers
-is the battery drain on the phone. This seems to be a particular concern for
-iOS users. The "Battery Saving" mode in Moves (M -&gt; Settings -&gt; Tracking
-Priority) seems to help significantly.
-
-<h3>Confidentiality</h3>
-We understand that location data can be sensitive, and we have taken several
-precautions related to the security of your data. You can verify these by
-checking out the publicly available code:
-<ol>
-<li> <a href="https://github.com/amplab/e-mission-phone">https://github.com/amplab/e-mission-phone</a> AND
-<li> <a href="https://github.com/amplab/e-mission-server">https://github.com/amplab/e-mission-server</a>
-</ol>
-In particular:
-<ol>
-  <li>All communication with our server is encrypted.</li>
-  <li>We divide our endpoints into ones that expose personally identifiable
-  information (PII) (such as your personal carbon footprint) and ones which
-  expose aggregate information (such as the carbon footprint of UC Berkeley). All
-  endpoints which expose PII have a "user" field in the request that is used for
-  authentication.</li>
-  <li>We use your gmail ID for authentication in order to avoid the risks
-  associated with storing passwords. If you wish to remain completely anonymous,
-  you can create a separate gmail address only for this app.</li>
-  <li>The trip data is associated with unique user IDs, not with the gmail addresses. The mapping from the userIDs to the gmail addresses is done through a separate table. The lead researcher (Shankari) is the only person who has access to the database, for both the trip and user access tables. Other researchers will only have access to data from the trip database, exported by the lead researcher, but without the linked gmail addresses.</li>
-  <li>The server on which the web app is running is protected by a firewall which only exposes the Secure Shell (SSH) and HTTPS ports - the database cannot be accessed directly from outside the host. The SSH server on the host is configured to only support public key authentication, and the only user with access to the private key for the server is the lead researcher (Shankari).</li>
-</ol>
-
-Note, however, that we integrate with a third party app - <a
-href="http://www.moves-app.com/">Moves</a> - to collect the data. Moves has its
-<a href="http://www.moves-app.com/privacy.html">own policies on data
-collection, privacy and storage</a>. At the end of the study, we plan to
-destroy the table linking email addresses with the uuids. The trip table
-containing user UUIDs along with the list of trips will be retained as a travel
-pattern dataset for ongoing research. The travel pattern dataset will be available by
-request only, and researchers will be asked to agree that they will publish
+<h3>Who gets to see it</h3>
+Individually identified, real-time data is only available to the lead
+researcher for the study (Shankari). The data may be shared for aggregate
+analysis under two scenarios as described below. It will not be used for
+marketing or advertising purposes.
+<ul>
+<li> Aggregate views of the collected data (both automatic and optional) that
+do not show individual trajectories (e.g. heatmaps) will be made publicly
+available through the platform website and on the phone app. You can explore
+this data on the "aggregate" tab of this app before consenting to data
+collection.
+<li> Time-delayed subsets of individual trajectory data, associated with their
+UUIDs but not email addresses, may by shared with collaborators, or released as
+research datasets to the community from time to time. If this is done, the time
+delay for sharing with collaborators will be at least one month, and the time
+delay for releasing to the community will be at least one year. Both
+collaborators and researchers will be asked to agree that they will publish
 only aggregate, non personally identifiable results, and will not re-share the
-data with others. It will not be used for marketing or advertising purposes.
+data with others.
+</ul>
 
-Please note that Moves was recently acquired by Facebook, so data collected by
-Moves is searchable by Facebook. You do not have to provide your Facebook ID to
-use either Moves or E-Mission, so there is no explicit link between the data
-collected and your Facebook identity.  We communicate with Moves over SSL,
-using an access token for authentication.
+<h3>Benefits and Compensation</h3>
+You will not be directly compensated for contributing your data to this
+platform.
+<p>
+However, we will use this information to provide you with a personalized travel
+profile that can be compared with the travel profiles of our other users, and
+with state and federal goals for daily exercise and GHG emission reduction. In
+addition, we will display aggregate travel patterns and aggregate crowdsourced
+safe/unsafe zones that you can use while making travel choices. You will have a
+chance to see the aggregate data generated before choosing to provide your own.
 
-<h3>Compensation</h3>
-You will not be paid for taking part in this study.
+<h3>Studies lead by other researchers</h3>
+If this platform is being used to collect data for a study conducted by another
+researcher, for example, from a Transportation Engineering Department, then you
+will be asked to assent to a separate document outlining the data association,
+retention and sharing policies for that study, <b>in addition to the policies
+above</b>. We will make all data, including the mapping between the email
+address and the UUID, directly available to the lead researcher for the main
+study. This will allow them to associate the automatically gathered information
+with demographic data, and any pre and post surveys that they conduct as part
+of their study. The other researcher may also choose to compensate you for your
+time, as described in the protocol document for that study.
 
-<h3>Rights</h3>
+<h3>Your rights</h3>
 <b><i>Participation in research is completely voluntary</i></b>.  You have the
 right to decline to participate or to withdraw at any point in this study
 without penalty or loss of benefits to which you are otherwise entitled.
@@ -103,12 +92,15 @@ If you want to contact only the lead researcher or the PI, you can use their
 profiles above.
 
 If you have any questions about your rights or treatment as a research
-participant in this study, please contact the University of California at
+participant using this platform, please contact the University of California at
 Berkeley's Committee for Protection of Human Subjects at 510-642-7461, or
 e-mail <a href="mailto:subjects@berkeley.edu">subjects@berkeley.edu</a>.
 
-If you agree to take part in the research, please click "I agree" below to
-proceed. If you do not wish to take part in the research, please click "I
-disagree" below to exit the app. This notice is also available <a
-href="consent">online</a> in case you need to read it again in the future.
-
+If you agree to contribute your data to the platform, please click "I agree"
+below to proceed. If you do not wish to contribute your data to the platform,
+please click "I disagree" below to return to the aggregate views. This notice
+is also available <a
+href="https://e-mission.eecs.berkeley.edu/consent">online</a> in case you need
+to read it again in the future.
+</html>
+</body>


### PR DESCRIPTION
This was a fairly straightforward change.
The main issue was a bug with the metadata formatting workarounds on the server, which exposed a deeper bug https://github.com/e-mission/cordova-usercache/issues/17