### PR TITLE
Fix sort key for the timeline

### DIFF
--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -99,6 +99,8 @@ class BuiltinTimeSeries(esta.TimeSeries):
     def _get_sort_key(self, time_query = None):
         if time_query is None:
             return "metadata.write_ts"
+        elif time_query.timeType.endswith("local_dt"):
+            return time_query.timeType.replace("local_dt", "ts")
         else:
             return time_query.timeType
 


### PR DESCRIPTION
Although we search for timeline entries using the local date, we want to sort by the timestamp since that is fully ordered while the local date is:
- only partially ordered
- split into components

This fixes #354