### PR TITLE
remove dups from db: upsert + script to clean current db

### DIFF
--- a/bin/ext_service/create_party_leaders_in_db.py
+++ b/bin/ext_service/create_party_leaders_in_db.py
@@ -1,38 +1,8 @@
 import logging
 import emission.core.get_database as edb
+import emission.net.ext_service.habitica.create_party_leaders_script as lead
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
 
-    ju_email = "ju.uemura@gmail.com"
-    ju_uuid = edb.get_uuid_db().find_one({'user_email': ju_email})['uuid']
-    logging.debug("Found Juliana's uuid %s" % ju_uuid)
-    edb.get_habitica_db().insert({'habitica_id': "e26ef1c3-d45e-464a-998c-729d107ecc42", 
-        'habitica_password': u'autogenerate_me', 
-        'habitica_token': '5669eb83-3e36-468d-95f4-6af15801d6cc', 
-        'habitica_username': 'Juliana',
-        'habitica_group_id': "488cae51-aeee-4004-9fa0-dd4219a3a77e",
-        'metrics_data': {'bike_count': 0, 'last_timestamp': 1469020093, 'walk_count': 0}, 
-        'user_id': ju_uuid})
-
-    su_email = "sunil07t@gmail.com"
-    su_uuid = edb.get_uuid_db().find_one({'user_email': su_email})['uuid']
-    logging.debug("Found Sunil's uuid %s" % su_uuid)
-    edb.get_habitica_db().insert({'habitica_id': "9ca9993a-3d84-434f-97af-3df2bd1a1def", 
-        'habitica_password': u"autogenerate_me", 
-        'habitica_token': "56977c97-0604-48a2-9572-59d7011b6948", 
-        'habitica_username': "Sunil", 
-        'habitica_group_id': "751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d",
-        'metrics_data': {'bike_count': 0, 'last_timestamp': 1469020093, 'walk_count': 0}, 
-        'user_id': su_uuid})
-
-    sh_email = "shankari@berkeley.edu"
-    sh_uuid = edb.get_uuid_db().find_one({'user_email': sh_email})['uuid']
-    logging.debug("Found Shankari's uuid %s" % sh_uuid)
-    edb.get_habitica_db().insert({'habitica_id': "e5d31351-a18c-4898-9b56-21c3dd58c834", 
-        'habitica_password': u"autogenerate_me", 
-        'habitica_token': "0793307f-dc24-40d2-8abe-a91fc5b685d0", 
-        'habitica_username': "Shankari", 
-        'habitica_group_id': "93c35a70-f70e-4d6e-ac2b-3e1c81fedf0f",
-        'metrics_data': {'bike_count': 0, 'last_timestamp': 1469020093, 'walk_count': 0}, 
-        'user_id': sh_uuid})
+    lead.create_party_leaders()

--- a/bin/ext_service/remove_dups.py
+++ b/bin/ext_service/remove_dups.py
@@ -1,0 +1,32 @@
+import logging
+import emission.core.get_database as edb
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
+
+    for group_of_dups in edb.get_habitica_db().aggregate([
+        { "$group": {
+            "_id": { "user_id": "$user_id" },
+            "dups": { "$push": "$user_id" },
+            "count": { "$sum": 1 }
+        }},
+        { "$match": { "count": { "$gt": 1 } }}
+    ])['result']:
+        logging.debug("Group of Duplicates %s" % group_of_dups)
+        bike = 0
+        walk = 0
+        for dup in group_of_dups['dups']:
+            logging.debug("Each Duplicate %s" % dup)
+            bike += list(edb.get_habitica_db().find({'user_id': dup}))[0]['metrics_data']['bike_count']
+            walk += list(edb.get_habitica_db().find({'user_id': dup}))[0]['metrics_data']['walk_count']
+            if edb.get_habitica_db().find({'user_id': dup}).count() > 1:            
+                edb.get_habitica_db().remove({'user_id': dup}, multi=False)
+            elif edb.get_habitica_db().find({'user_id': dup}).count() == 1:
+                edb.get_habitica_db().update({"user_id": dup},{"$set": {'metrics_data.bike_count': bike, 'metrics_data.walk_count': walk}},upsert=True)
+        
+
+
+
+
+

--- a/emission/net/ext_service/habitica/create_party_leaders_script.py
+++ b/emission/net/ext_service/habitica/create_party_leaders_script.py
@@ -8,14 +8,17 @@ def create_party_leaders():
     ju_email = "ju.uemura@gmail.com"
     ecwu.User.register(ju_email)
     ju_uuid = edb.get_uuid_db().find_one({'user_email': ju_email})['uuid']
+    logging.debug("Found Juliana's uuid %s" % ju_uuid)
     proxy.habiticaRegister("Juliana", ju_email, "autogenerate_me", ju_uuid)
 
     su_email = "sunil07t@gmail.com"
     ecwu.User.register(su_email)
     su_uuid = edb.get_uuid_db().find_one({'user_email': su_email})['uuid']
+    logging.debug("Found Sunil's uuid %s" % su_uuid)
     proxy.habiticaRegister("Sunil", su_email, "autogenerate_me", su_uuid)
 
     sh_email = "shankari@berkeley.edu"
     ecwu.User.register(sh_email)
     sh_uuid = edb.get_uuid_db().find_one({'user_email': sh_email})['uuid']
+    logging.debug("Found Shankari's uuid %s" % sh_uuid)
     proxy.habiticaRegister("Shankari", sh_email, "autogenerate_me", sh_uuid)

--- a/emission/net/ext_service/habitica/proxy.py
+++ b/emission/net/ext_service/habitica/proxy.py
@@ -37,9 +37,9 @@ def habiticaRegister(username, email, password, our_uuid):
       'habitica_password': password, 
       'habitica_id': user_dict['data']['_id'], 
       'habitica_token': user_dict['data']['apiToken'],
-      'habitica_group_id': None}})
+      'habitica_group_id': None}},upsert=True)
       if user_dict['data']['party']['_id']:
-        edb.get_habitica_db().update({"user_id": our_uuid},{"$set": {'habitica_group_id': user_dict['data']['party']['_id']}})
+        edb.get_habitica_db().update({"user_id": our_uuid},{"$set": {'habitica_group_id': user_dict['data']['party']['_id']}},upsert=True)
 
 
     #now we have the user data in user_dict, so check if db is correct
@@ -93,7 +93,7 @@ def habiticaRegister(username, email, password, our_uuid):
     setup_default_habits(our_uuid)
     #And invite new user to a group, or retrieve group id if user is already in one
     group_id = setup_party(our_uuid)
-    edb.get_habitica_db().update({"user_id": our_uuid},{"$set": {'habitica_group_id': group_id}})
+    edb.get_habitica_db().update({"user_id": our_uuid},{"$set": {'habitica_group_id': group_id}},upsert=True)
     user_dict['habitica_group_id'] = group_id
   return user_dict
 
@@ -138,7 +138,7 @@ def setup_party(user_id):
       result = habiticaProxy(user_id, 'GET', method_url, None)
       data = result.json()
       group_id = data['data']['party']['_id']
-      edb.get_habitica_db().update({"user_id": user_id},{"$set": {'habitica_group_id': group_id}})
+      edb.get_habitica_db().update({"user_id": user_id},{"$set": {'habitica_group_id': group_id}},upsert=True)
 
     except KeyError:
       #parties = [{"leader": "Juliana", "group_id": "488cae51-aeee-4004-9fa0-dd4219a3a77e"}, {"leader": "Sunil", "group_id": "751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d"}, {"leader": "Shankari", "group_id": "93c35a70-f70e-4d6e-ac2b-3e1c81fedf0f"}]
@@ -154,7 +154,7 @@ def setup_party(user_id):
       response = habiticaProxy(leader_val['user_id'], 'POST', invite_uri, method_args)
       logging.debug("invite user to party response = %s" % response)
       response.raise_for_status()
-      edb.get_habitica_db().update({"user_id": user_id},{"$set": {'habitica_group_id': group_id}})
+      edb.get_habitica_db().update({"user_id": user_id},{"$set": {'habitica_group_id': group_id}},upsert=True)
   return group_id
 
 def setup_default_habits(user_id):

--- a/emission/net/ext_service/habitica/sync_habitica.py
+++ b/emission/net/ext_service/habitica/sync_habitica.py
@@ -58,7 +58,7 @@ def reward_active_transportation(user_id):
     res2 = proxy.habiticaProxy(user_id, 'POST', method_uri_bike, None)
 
   #update the timestamp and bike/walk counts in db
-  edb.get_habitica_db().update({"user_id": user_id},{"$set": {'metrics_data': {'last_timestamp': arrow.utcnow().timestamp, 'bike_count': bike_distance%3000, 'walk_count': walk_distance%1000}}})
+  edb.get_habitica_db().update({"user_id": user_id},{"$set": {'metrics_data': {'last_timestamp': arrow.utcnow().timestamp, 'bike_count': bike_distance%3000, 'walk_count': walk_distance%1000}}},upsert=True)
 
 
 

--- a/emission/tests/netTests/TestHabiticaAutocheck.py
+++ b/emission/tests/netTests/TestHabiticaAutocheck.py
@@ -39,7 +39,7 @@ class TestHabiticaRegister(unittest.TestCase):
     sampleAuthMessage1Ad = ad.AttrDict(self.sampleAuthMessage1)
     proxy.habiticaRegister(sampleAuthMessage1Ad.username, sampleAuthMessage1Ad.email,
                            sampleAuthMessage1Ad.password, sampleAuthMessage1Ad.our_uuid)
-    edb.get_habitica_db().update({"user_id": self.testUUID},{"$set": {'metrics_data.last_timestamp': arrow.Arrow(2016,5,1).timestamp}})
+    edb.get_habitica_db().update({"user_id": self.testUUID},{"$set": {'metrics_data.last_timestamp': arrow.Arrow(2016,5,1).timestamp}},upsert=True)
 
     self.ts = esta.TimeSeries.get_time_series(self.testUUID)
     bike_habit = {'type': "habit", 'text': "Bike", 'up': True, 'down': False, 'priority': 2}


### PR DESCRIPTION
removed duplicate code: bin/ext_service/create_party_leaders_in_db.py now just calls the proper script in emission/net/ext_service/habitica/create_party_leaders_script.py

inserted upsert everywhere we call update on habitica_db

created script to clean habitica_db - it sums up all bike/walk counts and leaves only one entry with the totals.