### PR TITLE
Handle the (corner) case in which there is only one high confidence v…

### DIFF
--- a/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_motion.py
+++ b/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_motion.py
@@ -130,13 +130,13 @@ class SmoothedHighConfidenceMotion(eaiss.SectionSegmentationMethod):
             if len(motion_changes) == 1:
                 (start_motion, end_motion) = motion_changes[0]
 
-            if start_motion.type == end_motion.type:
-                logging.debug("No section because start_motion == end_motion, creating one dummy section")
-                section_list.append((fp, lp, start_motion.type))
-            # if len(motion_changes) == 0:
-            # # there are no high confidence motions useful motions, so we add a section of type NONE
-            # # as long as it is a discernable trip (end != start) and not a spurious trip
-            # logging.debug("No high confidence motions, creating dummy section of type NONE")
-            # section_list.append((fp, lp, ecwm.MotionTypes.NONE))
+                if start_motion.type == end_motion.type:
+                    logging.debug("No section because start_motion == end_motion, creating one dummy section")
+                    section_list.append((fp, lp, start_motion.type))
+                # if len(motion_changes) == 0:
+                # there are no high confidence motions useful motions, so we add a section of type NONE
+                # as long as it is a discernable trip (end != start) and not a spurious trip
+                    # logging.debug("No high confidence motions, creating dummy section of type NONE")
+                    # section_list.append((fp, lp, ecwm.MotionTypes.NONE))
 
         return section_list


### PR DESCRIPTION
…alid motion activity

This is a partial fix for #356. Basically, if we have only one high confidence valid motion activity, we still want to treat that as a section, since it will ensure that the trip is not squished later.

A more complex fix to avoid squishing real trips even if they have no high
confidence motion activies has been shelfed because of complexities in
implementation and concern that it could cause spurious trips to show up
again.