### PR TITLE
We have enough points to make a decision only when they span at least…

### DIFF
--- a/emission/tests/analysisTests/intakeTests/TestTripSegmentation.py
+++ b/emission/tests/analysisTests/intakeTests/TestTripSegmentation.py
@@ -61,7 +61,7 @@ class TestTripSegmentation(unittest.TestCase):
                           1440699933.687, 1440716367.376, 1440720239.012, 1440728519.971])
         self.assertEqual([end.ts for (start, end) in segmentation_points],
                          [1440689408.302, 1440690108.678, 1440694424.894, 1440699298.535,
-                          1440700040.477, 1440719699.470, 1440723334.898, 1440729184.411])
+                          1440700070.129, 1440719699.470, 1440723334.898, 1440729184.411])
 
     def testSegmentationPointsDwellSegmentationDistFilter(self):
         ts = esta.TimeSeries.get_time_series(self.iosUUID)


### PR DESCRIPTION
… 5 mins

Before this change, we had two checks to determine whether we had enough
points to make a decision

- whether we had at least 10 points
- whether any of them were in the past 5 mins

If the points that we received were 30 secs apart, as we expected, this would
work just fine. But if they were more frequent, as when navigating while
walking, then we detect a trip end way before 5 mins.

In this change, we also add an additional check to ensure that the points from
the last 5 mins query actually span 5 mins. With this check, I think that we
can remove the last 10 points check, but I want to wait until we have a more
principled checker to confirm before making a subtractive change.