### PR TITLE
Allowing to pull data of specific phones

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -388,7 +388,6 @@ def getCarbonCompare():
 @get('/eval/publicData/timeseries')
 def getPublicData():
   ids = request.json['phone_ids']
-  print ids 
   uuids = map(lambda id: UUID(id), ids)
 
   from_ts = request.query.from_ts

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -387,31 +387,26 @@ def getCarbonCompare():
 # Pulling public data from the server  
 @get('/eval/publicData/timeseries')
 def getPublicData():
+  ids = request.json['phone_ids']
+  print ids 
+  uuids = map(lambda id: UUID(id), ids)
+
   from_ts = request.query.from_ts
   to_ts = request.query.to_ts
 
   time_range = estt.TimeQuery("metadata.write_ts", float(from_ts), float(to_ts))
   time_query = time_range.get_query()
-
-  iphone_ids = [UUID("079e0f1a-c440-3d7c-b0e7-de160f748e35"), UUID("c76a0487-7e5a-3b17-a449-47be666b36f6"), 
-              UUID("c528bcd2-a88b-3e82-be62-ef4f2396967a"), UUID("95e70727-a04e-3e33-b7fe-34ab19194f8b")]
-  android_ids = [UUID("e471711e-bd14-3dbe-80b6-9c7d92ecc296"), UUID("fd7b4c2e-2c8b-3bfa-94f0-d1e3ecbd5fb7"),
-               UUID("86842c35-da28-32ed-a90e-2da6663c5c73"), UUID("3bc0f91f-7660-34a2-b005-5c399598a369"),
-               UUID("273efe85-937e-3622-9b34-19cb64653a9f")]
   
-  iphone_user_queries = map(lambda id: {'user_id': id}, iphone_ids)
-  android_user_queries = map(lambda id: {'user_id': id}, android_ids)
+  user_queries = map(lambda id: {'user_id': id}, uuids)
 
-  for q in iphone_user_queries:
+  for q in user_queries:
     q.update(time_query)
 
-  for q in android_user_queries:
-    q.update(time_query)
+  data_list = map(lambda q: list(edb.get_timeseries_db().find(q).sort("metadata.write_ts")), user_queries)
 
-  iphone_list = map(lambda q: list(edb.get_timeseries_db().find(q).sort("metadata.write_ts")), iphone_user_queries)
-  android_list = map(lambda q: list(edb.get_timeseries_db().find(q).sort("metadata.write_ts")), android_user_queries)
+  logging.debug("public data retrieved")
 
-  return {'iphone_data': iphone_list, 'android_data': android_list}
+  return {'phone_data': data_list}
 
 
 # Client related code START

--- a/request_public_data.py
+++ b/request_public_data.py
@@ -64,7 +64,7 @@ for index, entry_list in enumerate(phone_list):
 	if len(entry_list) == 0:
 		logging.debug("...has no data...")
 	else:
-		logging.debug(str(entry_list[0]))
+		logging.debug(str(entry_list[0].get('metadata').get('write_fmt_time')))
 
 	for entry in entry_list:
 		tsdb.save(entry)

--- a/request_public_data.py
+++ b/request_public_data.py
@@ -5,6 +5,15 @@ import json
 import argparse
 import logging
 import arrow 
+from uuid import UUID
+
+# List of UUIDs of phones to pull data for 
+iphone_ids = ["079e0f1a-c440-3d7c-b0e7-de160f748e35", "c76a0487-7e5a-3b17-a449-47be666b36f6", 
+              "c528bcd2-a88b-3e82-be62-ef4f2396967a", "95e70727-a04e-3e33-b7fe-34ab19194f8b"]
+android_ids = ["e471711e-bd14-3dbe-80b6-9c7d92ecc296", "fd7b4c2e-2c8b-3bfa-94f0-d1e3ecbd5fb7",
+             "86842c35-da28-32ed-a90e-2da6663c5c73", "3bc0f91f-7660-34a2-b005-5c399598a369",
+             "273efe85-937e-3622-9b34-19cb64653a9f"]
+phone_ids = iphone_ids + android_ids
 
 # This script pulls public data from the server and then loads it to a local server 
 parser = argparse.ArgumentParser()
@@ -13,7 +22,7 @@ parser.add_argument("from_date",
 parser.add_argument("to_date",
         help="to_date (local time, exclusive) in the format of YYYY-MM-DD-HH")
 parser.add_argument("server_url",
-        help="url of the server to pull data from i.e. localhost:8080")
+        help="url of the server to pull data from i.e. 'localhost:8080' or 'e-mission.eecs.berkeley.edu'")
 parser.add_argument("-v", "--verbose", 
 		help="turn on debugging", action="store_true")
 
@@ -22,23 +31,27 @@ from_date = args.from_date
 to_date = args.to_date
 server_url = args.server_url
 
+# Turn on logging if -v is specified 
 if args.verbose:
 	logging.basicConfig(level=logging.DEBUG)
 
+# Time query range
 from_ts = arrow.get(from_date, 'YYYY-MM-DD-HH').replace(tzinfo='local').timestamp
 to_ts = arrow.get(to_date, 'YYYY-MM-DD-HH').replace(tzinfo='local').timestamp
 
 logging.debug("from_ts = " + str(from_ts))
 logging.debug("to_ts = " + str(to_ts))
 
-r = requests.get("http://" + server_url + "/eval/publicData/timeseries?from_ts=" + str(from_ts) + "&to_ts=" + str(to_ts))
+url = "http://" + server_url + "/eval/publicData/timeseries?from_ts=" + str(from_ts) + "&to_ts=" + str(to_ts)
+ids = {'phone_ids': phone_ids}
+headers = {'Content-Type': 'application/json'}
+
+r = requests.get(url, data=json.dumps(ids), headers = headers)
 
 print r 
 
 dic = json.loads(r.text, object_hook = bju.object_hook)
-iphone_list = dic['iphone_data'] 
-android_list = dic['android_data']
-phone_list = iphone_list + android_list 
+phone_list = dic['phone_data']
 
 tsdb = edb.get_timeseries_db()
 
@@ -46,10 +59,7 @@ print "Loading data from " + from_date + " to " + to_date + " (local time)"
 print "..."
 
 for index, entry_list in enumerate(phone_list):
-	if index < 4:
-		logging.debug("iphone" + str(index+1) + " first entry:")
-	else:
-		logging.debug("android" + str(index-3) + " first entry:")
+	logging.debug("phone" + str(index+1) + " first entry:")
 
 	if len(entry_list) == 0:
 		logging.debug("...has no data...")


### PR DESCRIPTION
Now users can specify UUIDs of specific phones that they want to pull data for in the data request script. 