### PR TITLE
Cover the case in which we get a sync right after a phone-server mism…

### DIFF
--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -99,6 +99,9 @@ def setupRealExample(testObj, dump_file):
     logging.info("Before loading, timeseries db size = %s" % edb.get_timeseries_db().count())
     testObj.entries = json.load(open(dump_file), object_hook = bju.object_hook)
     testObj.testUUID = uuid.uuid4()
+    setupRealExampleWithEntries(testObj)
+
+def setupRealExampleWithEntries(testObj):
     tsdb = edb.get_timeseries_db()
     for entry in testObj.entries:
         entry["user_id"] = testObj.testUUID

--- a/emission/tests/data/real_examples/shankari_2016-08-09
+++ b/emission/tests/data/real_examples/shankari_2016-08-09
@@ -1,0 +1,16333 @@
+[
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90241"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 330, 
+            "fmt_time": "2016-08-09T00:44:14.804000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470728654.804, 
+            "local_dt": {
+                "hour": 0, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "battery_status": 2, 
+            "android_plugged": "AC", 
+            "android_voltage": 330, 
+            "battery_level_pct": 49
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T00:44:14.804000-07:00", 
+            "write_ts": 1470728654.804, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 0, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90242"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 290, 
+            "fmt_time": "2016-08-09T01:52:03.312000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470732723.312, 
+            "local_dt": {
+                "hour": 1, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 52
+            }, 
+            "battery_status": 2, 
+            "android_plugged": "AC", 
+            "android_voltage": 290, 
+            "battery_level_pct": 95
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T01:52:03.312000-07:00", 
+            "write_ts": 1470732723.312, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 1, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 52
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90243"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 260, 
+            "fmt_time": "2016-08-09T02:57:47.984000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470736667.984, 
+            "local_dt": {
+                "hour": 2, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "battery_status": 3, 
+            "android_plugged": "AC", 
+            "android_voltage": 260, 
+            "battery_level_pct": 100
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T02:57:47.984000-07:00", 
+            "write_ts": 1470736667.984, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 2, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90244"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 250, 
+            "fmt_time": "2016-08-09T04:44:14.288000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470743054.288, 
+            "local_dt": {
+                "hour": 4, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "battery_status": 2, 
+            "android_plugged": "AC", 
+            "android_voltage": 250, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T04:44:14.288000-07:00", 
+            "write_ts": 1470743054.288, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 4, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90245"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 240, 
+            "fmt_time": "2016-08-09T06:44:11.099000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470750251.099, 
+            "local_dt": {
+                "hour": 6, 
+                "month": 8, 
+                "second": 11, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 240, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T06:44:11.099000-07:00", 
+            "write_ts": 1470750251.099, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 6, 
+                "month": 8, 
+                "second": 11, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90246"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 240, 
+            "fmt_time": "2016-08-09T07:45:40.495000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470753940.495, 
+            "local_dt": {
+                "hour": 7, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 45
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 240, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T07:45:40.495000-07:00", 
+            "write_ts": 1470753940.495, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 7, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 45
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90247"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 240, 
+            "fmt_time": "2016-08-09T08:48:41.544000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470757721.544, 
+            "local_dt": {
+                "hour": 8, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 48
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 240, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T08:48:41.544000-07:00", 
+            "write_ts": 1470757721.544, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 8, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 48
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90248"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 240, 
+            "fmt_time": "2016-08-09T09:51:03.430000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470761463.43, 
+            "local_dt": {
+                "hour": 9, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 51
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 240, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T09:51:03.430000-07:00", 
+            "write_ts": 1470761463.43, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 9, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 51
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90249"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 240, 
+            "fmt_time": "2016-08-09T11:39:51.130000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470767991.13, 
+            "local_dt": {
+                "hour": 11, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 39
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 240, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T11:39:51.130000-07:00", 
+            "write_ts": 1470767991.13, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 11, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 39
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9024a"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 250, 
+            "fmt_time": "2016-08-09T12:44:20.838000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470771860.838, 
+            "local_dt": {
+                "hour": 12, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "battery_status": 2, 
+            "android_plugged": "AC", 
+            "android_voltage": 250, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T12:44:20.838000-07:00", 
+            "write_ts": 1470771860.838, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 12, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9024b"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 260, 
+            "fmt_time": "2016-08-09T13:44:13.744000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470775453.744, 
+            "local_dt": {
+                "hour": 13, 
+                "month": 8, 
+                "second": 13, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 260, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T13:44:13.744000-07:00", 
+            "write_ts": 1470775453.744, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 13, 
+                "month": 8, 
+                "second": 13, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9024c"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 260, 
+            "fmt_time": "2016-08-09T14:44:08.543000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470779048.543, 
+            "local_dt": {
+                "hour": 14, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 260, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T14:44:08.543000-07:00", 
+            "write_ts": 1470779048.543, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 14, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9024d"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 260, 
+            "fmt_time": "2016-08-09T15:46:03.034000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470782763.034, 
+            "local_dt": {
+                "hour": 15, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 46
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 260, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T15:46:03.034000-07:00", 
+            "write_ts": 1470782763.034, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 15, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 46
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9024e"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 260, 
+            "fmt_time": "2016-08-09T16:49:47.517000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470786587.517, 
+            "local_dt": {
+                "hour": 16, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 49
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 260, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T16:49:47.517000-07:00", 
+            "write_ts": 1470786587.517, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 16, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 49
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9024f"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 260, 
+            "fmt_time": "2016-08-09T17:49:45.853000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470790185.853, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 49
+            }, 
+            "battery_status": 4, 
+            "android_plugged": "AC", 
+            "android_voltage": 260, 
+            "battery_level_pct": 99
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:49:45.853000-07:00", 
+            "write_ts": 1470790185.853, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 49
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90250"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0878277, 
+                    37.3906125
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:53:41.106000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790421.106, 
+            "longitude": -122.0878277, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342119730000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 53
+            }, 
+            "latitude": 37.3906125, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 699.999
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:53:52.907000-07:00", 
+            "write_ts": 1470790432.907, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 52, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 53
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90251"
+        }, 
+        "data": {
+            "curr_state": 1, 
+            "transition": 1, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 22, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "ts": 1470790462.634, 
+            "fmt_time": "2016-08-09T17:54:22.634000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:54:22.634000-07:00", 
+            "write_ts": 1470790462.634, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 22, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "key": "statemachine/transition", 
+            "read_ts": 1470794421.790017, 
+            "type": "message"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90252"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 310, 
+            "fmt_time": "2016-08-09T17:54:22.974000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470790462.974, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 22, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "battery_status": 1, 
+            "android_plugged": "UNKNOWN", 
+            "android_voltage": 310, 
+            "battery_level_pct": 98
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:54:22.974000-07:00", 
+            "write_ts": 1470790462.974, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 22, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90253"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 77, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 27, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "ts": 1470790467.071, 
+            "fmt_time": "2016-08-09T17:54:27.071000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:54:27.071000-07:00", 
+            "write_ts": 1470790467.071, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 27, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90254"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0878277, 
+                    37.3906125
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:54:25.646000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790465.646, 
+            "longitude": -122.0878277, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342164270000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "latitude": 37.3906125, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 699.999
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:54:29.113000-07:00", 
+            "write_ts": 1470790469.113, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90255"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865352, 
+                    37.3904407
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:54:54.529000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790494.529, 
+            "longitude": -122.0865352, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342193154000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 54, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "latitude": 37.3904407, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 36
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:54:54.856000-07:00", 
+            "write_ts": 1470790494.856, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 54, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90256"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865352, 
+                    37.3904407
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:54:54.529000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790494.529, 
+            "longitude": -122.0865352, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342193154000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 54, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "latitude": 37.3904407, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 36
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:54:55.678000-07:00", 
+            "write_ts": 1470790495.678, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90257"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 69, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "ts": 1470790497.006, 
+            "fmt_time": "2016-08-09T17:54:57.006000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:54:57.006000-07:00", 
+            "write_ts": 1470790497.006, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90258"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "ts": 1470790497.211, 
+            "fmt_time": "2016-08-09T17:54:57.211000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:54:57.211000-07:00", 
+            "write_ts": 1470790497.211, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 54
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90259"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.087777, 
+                    37.3884625
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:55:24.549000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790524.549, 
+            "longitude": -122.087777, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342223174000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "latitude": 37.3884625, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 36
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:55:31.120000-07:00", 
+            "write_ts": 1470790531.12, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9025a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.087777, 
+                    37.3884625
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:55:24.549000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790524.549, 
+            "longitude": -122.087777, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342223174000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "latitude": 37.3884625, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 36
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:55:31.750000-07:00", 
+            "write_ts": 1470790531.75, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9025b"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 80, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 33, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "ts": 1470790533.932, 
+            "fmt_time": "2016-08-09T17:55:33.932000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:55:33.932000-07:00", 
+            "write_ts": 1470790533.932, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 33, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9025c"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "ts": 1470790534.162, 
+            "fmt_time": "2016-08-09T17:55:34.162000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:55:34.162000-07:00", 
+            "write_ts": 1470790534.162, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9025d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0874702, 
+                    37.3883881
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:55:54.566000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790554.566, 
+            "longitude": -122.0874702, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342253191000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 54, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "latitude": 37.3883881, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 36
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:55:59.866000-07:00", 
+            "write_ts": 1470790559.866, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9025e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0874702, 
+                    37.3883881
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:55:54.566000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790554.566, 
+            "longitude": -122.0874702, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342253191000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 54, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 55
+            }, 
+            "latitude": 37.3883881, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 36
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:56:00.434000-07:00", 
+            "write_ts": 1470790560.434, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 0, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9025f"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 72, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "ts": 1470790563.958, 
+            "fmt_time": "2016-08-09T17:56:03.958000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:56:03.958000-07:00", 
+            "write_ts": 1470790563.958, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90260"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865666, 
+                    37.3894262
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:56:25-07:00", 
+            "altitude": 3.5, 
+            "ts": 1470790585, 
+            "longitude": -122.0865666, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342281953895201, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "latitude": 37.3894262, 
+            "heading": 180, 
+            "sensed_speed": 1.6263, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:56:23.635000-07:00", 
+            "write_ts": 1470790583.635, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 23, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90261"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865666, 
+                    37.3894262
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:56:25-07:00", 
+            "altitude": 3.5, 
+            "ts": 1470790585, 
+            "longitude": -122.0865666, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342281953895201, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "latitude": 37.3894262, 
+            "heading": 180, 
+            "sensed_speed": 1.6263, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:56:24.248000-07:00", 
+            "write_ts": 1470790584.248, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90262"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 49, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "ts": 1470790609.26, 
+            "fmt_time": "2016-08-09T17:56:49.260000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:56:49.260000-07:00", 
+            "write_ts": 1470790609.26, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90263"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "ts": 1470790609.412, 
+            "fmt_time": "2016-08-09T17:56:49.412000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:56:49.412000-07:00", 
+            "write_ts": 1470790609.412, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90264"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863643, 
+                    37.3892562
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:57:01-07:00", 
+            "altitude": 6.399993896484375, 
+            "ts": 1470790621, 
+            "longitude": -122.0863643, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342317508033377, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "latitude": 37.3892562, 
+            "heading": 161, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:56:59.144000-07:00", 
+            "write_ts": 1470790619.144, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90265"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863643, 
+                    37.3892562
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:57:01-07:00", 
+            "altitude": 6.399993896484375, 
+            "ts": 1470790621, 
+            "longitude": -122.0863643, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342317508033377, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "latitude": 37.3892562, 
+            "heading": 161, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:56:59.776000-07:00", 
+            "write_ts": 1470790619.776, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 56
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90266"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0876588, 
+                    37.3885921
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:57:09.097000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790629.097, 
+            "longitude": -122.0876588, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342327722000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "latitude": 37.3885921, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 63
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:57:19.784000-07:00", 
+            "write_ts": 1470790639.784, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90267"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0876588, 
+                    37.3885921
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:57:09.097000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790629.097, 
+            "longitude": -122.0876588, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342327722000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "latitude": 37.3885921, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 63
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:57:20.311000-07:00", 
+            "write_ts": 1470790640.311, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90268"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863549, 
+                    37.3891628
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:57:42-07:00", 
+            "altitude": 3.100006103515625, 
+            "ts": 1470790662, 
+            "longitude": -122.0863549, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342359098548515, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "latitude": 37.3891628, 
+            "heading": 6, 
+            "sensed_speed": 0.06255, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:57:40.722000-07:00", 
+            "write_ts": 1470790660.722, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90269"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863549, 
+                    37.3891628
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:57:42-07:00", 
+            "altitude": 3.100006103515625, 
+            "ts": 1470790662, 
+            "longitude": -122.0863549, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342359098548515, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "latitude": 37.3891628, 
+            "heading": 6, 
+            "sensed_speed": 0.06255, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:57:41.350000-07:00", 
+            "write_ts": 1470790661.35, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9026a"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 56, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "ts": 1470790664.324, 
+            "fmt_time": "2016-08-09T17:57:44.324000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:57:44.324000-07:00", 
+            "write_ts": 1470790664.324, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 57
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9026b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862936, 
+                    37.3891427
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:58:29-07:00", 
+            "altitude": -9.70001220703125, 
+            "ts": 1470790709, 
+            "longitude": -122.0862936, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342406051978690, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 58
+            }, 
+            "latitude": 37.3891427, 
+            "heading": 31, 
+            "sensed_speed": 0.37530002, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:58:27.680000-07:00", 
+            "write_ts": 1470790707.68, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 27, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 58
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9026c"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862936, 
+                    37.3891427
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:58:29-07:00", 
+            "altitude": -9.70001220703125, 
+            "ts": 1470790709, 
+            "longitude": -122.0862936, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342406051978690, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 58
+            }, 
+            "latitude": 37.3891427, 
+            "heading": 31, 
+            "sensed_speed": 0.37530002, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:58:28.275000-07:00", 
+            "write_ts": 1470790708.275, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 58
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9026d"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 95, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 58
+            }, 
+            "ts": 1470790710.024, 
+            "fmt_time": "2016-08-09T17:58:30.024000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:58:30.024000-07:00", 
+            "write_ts": 1470790710.024, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 58
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9026e"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 58
+            }, 
+            "ts": 1470790739.961, 
+            "fmt_time": "2016-08-09T17:58:59.961000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:58:59.961000-07:00", 
+            "write_ts": 1470790739.961, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 58
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9026f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863653, 
+                    37.3891644
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:59:09-07:00", 
+            "altitude": -10.399993896484375, 
+            "ts": 1470790749, 
+            "longitude": -122.0863653, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342446272956474, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "latitude": 37.3891644, 
+            "heading": 285, 
+            "sensed_speed": 0.31275, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:59:07.887000-07:00", 
+            "write_ts": 1470790747.887, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 7, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90270"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863653, 
+                    37.3891644
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:59:09-07:00", 
+            "altitude": -10.399993896484375, 
+            "ts": 1470790749, 
+            "longitude": -122.0863653, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342446272956474, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "latitude": 37.3891644, 
+            "heading": 285, 
+            "sensed_speed": 0.31275, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:59:08.421000-07:00", 
+            "write_ts": 1470790748.421, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90271"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 27, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "ts": 1470790767.566, 
+            "fmt_time": "2016-08-09T17:59:27.566000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:59:27.566000-07:00", 
+            "write_ts": 1470790767.566, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 27, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90272"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863653, 
+                    37.3891644
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:59:16.380000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790756.38, 
+            "longitude": -122.0863653, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342455005000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "latitude": 37.3891644, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 118.516
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:59:29.006000-07:00", 
+            "write_ts": 1470790769.006, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90273"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863653, 
+                    37.3891644
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:59:16.380000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790756.38, 
+            "longitude": -122.0863653, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342455005000000, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "latitude": 37.3891644, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 118.516
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:59:29.511000-07:00", 
+            "write_ts": 1470790769.511, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90274"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863628, 
+                    37.3891559
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:59:51-07:00", 
+            "altitude": -16.79998779296875, 
+            "ts": 1470790791, 
+            "longitude": -122.0863628, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342487938331229, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "latitude": 37.3891559, 
+            "heading": 159, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:59:49.545000-07:00", 
+            "write_ts": 1470790789.545, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90275"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863628, 
+                    37.3891559
+                ]
+            }, 
+            "fmt_time": "2016-08-09T17:59:51-07:00", 
+            "altitude": -16.79998779296875, 
+            "ts": 1470790791, 
+            "longitude": -122.0863628, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342487938331229, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "latitude": 37.3891559, 
+            "heading": 159, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:59:50.120000-07:00", 
+            "write_ts": 1470790790.12, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90276"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 56, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "ts": 1470790796.314, 
+            "fmt_time": "2016-08-09T17:59:56.314000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T17:59:56.314000-07:00", 
+            "write_ts": 1470790796.314, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 17, 
+                "month": 8, 
+                "second": 56, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 59
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90277"
+        }, 
+        "data": {
+            "type": 4, 
+            "confidence": 50, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "ts": 1470790844.021, 
+            "fmt_time": "2016-08-09T18:00:44.021000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:00:44.021000-07:00", 
+            "write_ts": 1470790844.021, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90278"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "ts": 1470790845.327, 
+            "fmt_time": "2016-08-09T18:00:45.327000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:00:45.327000-07:00", 
+            "write_ts": 1470790845.327, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90279"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863309, 
+                    37.3892424
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:00:46-07:00", 
+            "altitude": -4.600006103515625, 
+            "ts": 1470790846, 
+            "longitude": -122.0863309, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342542830482108, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "latitude": 37.3892424, 
+            "heading": 306, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:00:45.534000-07:00", 
+            "write_ts": 1470790845.534, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9027a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863309, 
+                    37.3892424
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:00:46-07:00", 
+            "altitude": -4.600006103515625, 
+            "ts": 1470790846, 
+            "longitude": -122.0863309, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342542830482108, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "latitude": 37.3892424, 
+            "heading": 306, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:00:46.596000-07:00", 
+            "write_ts": 1470790846.596, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9027b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863309, 
+                    37.3892424
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:00:51.821000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790851.821, 
+            "longitude": -122.0863309, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342550446000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "latitude": 37.3892424, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 109.001
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:00:52.727000-07:00", 
+            "write_ts": 1470790852.727, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 52, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9027c"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863309, 
+                    37.3892424
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:00:51.821000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790851.821, 
+            "longitude": -122.0863309, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342550446000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "latitude": 37.3892424, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 109.001
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:00:53.714000-07:00", 
+            "write_ts": 1470790853.714, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 53, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 0
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9027d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863593, 
+                    37.3891951
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:01:25-07:00", 
+            "altitude": 1.20001220703125, 
+            "ts": 1470790885, 
+            "longitude": -122.0863593, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342582498084647, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "latitude": 37.3891951, 
+            "heading": 217, 
+            "sensed_speed": 0.06255, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:01:24.102000-07:00", 
+            "write_ts": 1470790884.102, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9027e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863593, 
+                    37.3891951
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:01:25-07:00", 
+            "altitude": 1.20001220703125, 
+            "ts": 1470790885, 
+            "longitude": -122.0863593, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342582498084647, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "latitude": 37.3891951, 
+            "heading": 217, 
+            "sensed_speed": 0.06255, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:01:24.686000-07:00", 
+            "write_ts": 1470790884.686, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9027f"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 38, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 36, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "ts": 1470790896.467, 
+            "fmt_time": "2016-08-09T18:01:36.467000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:01:36.467000-07:00", 
+            "write_ts": 1470790896.467, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 36, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90280"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864963, 
+                    37.3888399
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:01:37.290000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790897.29, 
+            "longitude": -122.0864963, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342595915000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "latitude": 37.3888399, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 21.591
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:01:47.373000-07:00", 
+            "write_ts": 1470790907.373, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90281"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864963, 
+                    37.3888399
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:01:37.290000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790897.29, 
+            "longitude": -122.0864963, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342595915000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "latitude": 37.3888399, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 21.591
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:01:47.912000-07:00", 
+            "write_ts": 1470790907.912, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 1
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90282"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863367, 
+                    37.3891141
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:02:02-07:00", 
+            "altitude": -8.70001220703125, 
+            "ts": 1470790922, 
+            "longitude": -122.0863367, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342619178016288, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "latitude": 37.3891141, 
+            "heading": 176, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:00.803000-07:00", 
+            "write_ts": 1470790920.803, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 0, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90283"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863367, 
+                    37.3891141
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:02:02-07:00", 
+            "altitude": -8.70001220703125, 
+            "ts": 1470790922, 
+            "longitude": -122.0863367, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342619178016288, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "latitude": 37.3891141, 
+            "heading": 176, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:01.382000-07:00", 
+            "write_ts": 1470790921.382, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90284"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 35, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 10, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "ts": 1470790930.796, 
+            "fmt_time": "2016-08-09T18:02:10.796000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:10.796000-07:00", 
+            "write_ts": 1470790930.796, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 10, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90285"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862744, 
+                    37.3885695
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:02:09.132000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790929.132, 
+            "longitude": -122.0862744, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342627757000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "latitude": 37.3885695, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 25.202
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:17.085000-07:00", 
+            "write_ts": 1470790937.085, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90286"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862744, 
+                    37.3885695
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:02:09.132000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790929.132, 
+            "longitude": -122.0862744, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342627757000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "latitude": 37.3885695, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 25.202
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:17.612000-07:00", 
+            "write_ts": 1470790937.612, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90287"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865407, 
+                    37.388639
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:02:40.940000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790960.94, 
+            "longitude": -122.0865407, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342659565000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "latitude": 37.388639, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 20.563
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:47.127000-07:00", 
+            "write_ts": 1470790967.127, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90288"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865407, 
+                    37.388639
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:02:40.940000-07:00", 
+            "altitude": 0, 
+            "ts": 1470790960.94, 
+            "longitude": -122.0865407, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342659565000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "latitude": 37.388639, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 20.563
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:47.826000-07:00", 
+            "write_ts": 1470790967.826, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90289"
+        }, 
+        "data": {
+            "curr_state": 2, 
+            "transition": 2, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "ts": 1470790969.14, 
+            "fmt_time": "2016-08-09T18:02:49.140000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:49.140000-07:00", 
+            "write_ts": 1470790969.14, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "statemachine/transition", 
+            "read_ts": 0, 
+            "type": "message"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9028a"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 360, 
+            "fmt_time": "2016-08-09T18:02:49.441000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470790969.441, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "battery_status": 1, 
+            "android_plugged": "UNKNOWN", 
+            "android_voltage": 360, 
+            "battery_level_pct": 94
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:02:49.441000-07:00", 
+            "write_ts": 1470790969.441, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 2
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9028b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0868957, 
+                    37.3904819
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:04:16.449000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791056.449, 
+            "longitude": -122.0868957, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342755074000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "latitude": 37.3904819, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 50
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:19.880000-07:00", 
+            "write_ts": 1470791059.88, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9028c"
+        }, 
+        "data": {
+            "curr_state": 1, 
+            "transition": 1, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "ts": 1470791060.087, 
+            "fmt_time": "2016-08-09T18:04:20.087000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:20.087000-07:00", 
+            "write_ts": 1470791060.087, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "statemachine/transition", 
+            "read_ts": 0, 
+            "type": "message"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9028d"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 370, 
+            "fmt_time": "2016-08-09T18:04:20.767000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470791060.767, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "battery_status": 1, 
+            "android_plugged": "UNKNOWN", 
+            "android_voltage": 370, 
+            "battery_level_pct": 93
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:20.767000-07:00", 
+            "write_ts": 1470791060.767, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9028e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0868957, 
+                    37.3904819
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:04:16.449000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791056.449, 
+            "longitude": -122.0868957, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342755074000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "latitude": 37.3904819, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 50
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:22.007000-07:00", 
+            "write_ts": 1470791062.007, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 22, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9028f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0868957, 
+                    37.3904819
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:04:16.449000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791056.449, 
+            "longitude": -122.0868957, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342755074000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "latitude": 37.3904819, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 50
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:22.856000-07:00", 
+            "write_ts": 1470791062.856, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 22, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90290"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 92, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "ts": 1470791065.06, 
+            "fmt_time": "2016-08-09T18:04:25.060000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:25.060000-07:00", 
+            "write_ts": 1470791065.06, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90291"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863898, 
+                    37.3891256
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:04:30-07:00", 
+            "altitude": 1.29998779296875, 
+            "ts": 1470791070, 
+            "longitude": -122.0863898, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342766540534598, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "latitude": 37.3891256, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:28.259000-07:00", 
+            "write_ts": 1470791068.259, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90292"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863898, 
+                    37.3891256
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:04:30-07:00", 
+            "altitude": 1.29998779296875, 
+            "ts": 1470791070, 
+            "longitude": -122.0863898, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342766540534598, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "latitude": 37.3891256, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:28.909000-07:00", 
+            "write_ts": 1470791068.909, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90293"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0877511, 
+                    37.3885737
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:04:48.276000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791088.276, 
+            "longitude": -122.0877511, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342786901000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "latitude": 37.3885737, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 30
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:51.786000-07:00", 
+            "write_ts": 1470791091.786, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90294"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0877511, 
+                    37.3885737
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:04:48.276000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791088.276, 
+            "longitude": -122.0877511, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342786901000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "latitude": 37.3885737, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 30
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:04:52.264000-07:00", 
+            "write_ts": 1470791092.264, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 52, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 4
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90295"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864601, 
+                    37.3891193
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:05:07-07:00", 
+            "altitude": 2.79998779296875, 
+            "ts": 1470791107, 
+            "longitude": -122.0864601, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342804190528494, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 7, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "latitude": 37.3891193, 
+            "heading": 318, 
+            "sensed_speed": 0.75060004, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:05:05.821000-07:00", 
+            "write_ts": 1470791105.821, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 5, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90296"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864601, 
+                    37.3891193
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:05:07-07:00", 
+            "altitude": 2.79998779296875, 
+            "ts": 1470791107, 
+            "longitude": -122.0864601, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342804190528494, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 7, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "latitude": 37.3891193, 
+            "heading": 318, 
+            "sensed_speed": 0.75060004, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:05:06.430000-07:00", 
+            "write_ts": 1470791106.43, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90297"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 56, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "ts": 1470791119.051, 
+            "fmt_time": "2016-08-09T18:05:19.051000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:05:19.051000-07:00", 
+            "write_ts": 1470791119.051, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90298"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864963, 
+                    37.3888399
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:05:20.111000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791120.111, 
+            "longitude": -122.0864963, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342818736000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "latitude": 37.3888399, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 20.127
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:05:21.894000-07:00", 
+            "write_ts": 1470791121.894, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90299"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864963, 
+                    37.3888399
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:05:20.111000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791120.111, 
+            "longitude": -122.0864963, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342818736000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "latitude": 37.3888399, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 20.127
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:05:22.453000-07:00", 
+            "write_ts": 1470791122.453, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 22, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9029a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863729, 
+                    37.3890343
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:05:43-07:00", 
+            "altitude": 6.70001220703125, 
+            "ts": 1470791143, 
+            "longitude": -122.0863729, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342840092872244, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 43, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "latitude": 37.3890343, 
+            "heading": 84, 
+            "sensed_speed": 0.68805, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:05:41.750000-07:00", 
+            "write_ts": 1470791141.75, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9029b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863729, 
+                    37.3890343
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:05:43-07:00", 
+            "altitude": 6.70001220703125, 
+            "ts": 1470791143, 
+            "longitude": -122.0863729, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342840092872244, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 43, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "latitude": 37.3890343, 
+            "heading": 84, 
+            "sensed_speed": 0.68805, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:05:42.438000-07:00", 
+            "write_ts": 1470791142.438, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9029c"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 46, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "ts": 1470791172.215, 
+            "fmt_time": "2016-08-09T18:06:12.215000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:06:12.215000-07:00", 
+            "write_ts": 1470791172.215, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9029d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862884, 
+                    37.3890116
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:06:31-07:00", 
+            "altitude": -6.79998779296875, 
+            "ts": 1470791191, 
+            "longitude": -122.0862884, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342888051032645, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "latitude": 37.3890116, 
+            "heading": 172, 
+            "sensed_speed": 1.3761, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:06:29.685000-07:00", 
+            "write_ts": 1470791189.685, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9029e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862884, 
+                    37.3890116
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:06:31-07:00", 
+            "altitude": -6.79998779296875, 
+            "ts": 1470791191, 
+            "longitude": -122.0862884, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342888051032645, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "latitude": 37.3890116, 
+            "heading": 172, 
+            "sensed_speed": 1.3761, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:06:30.279000-07:00", 
+            "write_ts": 1470791190.279, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9029f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862884, 
+                    37.3890116
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:06:37.273000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791197.273, 
+            "longitude": -122.0862884, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342895898000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "latitude": 37.3890116, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 112.01
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:06:42.432000-07:00", 
+            "write_ts": 1470791202.432, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a0"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862884, 
+                    37.3890116
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:06:37.273000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791197.273, 
+            "longitude": -122.0862884, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342895898000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "latitude": 37.3890116, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 112.01
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:06:43.024000-07:00", 
+            "write_ts": 1470791203.024, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 43, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 6
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a1"
+        }, 
+        "data": {
+            "type": 4, 
+            "confidence": 69, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "ts": 1470791221.233, 
+            "fmt_time": "2016-08-09T18:07:01.233000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:01.233000-07:00", 
+            "write_ts": 1470791221.233, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a2"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "ts": 1470791221.389, 
+            "fmt_time": "2016-08-09T18:07:01.389000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:01.389000-07:00", 
+            "write_ts": 1470791221.389, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a3"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086472, 
+                    37.3893009
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:07:18-07:00", 
+            "altitude": 11.5, 
+            "ts": 1470791238, 
+            "longitude": -122.086472, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342934563972099, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 18, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "latitude": 37.3893009, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:16.162000-07:00", 
+            "write_ts": 1470791236.162, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a4"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086472, 
+                    37.3893009
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:07:18-07:00", 
+            "altitude": 11.5, 
+            "ts": 1470791238, 
+            "longitude": -122.086472, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342934563972099, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 18, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "latitude": 37.3893009, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:16.744000-07:00", 
+            "write_ts": 1470791236.744, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a5"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865754, 
+                    37.3902692
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:07:24.992000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791244.992, 
+            "longitude": -122.0865754, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342943616000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "latitude": 37.3902692, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 37.5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:31.493000-07:00", 
+            "write_ts": 1470791251.493, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a6"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865754, 
+                    37.3902692
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:07:24.992000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791244.992, 
+            "longitude": -122.0865754, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342943616000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "latitude": 37.3902692, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 37.5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:32.027000-07:00", 
+            "write_ts": 1470791252.027, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a7"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 35, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "ts": 1470791270.484, 
+            "fmt_time": "2016-08-09T18:07:50.484000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:50.484000-07:00", 
+            "write_ts": 1470791270.484, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a8"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864043, 
+                    37.3891617
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:08:01-07:00", 
+            "altitude": -2.29998779296875, 
+            "ts": 1470791281, 
+            "longitude": -122.0864043, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342977634711845, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 8
+            }, 
+            "latitude": 37.3891617, 
+            "heading": 334, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:59.241000-07:00", 
+            "write_ts": 1470791279.241, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902a9"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864043, 
+                    37.3891617
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:08:01-07:00", 
+            "altitude": -2.29998779296875, 
+            "ts": 1470791281, 
+            "longitude": -122.0864043, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 342977634711845, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 8
+            }, 
+            "latitude": 37.3891617, 
+            "heading": 334, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:07:59.810000-07:00", 
+            "write_ts": 1470791279.81, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 7
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902aa"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 67, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 36, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 8
+            }, 
+            "ts": 1470791316.125, 
+            "fmt_time": "2016-08-09T18:08:36.125000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:08:36.125000-07:00", 
+            "write_ts": 1470791316.125, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 36, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 8
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ab"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863591, 
+                    37.3891779
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:08:46-07:00", 
+            "altitude": -4.100006103515625, 
+            "ts": 1470791326, 
+            "longitude": -122.0863591, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343023208839042, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 8
+            }, 
+            "latitude": 37.3891779, 
+            "heading": 89, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:08:44.867000-07:00", 
+            "write_ts": 1470791324.867, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 8
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ac"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863591, 
+                    37.3891779
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:08:46-07:00", 
+            "altitude": -4.100006103515625, 
+            "ts": 1470791326, 
+            "longitude": -122.0863591, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343023208839042, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 8
+            }, 
+            "latitude": 37.3891779, 
+            "heading": 89, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:08:45.380000-07:00", 
+            "write_ts": 1470791325.38, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 8
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ad"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0876923, 
+                    37.3886179
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:09:00.460000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791340.46, 
+            "longitude": -122.0876923, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343039085000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 0, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "latitude": 37.3886179, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 165.092
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:09:01.802000-07:00", 
+            "write_ts": 1470791341.802, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ae"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0876923, 
+                    37.3886179
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:09:00.460000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791340.46, 
+            "longitude": -122.0876923, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343039085000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 0, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "latitude": 37.3886179, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 165.092
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:09:02.343000-07:00", 
+            "write_ts": 1470791342.343, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902af"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 46, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 4, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "ts": 1470791344.882, 
+            "fmt_time": "2016-08-09T18:09:04.882000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:09:04.882000-07:00", 
+            "write_ts": 1470791344.882, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 4, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b0"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086343, 
+                    37.3891808
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:09:29-07:00", 
+            "altitude": 1.29998779296875, 
+            "ts": 1470791369, 
+            "longitude": -122.086343, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343066316840751, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "latitude": 37.3891808, 
+            "heading": 280, 
+            "sensed_speed": 0.1251, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:09:28.016000-07:00", 
+            "write_ts": 1470791368.016, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b1"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086343, 
+                    37.3891808
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:09:29-07:00", 
+            "altitude": 1.29998779296875, 
+            "ts": 1470791369, 
+            "longitude": -122.086343, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343066316840751, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "latitude": 37.3891808, 
+            "heading": 280, 
+            "sensed_speed": 0.1251, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:09:28.572000-07:00", 
+            "write_ts": 1470791368.572, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b2"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 69, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 33, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "ts": 1470791373.646, 
+            "fmt_time": "2016-08-09T18:09:33.646000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:09:33.646000-07:00", 
+            "write_ts": 1470791373.646, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 33, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 9
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b3"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086377, 
+                    37.3891618
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:10:05-07:00", 
+            "altitude": 11.20001220703125, 
+            "ts": 1470791405, 
+            "longitude": -122.086377, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343101603919608, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 5, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "latitude": 37.3891618, 
+            "heading": 149, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:10:03.281000-07:00", 
+            "write_ts": 1470791403.281, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b4"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086377, 
+                    37.3891618
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:10:05-07:00", 
+            "altitude": 11.20001220703125, 
+            "ts": 1470791405, 
+            "longitude": -122.086377, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343101603919608, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 5, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "latitude": 37.3891618, 
+            "heading": 149, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:10:03.870000-07:00", 
+            "write_ts": 1470791403.87, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b5"
+        }, 
+        "data": {
+            "type": 4, 
+            "confidence": 33, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "ts": 1470791425.139, 
+            "fmt_time": "2016-08-09T18:10:25.139000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:10:25.139000-07:00", 
+            "write_ts": 1470791425.139, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b6"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0868957, 
+                    37.3886066
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:10:31.279000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791431.279, 
+            "longitude": -122.0868957, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343129904000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "latitude": 37.3886066, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 39.332
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:10:31.547000-07:00", 
+            "write_ts": 1470791431.547, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b7"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0868957, 
+                    37.3886066
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:10:31.279000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791431.279, 
+            "longitude": -122.0868957, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343129904000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "latitude": 37.3886066, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 39.332
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:10:32.321000-07:00", 
+            "write_ts": 1470791432.321, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 10
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b8"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0872421, 
+                    37.3885599
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:11:01.292000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791461.292, 
+            "longitude": -122.0872421, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343159917000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "latitude": 37.3885599, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 30
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:11:06.982000-07:00", 
+            "write_ts": 1470791466.982, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902b9"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0872421, 
+                    37.3885599
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:11:01.292000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791461.292, 
+            "longitude": -122.0872421, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343159917000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "latitude": 37.3885599, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 30
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:11:07.633000-07:00", 
+            "write_ts": 1470791467.633, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 7, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ba"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "ts": 1470791468.476, 
+            "fmt_time": "2016-08-09T18:11:08.476000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:11:08.476000-07:00", 
+            "write_ts": 1470791468.476, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902bb"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864133, 
+                    37.3892771
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:11:12-07:00", 
+            "altitude": -1.100006103515625, 
+            "ts": 1470791472, 
+            "longitude": -122.0864133, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343168551978653, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "latitude": 37.3892771, 
+            "heading": 58, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:11:10.165000-07:00", 
+            "write_ts": 1470791470.165, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 10, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902bc"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864133, 
+                    37.3892771
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:11:12-07:00", 
+            "altitude": -1.100006103515625, 
+            "ts": 1470791472, 
+            "longitude": -122.0864133, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343168551978653, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "latitude": 37.3892771, 
+            "heading": 58, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:11:33.452000-07:00", 
+            "write_ts": 1470791493.452, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 33, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902bd"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 77, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "ts": 1470791497.262, 
+            "fmt_time": "2016-08-09T18:11:37.262000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:11:37.262000-07:00", 
+            "write_ts": 1470791497.262, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902be"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866294, 
+                    37.3888372
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:11:37.902000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791497.902, 
+            "longitude": -122.0866294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343196526000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "latitude": 37.3888372, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 21.306
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:11:38.134000-07:00", 
+            "write_ts": 1470791498.134, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 38, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902bf"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866294, 
+                    37.3888372
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:11:37.902000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791497.902, 
+            "longitude": -122.0866294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343196526000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "latitude": 37.3888372, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 21.306
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:11:38.797000-07:00", 
+            "write_ts": 1470791498.797, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 38, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 11
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c0"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865191, 
+                    37.3892183
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:12:06-07:00", 
+            "altitude": -7.29998779296875, 
+            "ts": 1470791526, 
+            "longitude": -122.0865191, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343223442023801, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "latitude": 37.3892183, 
+            "heading": 242, 
+            "sensed_speed": 0.06255, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:12:05.102000-07:00", 
+            "write_ts": 1470791525.102, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 5, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c1"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865191, 
+                    37.3892183
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:12:06-07:00", 
+            "altitude": -7.29998779296875, 
+            "ts": 1470791526, 
+            "longitude": -122.0865191, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343223442023801, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "latitude": 37.3892183, 
+            "heading": 242, 
+            "sensed_speed": 0.06255, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:12:05.725000-07:00", 
+            "write_ts": 1470791525.725, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 5, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c2"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 92, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "ts": 1470791528.637, 
+            "fmt_time": "2016-08-09T18:12:08.637000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:12:08.637000-07:00", 
+            "write_ts": 1470791528.637, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c3"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "ts": 1470791557.329, 
+            "fmt_time": "2016-08-09T18:12:37.329000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:12:37.329000-07:00", 
+            "write_ts": 1470791557.329, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c4"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864987, 
+                    37.3891209
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:12:39-07:00", 
+            "altitude": 6.5, 
+            "ts": 1470791559, 
+            "longitude": -122.0864987, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343255829291868, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 39, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "latitude": 37.3891209, 
+            "heading": 104, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:12:37.561000-07:00", 
+            "write_ts": 1470791557.561, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c5"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864987, 
+                    37.3891209
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:12:39-07:00", 
+            "altitude": 6.5, 
+            "ts": 1470791559, 
+            "longitude": -122.0864987, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343255829291868, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 39, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "latitude": 37.3891209, 
+            "heading": 104, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:12:38.228000-07:00", 
+            "write_ts": 1470791558.228, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 38, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 12
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c6"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "ts": 1470791586.108, 
+            "fmt_time": "2016-08-09T18:13:06.108000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:13:06.108000-07:00", 
+            "write_ts": 1470791586.108, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c7"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864519, 
+                    37.3887408
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:13:08.400000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791588.4, 
+            "longitude": -122.0864519, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343287025000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "latitude": 37.3887408, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 21.282
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:13:08.645000-07:00", 
+            "write_ts": 1470791588.645, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c8"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864519, 
+                    37.3887408
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:13:08.400000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791588.4, 
+            "longitude": -122.0864519, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343287025000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "latitude": 37.3887408, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 21.282
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:13:09.268000-07:00", 
+            "write_ts": 1470791589.268, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902c9"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0875441, 
+                    37.3885329
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:13:30.425000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791610.425, 
+            "longitude": -122.0875441, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343309050000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "latitude": 37.3885329, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 156.028
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:13:37.536000-07:00", 
+            "write_ts": 1470791617.536, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ca"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0875441, 
+                    37.3885329
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:13:30.425000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791610.425, 
+            "longitude": -122.0875441, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343309050000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "latitude": 37.3885329, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 156.028
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:13:38.112000-07:00", 
+            "write_ts": 1470791618.112, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 38, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902cb"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863176, 
+                    37.3892259
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:13:47-07:00", 
+            "altitude": -2.899993896484375, 
+            "ts": 1470791627, 
+            "longitude": -122.0863176, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343324325263533, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "latitude": 37.3892259, 
+            "heading": 41, 
+            "sensed_speed": 0.68805, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:13:46-07:00", 
+            "write_ts": 1470791626, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902cc"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863176, 
+                    37.3892259
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:13:47-07:00", 
+            "altitude": -2.899993896484375, 
+            "ts": 1470791627, 
+            "longitude": -122.0863176, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343324325263533, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "latitude": 37.3892259, 
+            "heading": 41, 
+            "sensed_speed": 0.68805, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:13:46.677000-07:00", 
+            "write_ts": 1470791626.677, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 13
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902cd"
+        }, 
+        "data": {
+            "type": 0, 
+            "confidence": 52, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "ts": 1470791646.088, 
+            "fmt_time": "2016-08-09T18:14:06.088000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:06.088000-07:00", 
+            "write_ts": 1470791646.088, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ce"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "ts": 1470791646.223, 
+            "fmt_time": "2016-08-09T18:14:06.223000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:06.223000-07:00", 
+            "write_ts": 1470791646.223, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902cf"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0874782, 
+                    37.3886023
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:14:02.256000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791642.256, 
+            "longitude": -122.0874782, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343340880000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "latitude": 37.3886023, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 45
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:07.652000-07:00", 
+            "write_ts": 1470791647.652, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 7, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d0"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0874782, 
+                    37.3886023
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:14:02.256000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791642.256, 
+            "longitude": -122.0874782, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343340880000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "latitude": 37.3886023, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 45
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:08.183000-07:00", 
+            "write_ts": 1470791648.183, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d1"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863888, 
+                    37.3892299
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:14:23-07:00", 
+            "altitude": 2.5, 
+            "ts": 1470791663, 
+            "longitude": -122.0863888, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343359627234969, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 23, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "latitude": 37.3892299, 
+            "heading": 312, 
+            "sensed_speed": 0.93825, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:21.243000-07:00", 
+            "write_ts": 1470791661.243, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d2"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863888, 
+                    37.3892299
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:14:23-07:00", 
+            "altitude": 2.5, 
+            "ts": 1470791663, 
+            "longitude": -122.0863888, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343359627234969, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 23, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "latitude": 37.3892299, 
+            "heading": 312, 
+            "sensed_speed": 0.93825, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:21.776000-07:00", 
+            "write_ts": 1470791661.776, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d3"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0876927, 
+                    37.3885158
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:14:34.080000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791674.08, 
+            "longitude": -122.0876927, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343372705000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "latitude": 37.3885158, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 167.076
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:38.415000-07:00", 
+            "write_ts": 1470791678.415, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 38, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d4"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0876927, 
+                    37.3885158
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:14:34.080000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791674.08, 
+            "longitude": -122.0876927, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343372705000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "latitude": 37.3885158, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 167.076
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:39.022000-07:00", 
+            "write_ts": 1470791679.022, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 39, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d5"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086338, 
+                    37.3892488
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:14:55-07:00", 
+            "altitude": -1.100006103515625, 
+            "ts": 1470791695, 
+            "longitude": -122.086338, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343392120154885, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "latitude": 37.3892488, 
+            "heading": 127, 
+            "sensed_speed": 0.5004, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:53.762000-07:00", 
+            "write_ts": 1470791693.762, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 53, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d6"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086338, 
+                    37.3892488
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:14:55-07:00", 
+            "altitude": -1.100006103515625, 
+            "ts": 1470791695, 
+            "longitude": -122.086338, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343392120154885, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "latitude": 37.3892488, 
+            "heading": 127, 
+            "sensed_speed": 0.5004, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:14:54.521000-07:00", 
+            "write_ts": 1470791694.521, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 54, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 14
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d7"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 65, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "ts": 1470791706.415, 
+            "fmt_time": "2016-08-09T18:15:06.415000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:06.415000-07:00", 
+            "write_ts": 1470791706.415, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d8"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "ts": 1470791706.564, 
+            "fmt_time": "2016-08-09T18:15:06.564000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:06.564000-07:00", 
+            "write_ts": 1470791706.564, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902d9"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0876515, 
+                    37.3885928
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:15:08.824000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791708.824, 
+            "longitude": -122.0876515, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343407449000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "latitude": 37.3885928, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 163.182
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:09.362000-07:00", 
+            "write_ts": 1470791709.362, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902da"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0876515, 
+                    37.3885928
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:15:08.824000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791708.824, 
+            "longitude": -122.0876515, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343407449000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "latitude": 37.3885928, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 163.182
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:10.123000-07:00", 
+            "write_ts": 1470791710.123, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 10, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902db"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863512, 
+                    37.3891201
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:15:28-07:00", 
+            "altitude": -3.70001220703125, 
+            "ts": 1470791728, 
+            "longitude": -122.0863512, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343424629798471, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "latitude": 37.3891201, 
+            "heading": 259, 
+            "sensed_speed": 0.31275, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:26.227000-07:00", 
+            "write_ts": 1470791726.227, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902dc"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863512, 
+                    37.3891201
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:15:28-07:00", 
+            "altitude": -3.70001220703125, 
+            "ts": 1470791728, 
+            "longitude": -122.0863512, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343424629798471, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "latitude": 37.3891201, 
+            "heading": 259, 
+            "sensed_speed": 0.31275, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:27.204000-07:00", 
+            "write_ts": 1470791727.204, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 27, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902dd"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0873371, 
+                    37.3886128
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:15:40.039000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791740.039, 
+            "longitude": -122.0873371, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343438664000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "latitude": 37.3886128, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 55.5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:40.292000-07:00", 
+            "write_ts": 1470791740.292, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902de"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0873371, 
+                    37.3886128
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:15:40.039000-07:00", 
+            "altitude": 0, 
+            "ts": 1470791740.039, 
+            "longitude": -122.0873371, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343438664000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "latitude": 37.3886128, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 55.5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:40.932000-07:00", 
+            "write_ts": 1470791740.932, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902df"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 57, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "ts": 1470791757.993, 
+            "fmt_time": "2016-08-09T18:15:57.993000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:15:57.993000-07:00", 
+            "write_ts": 1470791757.993, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 15
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e0"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863642, 
+                    37.3889937
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:03-07:00", 
+            "altitude": 9.29998779296875, 
+            "ts": 1470791763, 
+            "longitude": -122.0863642, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343459749854602, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3889937, 
+            "heading": 162, 
+            "sensed_speed": 0.8757, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:01.359000-07:00", 
+            "write_ts": 1470791761.359, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e1"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863642, 
+                    37.3889937
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:03-07:00", 
+            "altitude": 9.29998779296875, 
+            "ts": 1470791763, 
+            "longitude": -122.0863642, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343459749854602, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3889937, 
+            "heading": 162, 
+            "sensed_speed": 0.8757, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:02.063000-07:00", 
+            "write_ts": 1470791762.063, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e2"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862998, 
+                    37.3889696
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:09-07:00", 
+            "altitude": 8.100006103515625, 
+            "ts": 1470791769, 
+            "longitude": -122.0862998, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343465660071887, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3889696, 
+            "heading": 129, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:07.284000-07:00", 
+            "write_ts": 1470791767.284, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 7, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e3"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862998, 
+                    37.3889696
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:09-07:00", 
+            "altitude": 8.100006103515625, 
+            "ts": 1470791769, 
+            "longitude": -122.0862998, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343465660071887, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3889696, 
+            "heading": 129, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:08.050000-07:00", 
+            "write_ts": 1470791768.05, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e4"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863036, 
+                    37.3889718
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:15-07:00", 
+            "altitude": 6.399993896484375, 
+            "ts": 1470791775, 
+            "longitude": -122.0863036, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343471612403430, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 15, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3889718, 
+            "heading": 181, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:13.243000-07:00", 
+            "write_ts": 1470791773.243, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 13, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e5"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863036, 
+                    37.3889718
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:15-07:00", 
+            "altitude": 6.399993896484375, 
+            "ts": 1470791775, 
+            "longitude": -122.0863036, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343471612403430, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 15, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3889718, 
+            "heading": 181, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:13.905000-07:00", 
+            "write_ts": 1470791773.905, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 13, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e6"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863358, 
+                    37.3890211
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:21-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791781, 
+            "longitude": -122.0863358, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343477522559681, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3890211, 
+            "heading": 253, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:19.112000-07:00", 
+            "write_ts": 1470791779.112, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e7"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863358, 
+                    37.3890211
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:21-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791781, 
+            "longitude": -122.0863358, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343477522559681, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3890211, 
+            "heading": 253, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:19.742000-07:00", 
+            "write_ts": 1470791779.742, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e8"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863353, 
+                    37.3890873
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:26-07:00", 
+            "altitude": 10.600006103515625, 
+            "ts": 1470791786, 
+            "longitude": -122.0863353, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343482560798206, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3890873, 
+            "heading": 344, 
+            "sensed_speed": 1.1259, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:24.171000-07:00", 
+            "write_ts": 1470791784.171, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902e9"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863353, 
+                    37.3890873
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:26-07:00", 
+            "altitude": 10.600006103515625, 
+            "ts": 1470791786, 
+            "longitude": -122.0863353, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343482560798206, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3890873, 
+            "heading": 344, 
+            "sensed_speed": 1.1259, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:24.812000-07:00", 
+            "write_ts": 1470791784.812, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ea"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863282, 
+                    37.3891153
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:31-07:00", 
+            "altitude": 13.4000244140625, 
+            "ts": 1470791791, 
+            "longitude": -122.0863282, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343487575843372, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891153, 
+            "heading": 13, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:29.182000-07:00", 
+            "write_ts": 1470791789.182, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902eb"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863282, 
+                    37.3891153
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:31-07:00", 
+            "altitude": 13.4000244140625, 
+            "ts": 1470791791, 
+            "longitude": -122.0863282, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343487575843372, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 31, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891153, 
+            "heading": 13, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:29.846000-07:00", 
+            "write_ts": 1470791789.846, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ec"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 95, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "ts": 1470791790.726, 
+            "fmt_time": "2016-08-09T18:16:30.726000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:30.726000-07:00", 
+            "write_ts": 1470791790.726, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ed"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863226, 
+                    37.3891215
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:36-07:00", 
+            "altitude": 13.29998779296875, 
+            "ts": 1470791796, 
+            "longitude": -122.0863226, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343492591712513, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 36, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891215, 
+            "heading": 15, 
+            "sensed_speed": 0.2502, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:34.178000-07:00", 
+            "write_ts": 1470791794.178, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ee"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863226, 
+                    37.3891215
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:36-07:00", 
+            "altitude": 13.29998779296875, 
+            "ts": 1470791796, 
+            "longitude": -122.0863226, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343492591712513, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 36, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891215, 
+            "heading": 15, 
+            "sensed_speed": 0.2502, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:34.933000-07:00", 
+            "write_ts": 1470791794.933, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ef"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863324, 
+                    37.3891445
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:42-07:00", 
+            "altitude": 16.79998779296875, 
+            "ts": 1470791802, 
+            "longitude": -122.0863324, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343498510505237, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891445, 
+            "heading": 7, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:40.241000-07:00", 
+            "write_ts": 1470791800.241, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f0"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863324, 
+                    37.3891445
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:42-07:00", 
+            "altitude": 16.79998779296875, 
+            "ts": 1470791802, 
+            "longitude": -122.0863324, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343498510505237, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891445, 
+            "heading": 7, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:41.276000-07:00", 
+            "write_ts": 1470791801.276, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f1"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863453, 
+                    37.3891396
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:47-07:00", 
+            "altitude": 19.0999755859375, 
+            "ts": 1470791807, 
+            "longitude": -122.0863453, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343503514258899, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891396, 
+            "heading": 346, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:45.102000-07:00", 
+            "write_ts": 1470791805.102, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f2"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863453, 
+                    37.3891396
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:47-07:00", 
+            "altitude": 19.0999755859375, 
+            "ts": 1470791807, 
+            "longitude": -122.0863453, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343503514258899, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891396, 
+            "heading": 346, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:45.770000-07:00", 
+            "write_ts": 1470791805.77, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f3"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863293, 
+                    37.3891266
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:52-07:00", 
+            "altitude": 16, 
+            "ts": 1470791812, 
+            "longitude": -122.0863293, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343508565345325, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 52, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891266, 
+            "heading": 55, 
+            "sensed_speed": 0.37530002, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:50.143000-07:00", 
+            "write_ts": 1470791810.143, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f4"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863293, 
+                    37.3891266
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:52-07:00", 
+            "altitude": 16, 
+            "ts": 1470791812, 
+            "longitude": -122.0863293, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343508565345325, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 52, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891266, 
+            "heading": 55, 
+            "sensed_speed": 0.37530002, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:50.790000-07:00", 
+            "write_ts": 1470791810.79, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f5"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863257, 
+                    37.3891017
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:57-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791817, 
+            "longitude": -122.0863257, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343513596717395, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891017, 
+            "heading": 100, 
+            "sensed_speed": 0, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:55.188000-07:00", 
+            "write_ts": 1470791815.188, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f6"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863257, 
+                    37.3891017
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:16:57-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791817, 
+            "longitude": -122.0863257, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343513596717395, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "latitude": 37.3891017, 
+            "heading": 100, 
+            "sensed_speed": 0, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:55.882000-07:00", 
+            "write_ts": 1470791815.882, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f7"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "ts": 1470791819.051, 
+            "fmt_time": "2016-08-09T18:16:59.051000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:16:59.051000-07:00", 
+            "write_ts": 1470791819.051, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 16
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f8"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863257, 
+                    37.3891017
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:02-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791822, 
+            "longitude": -122.0863257, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343518608436145, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891017, 
+            "heading": 100, 
+            "sensed_speed": 0, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:00.196000-07:00", 
+            "write_ts": 1470791820.196, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 0, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902f9"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863257, 
+                    37.3891017
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:02-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791822, 
+            "longitude": -122.0863257, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343518608436145, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891017, 
+            "heading": 100, 
+            "sensed_speed": 0, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:00.802000-07:00", 
+            "write_ts": 1470791820.802, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 0, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902fa"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863257, 
+                    37.3891017
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:08-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791828, 
+            "longitude": -122.0863257, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343524596717395, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891017, 
+            "heading": 100, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:06.210000-07:00", 
+            "write_ts": 1470791826.21, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902fb"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863257, 
+                    37.3891017
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:08-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791828, 
+            "longitude": -122.0863257, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343524596717395, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891017, 
+            "heading": 100, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:06.939000-07:00", 
+            "write_ts": 1470791826.939, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902fc"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863257, 
+                    37.3891017
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:14-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791834, 
+            "longitude": -122.0863257, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343530520301380, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891017, 
+            "heading": 100, 
+            "sensed_speed": 0, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:12.096000-07:00", 
+            "write_ts": 1470791832.096, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902fd"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863257, 
+                    37.3891017
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:14-07:00", 
+            "altitude": 14.20001220703125, 
+            "ts": 1470791834, 
+            "longitude": -122.0863257, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343530520301380, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891017, 
+            "heading": 100, 
+            "sensed_speed": 0, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:12.817000-07:00", 
+            "write_ts": 1470791832.817, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902fe"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863133, 
+                    37.3890265
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:19-07:00", 
+            "altitude": 8.79998779296875, 
+            "ts": 1470791839, 
+            "longitude": -122.0863133, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343535565162219, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890265, 
+            "heading": 63, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:17.185000-07:00", 
+            "write_ts": 1470791837.185, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd902ff"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863133, 
+                    37.3890265
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:19-07:00", 
+            "altitude": 8.79998779296875, 
+            "ts": 1470791839, 
+            "longitude": -122.0863133, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343535565162219, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890265, 
+            "heading": 63, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:17.873000-07:00", 
+            "write_ts": 1470791837.873, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90300"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863232, 
+                    37.3890192
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:24-07:00", 
+            "altitude": 8.70001220703125, 
+            "ts": 1470791844, 
+            "longitude": -122.0863232, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343540574683704, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890192, 
+            "heading": 316, 
+            "sensed_speed": 0, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:22.208000-07:00", 
+            "write_ts": 1470791842.208, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 22, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90301"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863232, 
+                    37.3890192
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:24-07:00", 
+            "altitude": 8.70001220703125, 
+            "ts": 1470791844, 
+            "longitude": -122.0863232, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343540574683704, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890192, 
+            "heading": 316, 
+            "sensed_speed": 0, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:23.052000-07:00", 
+            "write_ts": 1470791843.052, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 23, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90302"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863392, 
+                    37.3890261
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:29-07:00", 
+            "altitude": 9.29998779296875, 
+            "ts": 1470791849, 
+            "longitude": -122.0863392, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343545584235706, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890261, 
+            "heading": 253, 
+            "sensed_speed": 0.31275, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:27.172000-07:00", 
+            "write_ts": 1470791847.172, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 27, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90303"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863392, 
+                    37.3890261
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:29-07:00", 
+            "altitude": 9.29998779296875, 
+            "ts": 1470791849, 
+            "longitude": -122.0863392, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343545584235706, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890261, 
+            "heading": 253, 
+            "sensed_speed": 0.31275, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:27.901000-07:00", 
+            "write_ts": 1470791847.901, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 27, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90304"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863478, 
+                    37.3890347
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:34-07:00", 
+            "altitude": 9.79998779296875, 
+            "ts": 1470791854, 
+            "longitude": -122.0863478, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343550596656360, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890347, 
+            "heading": 324, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:32.193000-07:00", 
+            "write_ts": 1470791852.193, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90305"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863478, 
+                    37.3890347
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:34-07:00", 
+            "altitude": 9.79998779296875, 
+            "ts": 1470791854, 
+            "longitude": -122.0863478, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343550596656360, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890347, 
+            "heading": 324, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:32.917000-07:00", 
+            "write_ts": 1470791852.917, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90306"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863495, 
+                    37.3890696
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:39-07:00", 
+            "altitude": 7.399993896484375, 
+            "ts": 1470791859, 
+            "longitude": -122.0863495, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343555686683216, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 39, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890696, 
+            "heading": 340, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:37.274000-07:00", 
+            "write_ts": 1470791857.274, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90307"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863495, 
+                    37.3890696
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:39-07:00", 
+            "altitude": 7.399993896484375, 
+            "ts": 1470791859, 
+            "longitude": -122.0863495, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343555686683216, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 39, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3890696, 
+            "heading": 340, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:38.051000-07:00", 
+            "write_ts": 1470791858.051, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 38, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90308"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863687, 
+                    37.3891564
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:45-07:00", 
+            "altitude": 7.70001220703125, 
+            "ts": 1470791865, 
+            "longitude": -122.0863687, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343561515082874, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891564, 
+            "heading": 354, 
+            "sensed_speed": 1.3761, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:43.149000-07:00", 
+            "write_ts": 1470791863.149, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 43, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90309"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863687, 
+                    37.3891564
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:45-07:00", 
+            "altitude": 7.70001220703125, 
+            "ts": 1470791865, 
+            "longitude": -122.0863687, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343561515082874, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891564, 
+            "heading": 354, 
+            "sensed_speed": 1.3761, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:43.949000-07:00", 
+            "write_ts": 1470791863.949, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 43, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9030a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086358, 
+                    37.3891924
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:50-07:00", 
+            "altitude": 9.899993896484375, 
+            "ts": 1470791870, 
+            "longitude": -122.086358, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343566556800403, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891924, 
+            "heading": 5, 
+            "sensed_speed": 1.18845, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:48.256000-07:00", 
+            "write_ts": 1470791868.256, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9030b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086358, 
+                    37.3891924
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:50-07:00", 
+            "altitude": 9.899993896484375, 
+            "ts": 1470791870, 
+            "longitude": -122.086358, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343566556800403, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3891924, 
+            "heading": 5, 
+            "sensed_speed": 1.18845, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:49.024000-07:00", 
+            "write_ts": 1470791869.024, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9030c"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 59, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "ts": 1470791871.303, 
+            "fmt_time": "2016-08-09T18:17:51.303000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:51.303000-07:00", 
+            "write_ts": 1470791871.303, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9030d"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "ts": 1470791871.437, 
+            "fmt_time": "2016-08-09T18:17:51.437000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:51.437000-07:00", 
+            "write_ts": 1470791871.437, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9030e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863532, 
+                    37.3892463
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:55-07:00", 
+            "altitude": 8.5, 
+            "ts": 1470791875, 
+            "longitude": -122.0863532, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343571567145862, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3892463, 
+            "heading": 9, 
+            "sensed_speed": 0.68805, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:53.148000-07:00", 
+            "write_ts": 1470791873.148, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 53, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9030f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863532, 
+                    37.3892463
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:17:55-07:00", 
+            "altitude": 8.5, 
+            "ts": 1470791875, 
+            "longitude": -122.0863532, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343571567145862, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "latitude": 37.3892463, 
+            "heading": 9, 
+            "sensed_speed": 0.68805, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:53.939000-07:00", 
+            "write_ts": 1470791873.939, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 53, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90310"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086335, 
+                    37.3892718
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:00-07:00", 
+            "altitude": 7.899993896484375, 
+            "ts": 1470791880, 
+            "longitude": -122.086335, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343576575812854, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 0, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3892718, 
+            "heading": 29, 
+            "sensed_speed": 0.6255, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:58.152000-07:00", 
+            "write_ts": 1470791878.152, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 58, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90311"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086335, 
+                    37.3892718
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:00-07:00", 
+            "altitude": 7.899993896484375, 
+            "ts": 1470791880, 
+            "longitude": -122.086335, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343576575812854, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 0, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3892718, 
+            "heading": 29, 
+            "sensed_speed": 0.6255, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:17:58.951000-07:00", 
+            "write_ts": 1470791878.951, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 58, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 17
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90312"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863233, 
+                    37.3893351
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:05-07:00", 
+            "altitude": 8.29998779296875, 
+            "ts": 1470791885, 
+            "longitude": -122.0863233, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343581587928333, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 5, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3893351, 
+            "heading": 38, 
+            "sensed_speed": 0.6255, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:03.316000-07:00", 
+            "write_ts": 1470791883.316, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90313"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863233, 
+                    37.3893351
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:05-07:00", 
+            "altitude": 8.29998779296875, 
+            "ts": 1470791885, 
+            "longitude": -122.0863233, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343581587928333, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 5, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3893351, 
+            "heading": 38, 
+            "sensed_speed": 0.6255, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:04.289000-07:00", 
+            "write_ts": 1470791884.289, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 4, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90314"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863206, 
+                    37.3893823
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:11-07:00", 
+            "altitude": 8.29998779296875, 
+            "ts": 1470791891, 
+            "longitude": -122.0863206, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343587566016712, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 11, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3893823, 
+            "heading": 12, 
+            "sensed_speed": 0.75060004, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:09.154000-07:00", 
+            "write_ts": 1470791889.154, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90315"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863206, 
+                    37.3893823
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:11-07:00", 
+            "altitude": 8.29998779296875, 
+            "ts": 1470791891, 
+            "longitude": -122.0863206, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343587566016712, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 11, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3893823, 
+            "heading": 12, 
+            "sensed_speed": 0.75060004, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:09.959000-07:00", 
+            "write_ts": 1470791889.959, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90316"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862946, 
+                    37.3894092
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:16-07:00", 
+            "altitude": 7.600006103515625, 
+            "ts": 1470791896, 
+            "longitude": -122.0862946, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343592576911487, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3894092, 
+            "heading": 12, 
+            "sensed_speed": 1.56375, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:14.166000-07:00", 
+            "write_ts": 1470791894.166, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90317"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862946, 
+                    37.3894092
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:16-07:00", 
+            "altitude": 7.600006103515625, 
+            "ts": 1470791896, 
+            "longitude": -122.0862946, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343592576911487, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 16, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3894092, 
+            "heading": 12, 
+            "sensed_speed": 1.56375, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:14.926000-07:00", 
+            "write_ts": 1470791894.926, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90318"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862918, 
+                    37.3894484
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:21-07:00", 
+            "altitude": 8.399993896484375, 
+            "ts": 1470791901, 
+            "longitude": -122.0862918, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343597586402454, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3894484, 
+            "heading": 9, 
+            "sensed_speed": 1.0008, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:19.181000-07:00", 
+            "write_ts": 1470791899.181, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90319"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0862918, 
+                    37.3894484
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:21-07:00", 
+            "altitude": 8.399993896484375, 
+            "ts": 1470791901, 
+            "longitude": -122.0862918, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343597586402454, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3894484, 
+            "heading": 9, 
+            "sensed_speed": 1.0008, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:19.957000-07:00", 
+            "write_ts": 1470791899.957, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9031a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086294, 
+                    37.3894812
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:26-07:00", 
+            "altitude": 8.600006103515625, 
+            "ts": 1470791906, 
+            "longitude": -122.086294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343602597419300, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3894812, 
+            "heading": 344, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:24.204000-07:00", 
+            "write_ts": 1470791904.204, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9031b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086294, 
+                    37.3894812
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:26-07:00", 
+            "altitude": 8.600006103515625, 
+            "ts": 1470791906, 
+            "longitude": -122.086294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343602597419300, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3894812, 
+            "heading": 344, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:24.935000-07:00", 
+            "write_ts": 1470791904.935, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9031c"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 79, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "ts": 1470791906.786, 
+            "fmt_time": "2016-08-09T18:18:26.786000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:26.786000-07:00", 
+            "write_ts": 1470791906.786, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9031d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863195, 
+                    37.3895114
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:32-07:00", 
+            "altitude": 8.20001220703125, 
+            "ts": 1470791912, 
+            "longitude": -122.0863195, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343608516791858, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3895114, 
+            "heading": 315, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:30.116000-07:00", 
+            "write_ts": 1470791910.116, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9031e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863195, 
+                    37.3895114
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:32-07:00", 
+            "altitude": 8.20001220703125, 
+            "ts": 1470791912, 
+            "longitude": -122.0863195, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343608516791858, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3895114, 
+            "heading": 315, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:30.901000-07:00", 
+            "write_ts": 1470791910.901, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9031f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863562, 
+                    37.3895461
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:37-07:00", 
+            "altitude": 7.70001220703125, 
+            "ts": 1470791917, 
+            "longitude": -122.0863562, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343613596046009, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3895461, 
+            "heading": 310, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:35.160000-07:00", 
+            "write_ts": 1470791915.16, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 35, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90320"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863562, 
+                    37.3895461
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:37-07:00", 
+            "altitude": 7.70001220703125, 
+            "ts": 1470791917, 
+            "longitude": -122.0863562, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343613596046009, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3895461, 
+            "heading": 310, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:35.949000-07:00", 
+            "write_ts": 1470791915.949, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 35, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90321"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864369, 
+                    37.3895691
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:43-07:00", 
+            "altitude": 7.79998779296875, 
+            "ts": 1470791923, 
+            "longitude": -122.0864369, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343619576728382, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 43, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3895691, 
+            "heading": 285, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:41.433000-07:00", 
+            "write_ts": 1470791921.433, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90322"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864369, 
+                    37.3895691
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:43-07:00", 
+            "altitude": 7.79998779296875, 
+            "ts": 1470791923, 
+            "longitude": -122.0864369, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343619576728382, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 43, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3895691, 
+            "heading": 285, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:42.194000-07:00", 
+            "write_ts": 1470791922.194, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90323"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864651, 
+                    37.3896084
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:48-07:00", 
+            "altitude": 8.79998779296875, 
+            "ts": 1470791928, 
+            "longitude": -122.0864651, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343624586036243, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3896084, 
+            "heading": 316, 
+            "sensed_speed": 0.8757, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:46.408000-07:00", 
+            "write_ts": 1470791926.408, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90324"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864651, 
+                    37.3896084
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:48-07:00", 
+            "altitude": 8.79998779296875, 
+            "ts": 1470791928, 
+            "longitude": -122.0864651, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343624586036243, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3896084, 
+            "heading": 316, 
+            "sensed_speed": 0.8757, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:47.408000-07:00", 
+            "write_ts": 1470791927.408, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90325"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865058, 
+                    37.3896539
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:53-07:00", 
+            "altitude": 8.29998779296875, 
+            "ts": 1470791933, 
+            "longitude": -122.0865058, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343629595557727, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 53, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3896539, 
+            "heading": 315, 
+            "sensed_speed": 1.251, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:51.180000-07:00", 
+            "write_ts": 1470791931.18, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90326"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865058, 
+                    37.3896539
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:53-07:00", 
+            "altitude": 8.29998779296875, 
+            "ts": 1470791933, 
+            "longitude": -122.0865058, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343629595557727, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 53, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3896539, 
+            "heading": 315, 
+            "sensed_speed": 1.251, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:51.853000-07:00", 
+            "write_ts": 1470791931.853, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90327"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 62, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "ts": 1470791935.89, 
+            "fmt_time": "2016-08-09T18:18:55.890000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:55.890000-07:00", 
+            "write_ts": 1470791935.89, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90328"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865307, 
+                    37.3897168
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:58-07:00", 
+            "altitude": 8.20001220703125, 
+            "ts": 1470791938, 
+            "longitude": -122.0865307, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343634607062854, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 58, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3897168, 
+            "heading": 326, 
+            "sensed_speed": 0.93825, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:56.178000-07:00", 
+            "write_ts": 1470791936.178, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 56, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90329"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865307, 
+                    37.3897168
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:18:58-07:00", 
+            "altitude": 8.20001220703125, 
+            "ts": 1470791938, 
+            "longitude": -122.0865307, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343634607062854, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 58, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "latitude": 37.3897168, 
+            "heading": 326, 
+            "sensed_speed": 0.93825, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:18:56.913000-07:00", 
+            "write_ts": 1470791936.913, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 56, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 18
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9032a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865706, 
+                    37.3897692
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:04-07:00", 
+            "altitude": 8, 
+            "ts": 1470791944, 
+            "longitude": -122.0865706, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343640616218128, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 4, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3897692, 
+            "heading": 313, 
+            "sensed_speed": 0.8757, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:02.211000-07:00", 
+            "write_ts": 1470791942.211, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 2, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9032b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865706, 
+                    37.3897692
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:04-07:00", 
+            "altitude": 8, 
+            "ts": 1470791944, 
+            "longitude": -122.0865706, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343640616218128, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 4, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3897692, 
+            "heading": 313, 
+            "sensed_speed": 0.8757, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:03.014000-07:00", 
+            "write_ts": 1470791943.014, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9032c"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865951, 
+                    37.3898238
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:09-07:00", 
+            "altitude": 7.70001220703125, 
+            "ts": 1470791949, 
+            "longitude": -122.0865951, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343645671058216, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3898238, 
+            "heading": 328, 
+            "sensed_speed": 1.18845, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:07.263000-07:00", 
+            "write_ts": 1470791947.263, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 7, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9032d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865951, 
+                    37.3898238
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:09-07:00", 
+            "altitude": 7.70001220703125, 
+            "ts": 1470791949, 
+            "longitude": -122.0865951, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343645671058216, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 9, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3898238, 
+            "heading": 328, 
+            "sensed_speed": 1.18845, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:08.037000-07:00", 
+            "write_ts": 1470791948.037, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9032e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866515, 
+                    37.3898876
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:15-07:00", 
+            "altitude": 6.899993896484375, 
+            "ts": 1470791955, 
+            "longitude": -122.0866515, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343651617805042, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 15, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3898876, 
+            "heading": 342, 
+            "sensed_speed": 0.8757, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:13.190000-07:00", 
+            "write_ts": 1470791953.19, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 13, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9032f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866515, 
+                    37.3898876
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:15-07:00", 
+            "altitude": 6.899993896484375, 
+            "ts": 1470791955, 
+            "longitude": -122.0866515, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343651617805042, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 15, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3898876, 
+            "heading": 342, 
+            "sensed_speed": 0.8757, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:13.919000-07:00", 
+            "write_ts": 1470791953.919, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 13, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90330"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866431, 
+                    37.389942
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:21-07:00", 
+            "altitude": 5.899993896484375, 
+            "ts": 1470791961, 
+            "longitude": -122.0866431, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343657517371692, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.389942, 
+            "heading": 8, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:19.144000-07:00", 
+            "write_ts": 1470791959.144, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90331"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866431, 
+                    37.389942
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:21-07:00", 
+            "altitude": 5.899993896484375, 
+            "ts": 1470791961, 
+            "longitude": -122.0866431, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343657517371692, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.389942, 
+            "heading": 8, 
+            "sensed_speed": 0.81315, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:19.849000-07:00", 
+            "write_ts": 1470791959.849, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90332"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866642, 
+                    37.3900006
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:26-07:00", 
+            "altitude": 5.29998779296875, 
+            "ts": 1470791966, 
+            "longitude": -122.0866642, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343662524787464, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3900006, 
+            "heading": 337, 
+            "sensed_speed": 1.5012001, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:24.388000-07:00", 
+            "write_ts": 1470791964.388, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90333"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 54, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "ts": 1470791964.58, 
+            "fmt_time": "2016-08-09T18:19:24.580000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:24.580000-07:00", 
+            "write_ts": 1470791964.58, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 24, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90334"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866642, 
+                    37.3900006
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:26-07:00", 
+            "altitude": 5.29998779296875, 
+            "ts": 1470791966, 
+            "longitude": -122.0866642, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343662524787464, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 26, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3900006, 
+            "heading": 337, 
+            "sensed_speed": 1.5012001, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:25.270000-07:00", 
+            "write_ts": 1470791965.27, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90335"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866335, 
+                    37.3900585
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:32-07:00", 
+            "altitude": 3.70001220703125, 
+            "ts": 1470791972, 
+            "longitude": -122.0866335, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343668515082874, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3900585, 
+            "heading": 2, 
+            "sensed_speed": 0.68805, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:30.100000-07:00", 
+            "write_ts": 1470791970.1, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90336"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866335, 
+                    37.3900585
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:32-07:00", 
+            "altitude": 3.70001220703125, 
+            "ts": 1470791972, 
+            "longitude": -122.0866335, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343668515082874, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3900585, 
+            "heading": 2, 
+            "sensed_speed": 0.68805, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:30.916000-07:00", 
+            "write_ts": 1470791970.916, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90337"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866109, 
+                    37.3901172
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:37-07:00", 
+            "altitude": 3.600006103515625, 
+            "ts": 1470791977, 
+            "longitude": -122.0866109, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343673523505725, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3901172, 
+            "heading": 13, 
+            "sensed_speed": 1.93905, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:35.142000-07:00", 
+            "write_ts": 1470791975.142, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 35, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90338"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866109, 
+                    37.3901172
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:37-07:00", 
+            "altitude": 3.600006103515625, 
+            "ts": 1470791977, 
+            "longitude": -122.0866109, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343673523505725, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 37, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3901172, 
+            "heading": 13, 
+            "sensed_speed": 1.93905, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:35.866000-07:00", 
+            "write_ts": 1470791975.866, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 35, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90339"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865925, 
+                    37.390158
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:42-07:00", 
+            "altitude": 2.5, 
+            "ts": 1470791982, 
+            "longitude": -122.0865925, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343678556434192, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.390158, 
+            "heading": 5, 
+            "sensed_speed": 1.0008, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:40.131000-07:00", 
+            "write_ts": 1470791980.131, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9033a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865925, 
+                    37.390158
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:42-07:00", 
+            "altitude": 2.5, 
+            "ts": 1470791982, 
+            "longitude": -122.0865925, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343678556434192, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.390158, 
+            "heading": 5, 
+            "sensed_speed": 1.0008, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:40.853000-07:00", 
+            "write_ts": 1470791980.853, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 40, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9033b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865543, 
+                    37.3902303
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:47-07:00", 
+            "altitude": 0.79998779296875, 
+            "ts": 1470791987, 
+            "longitude": -122.0865543, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343683567664661, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3902303, 
+            "heading": 37, 
+            "sensed_speed": 1.5012001, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:45.143000-07:00", 
+            "write_ts": 1470791985.143, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9033c"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865543, 
+                    37.3902303
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:47-07:00", 
+            "altitude": 0.79998779296875, 
+            "ts": 1470791987, 
+            "longitude": -122.0865543, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343683567664661, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3902303, 
+            "heading": 37, 
+            "sensed_speed": 1.5012001, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:45.858000-07:00", 
+            "write_ts": 1470791985.858, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 45, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9033d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865351, 
+                    37.3902697
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:52-07:00", 
+            "altitude": 0.70001220703125, 
+            "ts": 1470791992, 
+            "longitude": -122.0865351, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343688579169788, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 52, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3902697, 
+            "heading": 6, 
+            "sensed_speed": 0.1251, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:50.145000-07:00", 
+            "write_ts": 1470791990.145, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9033e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865351, 
+                    37.3902697
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:52-07:00", 
+            "altitude": 0.70001220703125, 
+            "ts": 1470791992, 
+            "longitude": -122.0865351, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343688579169788, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 52, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3902697, 
+            "heading": 6, 
+            "sensed_speed": 0.1251, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:50.943000-07:00", 
+            "write_ts": 1470791990.943, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9033f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865361, 
+                    37.3902615
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:57-07:00", 
+            "altitude": 0.70001220703125, 
+            "ts": 1470791997, 
+            "longitude": -122.0865361, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343693590980091, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3902615, 
+            "heading": 6, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:55.160000-07:00", 
+            "write_ts": 1470791995.16, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90340"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0865361, 
+                    37.3902615
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:19:57-07:00", 
+            "altitude": 0.70001220703125, 
+            "ts": 1470791997, 
+            "longitude": -122.0865361, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343693590980091, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "latitude": 37.3902615, 
+            "heading": 6, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:19:55.846000-07:00", 
+            "write_ts": 1470791995.846, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 19
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90341"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086516, 
+                    37.3903
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:03-07:00", 
+            "altitude": 0.20001220703125, 
+            "ts": 1470792003, 
+            "longitude": -122.086516, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343699507483997, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3903, 
+            "heading": 23, 
+            "sensed_speed": 1.1259, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:01.086000-07:00", 
+            "write_ts": 1470792001.086, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90342"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086516, 
+                    37.3903
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:03-07:00", 
+            "altitude": 0.20001220703125, 
+            "ts": 1470792003, 
+            "longitude": -122.086516, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343699507483997, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 3, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3903, 
+            "heading": 23, 
+            "sensed_speed": 1.1259, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:01.947000-07:00", 
+            "write_ts": 1470792001.947, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90343"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864782, 
+                    37.3903442
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:08-07:00", 
+            "altitude": 0.100006103515625, 
+            "ts": 1470792008, 
+            "longitude": -122.0864782, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343704663886585, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3903442, 
+            "heading": 31, 
+            "sensed_speed": 1.18845, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:06.228000-07:00", 
+            "write_ts": 1470792006.228, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 6, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90344"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864782, 
+                    37.3903442
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:08-07:00", 
+            "altitude": 0.100006103515625, 
+            "ts": 1470792008, 
+            "longitude": -122.0864782, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343704663886585, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3903442, 
+            "heading": 31, 
+            "sensed_speed": 1.18845, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:07.053000-07:00", 
+            "write_ts": 1470792007.053, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 7, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90345"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 66, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "ts": 1470792008.591, 
+            "fmt_time": "2016-08-09T18:20:08.591000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:08.591000-07:00", 
+            "write_ts": 1470792008.591, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90346"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864364, 
+                    37.3903888
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:14-07:00", 
+            "altitude": -0.20001220703125, 
+            "ts": 1470792014, 
+            "longitude": -122.0864364, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343710532996692, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3903888, 
+            "heading": 43, 
+            "sensed_speed": 1.0008, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:12.165000-07:00", 
+            "write_ts": 1470792012.165, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90347"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864364, 
+                    37.3903888
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:14-07:00", 
+            "altitude": -0.20001220703125, 
+            "ts": 1470792014, 
+            "longitude": -122.0864364, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343710532996692, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 14, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3903888, 
+            "heading": 43, 
+            "sensed_speed": 1.0008, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:12.877000-07:00", 
+            "write_ts": 1470792012.877, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90348"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864138, 
+                    37.3904352
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:19-07:00", 
+            "altitude": -0.399993896484375, 
+            "ts": 1470792019, 
+            "longitude": -122.0864138, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343715611915149, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904352, 
+            "heading": 27, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:17.231000-07:00", 
+            "write_ts": 1470792017.231, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90349"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864138, 
+                    37.3904352
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:19-07:00", 
+            "altitude": -0.399993896484375, 
+            "ts": 1470792019, 
+            "longitude": -122.0864138, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343715611915149, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 19, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904352, 
+            "heading": 27, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:17.964000-07:00", 
+            "write_ts": 1470792017.964, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9034a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864376, 
+                    37.3904436
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:25-07:00", 
+            "altitude": 0.399993896484375, 
+            "ts": 1470792025, 
+            "longitude": -122.0864376, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343721505744495, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904436, 
+            "heading": 206, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:23.097000-07:00", 
+            "write_ts": 1470792023.097, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 23, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9034b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864376, 
+                    37.3904436
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:25-07:00", 
+            "altitude": 0.399993896484375, 
+            "ts": 1470792025, 
+            "longitude": -122.0864376, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343721505744495, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 25, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904436, 
+            "heading": 206, 
+            "sensed_speed": 0.43785, 
+            "accuracy": 10
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:23.882000-07:00", 
+            "write_ts": 1470792023.882, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 23, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9034c"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864416, 
+                    37.3904435
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:30-07:00", 
+            "altitude": 0.70001220703125, 
+            "ts": 1470792030, 
+            "longitude": -122.0864416, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343726590339222, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904435, 
+            "heading": 242, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:28.365000-07:00", 
+            "write_ts": 1470792028.365, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9034d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864416, 
+                    37.3904435
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:30-07:00", 
+            "altitude": 0.70001220703125, 
+            "ts": 1470792030, 
+            "longitude": -122.0864416, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343726590339222, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904435, 
+            "heading": 242, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:29.180000-07:00", 
+            "write_ts": 1470792029.18, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 29, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9034e"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864283, 
+                    37.390455
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:35-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792035, 
+            "longitude": -122.0864283, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343731604865589, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 35, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.390455, 
+            "heading": 354, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:33.202000-07:00", 
+            "write_ts": 1470792033.202, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 33, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9034f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864283, 
+                    37.390455
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:35-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792035, 
+            "longitude": -122.0864283, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343731604865589, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 35, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.390455, 
+            "heading": 354, 
+            "sensed_speed": 0.18765001, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:34.010000-07:00", 
+            "write_ts": 1470792034.01, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 34, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90350"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864294, 
+                    37.3904543
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:41-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792041, 
+            "longitude": -122.0864294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343737513190784, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904543, 
+            "heading": 349, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:39.102000-07:00", 
+            "write_ts": 1470792039.102, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 39, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90351"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864294, 
+                    37.3904543
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:41-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792041, 
+            "longitude": -122.0864294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343737513190784, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 41, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904543, 
+            "heading": 349, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:39.871000-07:00", 
+            "write_ts": 1470792039.871, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 39, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90352"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864294, 
+                    37.3904543
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:46-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792046, 
+            "longitude": -122.0864294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343742552283802, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904543, 
+            "heading": 349, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:44.135000-07:00", 
+            "write_ts": 1470792044.135, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90353"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864294, 
+                    37.3904543
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:46-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792046, 
+            "longitude": -122.0864294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343742552283802, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904543, 
+            "heading": 349, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:44.842000-07:00", 
+            "write_ts": 1470792044.842, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90354"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864294, 
+                    37.3904543
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:51-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792051, 
+            "longitude": -122.0864294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343747562324085, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904543, 
+            "heading": 349, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:49.185000-07:00", 
+            "write_ts": 1470792049.185, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 49, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90355"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864294, 
+                    37.3904543
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:51-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792051, 
+            "longitude": -122.0864294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343747562324085, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904543, 
+            "heading": 349, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:50.420000-07:00", 
+            "write_ts": 1470792050.42, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90356"
+        }, 
+        "data": {
+            "type": 4, 
+            "confidence": 39, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "ts": 1470792051.294, 
+            "fmt_time": "2016-08-09T18:20:51.294000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:51.294000-07:00", 
+            "write_ts": 1470792051.294, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90357"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864294, 
+                    37.3904543
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:56-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792056, 
+            "longitude": -122.0864294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343752572883167, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 56, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904543, 
+            "heading": 349, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:54.141000-07:00", 
+            "write_ts": 1470792054.141, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 54, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90358"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864294, 
+                    37.3904543
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:20:56-07:00", 
+            "altitude": 0.899993896484375, 
+            "ts": 1470792056, 
+            "longitude": -122.0864294, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343752572883167, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 56, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "latitude": 37.3904543, 
+            "heading": 349, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:54.991000-07:00", 
+            "write_ts": 1470792054.991, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 54, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90359"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864657, 
+                    37.3904546
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:21:01-07:00", 
+            "altitude": 0.79998779296875, 
+            "ts": 1470792061, 
+            "longitude": -122.0864657, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343757584723987, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 21
+            }, 
+            "latitude": 37.3904546, 
+            "heading": 242, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:20:59.178000-07:00", 
+            "write_ts": 1470792059.178, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 59, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 20
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9035a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864657, 
+                    37.3904546
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:21:01-07:00", 
+            "altitude": 0.79998779296875, 
+            "ts": 1470792061, 
+            "longitude": -122.0864657, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343757584723987, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 1, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 21
+            }, 
+            "latitude": 37.3904546, 
+            "heading": 242, 
+            "sensed_speed": 0, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:21:15.239000-07:00", 
+            "write_ts": 1470792075.239, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 15, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 21
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9035b"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 48, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 21
+            }, 
+            "ts": 1470792104.146, 
+            "fmt_time": "2016-08-09T18:21:44.146000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:21:44.146000-07:00", 
+            "write_ts": 1470792104.146, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 21
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9035c"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866887, 
+                    37.3905428
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:21:50-07:00", 
+            "altitude": 10.20001220703125, 
+            "ts": 1470792110, 
+            "longitude": -122.0866887, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343806703223731, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 21
+            }, 
+            "latitude": 37.3905428, 
+            "heading": 323, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:21:48.336000-07:00", 
+            "write_ts": 1470792108.336, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 21
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9035d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0866887, 
+                    37.3905428
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:21:50-07:00", 
+            "altitude": 10.20001220703125, 
+            "ts": 1470792110, 
+            "longitude": -122.0866887, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343806703223731, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 50, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 21
+            }, 
+            "latitude": 37.3905428, 
+            "heading": 323, 
+            "sensed_speed": 1.06335, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:22:08.566000-07:00", 
+            "write_ts": 1470792128.566, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 8, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9035e"
+        }, 
+        "data": {
+            "type": 2, 
+            "confidence": 85, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "ts": 1470792132.859, 
+            "fmt_time": "2016-08-09T18:22:12.859000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:22:12.859000-07:00", 
+            "write_ts": 1470792132.859, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9035f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864519, 
+                    37.3908412
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:22:15.081000-07:00", 
+            "altitude": 0, 
+            "ts": 1470792135.081, 
+            "longitude": -122.0864519, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343833706000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 15, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "latitude": 37.3908412, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 20.299
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:22:15.365000-07:00", 
+            "write_ts": 1470792135.365, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 15, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90360"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0864519, 
+                    37.3908412
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:22:15.081000-07:00", 
+            "altitude": 0, 
+            "ts": 1470792135.081, 
+            "longitude": -122.0864519, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343833706000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 15, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "latitude": 37.3908412, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 20.299
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:22:18.135000-07:00", 
+            "write_ts": 1470792138.135, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 18, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90361"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086523, 
+                    37.39069
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:22:44-07:00", 
+            "altitude": 24.0999755859375, 
+            "ts": 1470792164, 
+            "longitude": -122.086523, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343861281287677, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "latitude": 37.39069, 
+            "heading": 126, 
+            "sensed_speed": 1.6263, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:22:42.884000-07:00", 
+            "write_ts": 1470792162.884, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90362"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.086523, 
+                    37.39069
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:22:44-07:00", 
+            "altitude": 24.0999755859375, 
+            "ts": 1470792164, 
+            "longitude": -122.086523, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343861281287677, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 44, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "latitude": 37.39069, 
+            "heading": 126, 
+            "sensed_speed": 1.6263, 
+            "accuracy": 5
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:22:43.589000-07:00", 
+            "write_ts": 1470792163.589, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 43, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 22
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90363"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 40, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 18, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "ts": 1470792198.092, 
+            "fmt_time": "2016-08-09T18:23:18.092000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:23:18.092000-07:00", 
+            "write_ts": 1470792198.092, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 18, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90364"
+        }, 
+        "data": {
+            "type": 5, 
+            "confidence": 100, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 18, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "ts": 1470792198.253, 
+            "fmt_time": "2016-08-09T18:23:18.253000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:23:18.253000-07:00", 
+            "write_ts": 1470792198.253, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 18, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90365"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0861767, 
+                    37.3905527
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:23:32-07:00", 
+            "altitude": -51.20001220703125, 
+            "ts": 1470792212, 
+            "longitude": -122.0861767, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343908780616261, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "latitude": 37.3905527, 
+            "heading": 181, 
+            "sensed_speed": 4.7538, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:23:30.426000-07:00", 
+            "write_ts": 1470792210.426, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 30, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90366"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0861767, 
+                    37.3905527
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:23:32-07:00", 
+            "altitude": -51.20001220703125, 
+            "ts": 1470792212, 
+            "longitude": -122.0861767, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343908780616261, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 32, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "latitude": 37.3905527, 
+            "heading": 181, 
+            "sensed_speed": 4.7538, 
+            "accuracy": 15
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:23:42.297000-07:00", 
+            "write_ts": 1470792222.297, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 42, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90367"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863534, 
+                    37.3908404
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:23:46.472000-07:00", 
+            "altitude": 0, 
+            "ts": 1470792226.472, 
+            "longitude": -122.0863534, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343925097000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "latitude": 37.3908404, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 30
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:23:46.845000-07:00", 
+            "write_ts": 1470792226.845, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90368"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863534, 
+                    37.3908404
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:23:46.472000-07:00", 
+            "altitude": 0, 
+            "ts": 1470792226.472, 
+            "longitude": -122.0863534, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343925097000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 46, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "latitude": 37.3908404, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 30
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:23:47.686000-07:00", 
+            "write_ts": 1470792227.686, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 23
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90369"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 95, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "ts": 1470792252.012, 
+            "fmt_time": "2016-08-09T18:24:12.012000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:24:12.012000-07:00", 
+            "write_ts": 1470792252.012, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 12, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9036a"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863187, 
+                    37.390994
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:24:17.605000-07:00", 
+            "altitude": 0, 
+            "ts": 1470792257.605, 
+            "longitude": -122.0863187, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343956229000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "latitude": 37.390994, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 19.68
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:24:17.873000-07:00", 
+            "write_ts": 1470792257.873, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9036b"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863187, 
+                    37.390994
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:24:17.605000-07:00", 
+            "altitude": 0, 
+            "ts": 1470792257.605, 
+            "longitude": -122.0863187, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343956229000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 17, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "latitude": 37.390994, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 19.68
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:24:18.562000-07:00", 
+            "write_ts": 1470792258.562, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 18, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9036c"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 92, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "ts": 1470792260.092, 
+            "fmt_time": "2016-08-09T18:24:20.092000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:24:20.092000-07:00", 
+            "write_ts": 1470792260.092, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 20, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9036d"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863232, 
+                    37.3908399
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:24:47.616000-07:00", 
+            "altitude": 0, 
+            "ts": 1470792287.616, 
+            "longitude": -122.0863232, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343986241000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "latitude": 37.3908399, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 30
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:24:48.110000-07:00", 
+            "write_ts": 1470792288.11, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "key": "background/location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9036e"
+        }, 
+        "data": {
+            "type": 3, 
+            "confidence": 77, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "ts": 1470792288.896, 
+            "fmt_time": "2016-08-09T18:24:48.896000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:24:48.896000-07:00", 
+            "write_ts": 1470792288.896, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "key": "background/motion_activity", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd9036f"
+        }, 
+        "data": {
+            "loc": {
+                "type": "Point", 
+                "coordinates": [
+                    -122.0863232, 
+                    37.3908399
+                ]
+            }, 
+            "fmt_time": "2016-08-09T18:24:47.616000-07:00", 
+            "altitude": 0, 
+            "ts": 1470792287.616, 
+            "longitude": -122.0863232, 
+            "filter": "time", 
+            "elapsedRealtimeNanos": 343986241000000, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 47, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "latitude": 37.3908399, 
+            "heading": 0, 
+            "sensed_speed": 0, 
+            "accuracy": 30
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:24:48.962000-07:00", 
+            "write_ts": 1470792288.962, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 48, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "key": "background/filtered_location", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57aa88bdf311e474bfd90370"
+        }, 
+        "data": {
+            "curr_state": 2, 
+            "transition": 2, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "ts": 1470792291.74, 
+            "fmt_time": "2016-08-09T18:24:51.740000-07:00"
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:24:51.740000-07:00", 
+            "write_ts": 1470792291.74, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 51, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 24
+            }, 
+            "key": "statemachine/transition", 
+            "read_ts": 0, 
+            "type": "message"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57ab63cef311e474bfd97221"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 300, 
+            "fmt_time": "2016-08-09T18:52:57.902000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470793977.902, 
+            "local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 52
+            }, 
+            "battery_status": 1, 
+            "android_plugged": "UNKNOWN", 
+            "android_voltage": 300, 
+            "battery_level_pct": 85
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T18:52:57.902000-07:00", 
+            "write_ts": 1470793977.902, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 18, 
+                "month": 8, 
+                "second": 57, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 52
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57ab63cef311e474bfd97222"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 290, 
+            "fmt_time": "2016-08-09T20:41:55.430000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470800515.43, 
+            "local_dt": {
+                "hour": 20, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 41
+            }, 
+            "battery_status": 1, 
+            "android_plugged": "UNKNOWN", 
+            "android_voltage": 290, 
+            "battery_level_pct": 84
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T20:41:55.430000-07:00", 
+            "write_ts": 1470800515.43, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 20, 
+                "month": 8, 
+                "second": 55, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 41
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57ab63cef311e474bfd97223"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 290, 
+            "fmt_time": "2016-08-09T21:44:28.087000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470804268.087, 
+            "local_dt": {
+                "hour": 21, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "battery_status": 1, 
+            "android_plugged": "UNKNOWN", 
+            "android_voltage": 290, 
+            "battery_level_pct": 82
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T21:44:28.087000-07:00", 
+            "write_ts": 1470804268.087, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 21, 
+                "month": 8, 
+                "second": 28, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 44
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }, 
+    {
+        "user_id": {
+            "$uuid": "0763de67f61e3f5d90e7518e69793954"
+        }, 
+        "_id": {
+            "$oid": "57ab63cef311e474bfd97224"
+        }, 
+        "data": {
+            "android_health": "GOOD", 
+            "android_temperature": 290, 
+            "fmt_time": "2016-08-09T23:05:21.661000-07:00", 
+            "android_technology": "Li-ion", 
+            "ts": 1470809121.661, 
+            "local_dt": {
+                "hour": 23, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "battery_status": 1, 
+            "android_plugged": "UNKNOWN", 
+            "android_voltage": 290, 
+            "battery_level_pct": 80
+        }, 
+        "metadata": {
+            "write_fmt_time": "2016-08-09T23:05:21.661000-07:00", 
+            "write_ts": 1470809121.661, 
+            "time_zone": "America/Los_Angeles", 
+            "platform": "android", 
+            "write_local_dt": {
+                "hour": 23, 
+                "month": 8, 
+                "second": 21, 
+                "weekday": 1, 
+                "year": 2016, 
+                "timezone": "America/Los_Angeles", 
+                "day": 9, 
+                "minute": 5
+            }, 
+            "key": "background/battery", 
+            "read_ts": 0, 
+            "type": "sensor-data"
+        }
+    }
+]

--- a/emission/tests/data/real_examples/shankari_2016-08-910.ground_truth
+++ b/emission/tests/data/real_examples/shankari_2016-08-910.ground_truth
@@ -1,0 +1,2796 @@
+{
+    "data": [
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0865352, 
+                            37.3904407
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93cf6858f710e75686d", 
+                    "properties": {
+                        "exit_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 54, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 54
+                        }, 
+                        "display_name": "South Shoreline Boulevard, Mountain View", 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2016-08-09T17:54:54.529000-07:00", 
+                        "starting_trip": {
+                            "$oid": "57b7b93af6858f710e7567b1"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e756794"
+                            }
+                        ], 
+                        "exit_ts": 1470790494.529
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0863309, 
+                            37.3892424
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93df6858f710e75686e", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-09T18:00:46-07:00", 
+                        "exit_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 16, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 4
+                        }, 
+                        "display_name": "Franklin Street, Mountain View", 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2016-08-09T18:04:16.449000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 46, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 0
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93af6858f710e7567b1"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93af6858f710e7567c0"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470790846, 
+                        "duration": 210.44899988174438, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e756796"
+                            }
+                        ], 
+                        "exit_ts": 1470791056.449
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0865352, 
+                                        37.3904407
+                                    ], 
+                                    [
+                                        -122.0865352, 
+                                        37.3904407
+                                    ], 
+                                    [
+                                        -122.08777617268566, 
+                                        37.38846381792013
+                                    ], 
+                                    [
+                                        -122.08747057817176, 
+                                        37.38838819170788
+                                    ], 
+                                    [
+                                        -122.0865805842137, 
+                                        37.38941013424939
+                                    ], 
+                                    [
+                                        -122.08640066342475, 
+                                        37.38928675749979
+                                    ], 
+                                    [
+                                        -122.08704725135891, 
+                                        37.38885976685288
+                                    ], 
+                                    [
+                                        -122.08633855898505, 
+                                        37.38915744185317
+                                    ], 
+                                    [
+                                        -122.08629943132549, 
+                                        37.38914461206594
+                                    ], 
+                                    [
+                                        -122.08633936073258, 
+                                        37.38915654948252
+                                    ], 
+                                    [
+                                        -122.08636471153957, 
+                                        37.38916239923456
+                                    ], 
+                                    [
+                                        -122.08636075317997, 
+                                        37.38916145015461
+                                    ], 
+                                    [
+                                        -122.08634335317997, 
+                                        37.3892086319728
+                                    ], 
+                                    [
+                                        -122.0863309, 
+                                        37.3892424
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93af6858f710e7567b2", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    245.6434185232213, 
+                                    28.27811681148212, 
+                                    138.1861672890384, 
+                                    20.99703604473199, 
+                                    74.27982760916484, 
+                                    70.8223005566905, 
+                                    3.7396432950793437, 
+                                    3.7691367978829122, 
+                                    2.3322280002713147, 
+                                    0.365288251256203, 
+                                    5.466957469360804, 
+                                    3.9127012849361513
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1470790846, 
+                                "start_ts": 1470790494.529, 
+                                "start_fmt_time": "2016-08-09T17:54:54.529000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-09T18:00:46-07:00", 
+                                "end_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 46, 
+                                    "weekday": 1, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 9, 
+                                    "minute": 0
+                                }, 
+                                "duration": 351.470999956131, 
+                                "trip_id": {
+                                    "$oid": "57b7b93af6858f710e7567b1"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 54, 
+                                    "weekday": 1, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 9, 
+                                    "minute": 54
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    8.188113950774044, 
+                                    0.9426038937160707, 
+                                    4.60620557630128, 
+                                    0.6999012014910663, 
+                                    2.475994253638828, 
+                                    2.360743351889683, 
+                                    0.1246547765026448, 
+                                    0.12563789326276373, 
+                                    0.07774093334237715, 
+                                    0.012176275041873434, 
+                                    0.18223191564536015, 
+                                    0.18223190782592735
+                                ], 
+                                "distance": 597.7928219331158
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57b7b93af6858f710e7567b1", 
+            "properties": {
+                "distance": 597.7928219331158, 
+                "end_place": {
+                    "$oid": "57b7b93df6858f710e75686e"
+                }, 
+                "raw_trip": {
+                    "$oid": "57b7b939f6858f710e756795"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0865352, 
+                        37.3904407
+                    ]
+                }, 
+                "end_ts": 1470790846, 
+                "start_ts": 1470790494.529, 
+                "start_fmt_time": "2016-08-09T17:54:54.529000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0863309, 
+                        37.3892424
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57b7b93cf6858f710e75686d"
+                }, 
+                "end_fmt_time": "2016-08-09T18:00:46-07:00", 
+                "end_local_dt": {
+                    "hour": 18, 
+                    "month": 8, 
+                    "second": 46, 
+                    "weekday": 1, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 9, 
+                    "minute": 0
+                }, 
+                "duration": 351.470999956131, 
+                "start_local_dt": {
+                    "hour": 17, 
+                    "month": 8, 
+                    "second": 54, 
+                    "weekday": 1, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 9, 
+                    "minute": 54
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0863309, 
+                            37.3892424
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93df6858f710e75686e", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-09T18:00:46-07:00", 
+                        "exit_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 16, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 4
+                        }, 
+                        "display_name": "Franklin Street, Mountain View", 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2016-08-09T18:04:16.449000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 46, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 0
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93af6858f710e7567b1"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93af6858f710e7567c0"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470790846, 
+                        "duration": 210.44899988174438, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e756796"
+                            }
+                        ], 
+                        "exit_ts": 1470791056.449
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0864294, 
+                            37.3904543
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93df6858f710e75686f", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-09T18:20:41-07:00", 
+                        "exit_local_dt": {
+                            "hour": 9, 
+                            "month": 8, 
+                            "second": 59, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 53
+                        }, 
+                        "display_name": "South Shoreline Boulevard, Mountain View", 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2016-08-10T09:53:59.425000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 41, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 20
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93af6858f710e7567c0"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93bf6858f710e7567e8"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470792041, 
+                        "duration": 55998.424999952316, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e756798"
+                            }
+                        ], 
+                        "exit_ts": 1470848039.425
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.086294, 
+                                37.3894812
+                            ], 
+                            [
+                                -122.0863195, 
+                                37.3895114
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93bf6858f710e7567e7", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-09T18:18:26-07:00", 
+                        "exit_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 32, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 18
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57b7b93af6858f710e7567c1"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57b7b93bf6858f710e7567e0"
+                        }, 
+                        "exit_fmt_time": "2016-08-09T18:18:32-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 26, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 18
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0863195, 
+                                37.3895114
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.086294, 
+                                37.3894812
+                            ]
+                        }, 
+                        "enter_ts": 1470791906, 
+                        "duration": 6, 
+                        "_id": {
+                            "$oid": "57b7b93af6858f710e7567c0"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57b7b93af6858f710e7567c0"
+                        }, 
+                        "exit_ts": 1470791912
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0863309, 
+                                        37.3892424
+                                    ], 
+                                    [
+                                        -122.0868957, 
+                                        37.3904819
+                                    ], 
+                                    [
+                                        -122.08761501468106, 
+                                        37.38862887188535
+                                    ], 
+                                    [
+                                        -122.08648618906979, 
+                                        37.38891793850548
+                                    ], 
+                                    [
+                                        -122.08636682832312, 
+                                        37.389032668910474
+                                    ], 
+                                    [
+                                        -122.08631401582312, 
+                                        37.389018481410474
+                                    ], 
+                                    [
+                                        -122.08632976601218, 
+                                        37.38907678075884
+                                    ], 
+                                    [
+                                        -122.08646500798925, 
+                                        37.389289882632305
+                                    ], 
+                                    [
+                                        -122.08647344230525, 
+                                        37.389609245897496
+                                    ], 
+                                    [
+                                        -122.08638878233789, 
+                                        37.38916726163996
+                                    ], 
+                                    [
+                                        -122.08640049741636, 
+                                        37.389160511346255
+                                    ], 
+                                    [
+                                        -122.08693637997484, 
+                                        37.388933254170425
+                                    ], 
+                                    [
+                                        -122.086359479611, 
+                                        37.38917159080562
+                                    ], 
+                                    [
+                                        -122.08660298258035, 
+                                        37.388919915425866
+                                    ], 
+                                    [
+                                        -122.08707078706033, 
+                                        37.388582995595506
+                                    ], 
+                                    [
+                                        -122.08645041793979, 
+                                        37.38920154154692
+                                    ], 
+                                    [
+                                        -122.08659584835608, 
+                                        37.38895312503623
+                                    ], 
+                                    [
+                                        -122.08651264061827, 
+                                        37.38918745961853
+                                    ], 
+                                    [
+                                        -122.08648684240839, 
+                                        37.38902459507327
+                                    ], 
+                                    [
+                                        -122.0868510426844, 
+                                        37.3886648232887
+                                    ], 
+                                    [
+                                        -122.0863583723465, 
+                                        37.38920286271006
+                                    ], 
+                                    [
+                                        -122.08673283487964, 
+                                        37.389031702560615
+                                    ], 
+                                    [
+                                        -122.08689173039282, 
+                                        37.38894918799886
+                                    ], 
+                                    [
+                                        -122.08713445851905, 
+                                        37.38880247159341
+                                    ], 
+                                    [
+                                        -122.08706549646092, 
+                                        37.388719135479526
+                                    ], 
+                                    [
+                                        -122.08631137629936, 
+                                        37.38898370594903
+                                    ], 
+                                    [
+                                        -122.0863438784197, 
+                                        37.389140139980114
+                                    ], 
+                                    [
+                                        -122.08631962648029, 
+                                        37.389064867041775
+                                    ], 
+                                    [
+                                        -122.08636559914025, 
+                                        37.38916683279915
+                                    ], 
+                                    [
+                                        -122.08629434856007, 
+                                        37.38941272015907
+                                    ], 
+                                    [
+                                        -122.086294, 
+                                        37.3894812
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93af6858f710e7567c1", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    215.62474347551057, 
+                                    104.78143987018686, 
+                                    16.55158355844802, 
+                                    4.925351076829967, 
+                                    6.630252814161936, 
+                                    26.53780740961876, 
+                                    35.51939182006712, 
+                                    49.71229273395158, 
+                                    1.278523438909769, 
+                                    53.66584481701603, 
+                                    57.44623586902007, 
+                                    35.29828024864098, 
+                                    55.78238668662744, 
+                                    87.94617530962394, 
+                                    30.4646314898379, 
+                                    27.07393742345045, 
+                                    18.25257378663355, 
+                                    51.339096857905616, 
+                                    73.98545597344253, 
+                                    38.16675142587884, 
+                                    16.770566996405176, 
+                                    26.94473707439051, 
+                                    11.09006821560023, 
+                                    72.83106847674833, 
+                                    17.630088459361083, 
+                                    8.639856976148806, 
+                                    12.043602704847252, 
+                                    28.05669736833482, 
+                                    7.6146731561314915
+                                ], 
+                                "end_ts": 1470791906, 
+                                "feature_type": "section", 
+                                "distance": 1192.6041155137295, 
+                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
+                                "start_ts": 1470791056.449, 
+                                "start_fmt_time": "2016-08-09T18:04:16.449000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-09T18:18:26-07:00", 
+                                "end_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 26, 
+                                    "weekday": 1, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 9, 
+                                    "minute": 18
+                                }, 
+                                "duration": 849.5510001182556, 
+                                "end_stop": {
+                                    "$oid": "57b7b93bf6858f710e7567e7"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57b7b93af6858f710e7567c0"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 16, 
+                                    "weekday": 1, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 9, 
+                                    "minute": 4
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    7.187491449183685, 
+                                    3.4927146623395617, 
+                                    0.5517194519482673, 
+                                    0.16417836922766557, 
+                                    0.2210084271387312, 
+                                    0.8845935803206254, 
+                                    1.1839797273355708, 
+                                    1.6570764244650527, 
+                                    0.04261744796365897, 
+                                    1.7888614939005343, 
+                                    1.9148745289673357, 
+                                    1.1766093416213659, 
+                                    1.859412889554248, 
+                                    2.9315391769874646, 
+                                    1.01548771632793, 
+                                    0.9024645807816817, 
+                                    0.6084191262211184, 
+                                    1.711303228596854, 
+                                    2.4661818657814174, 
+                                    1.2722250475292947, 
+                                    0.5590188998801725, 
+                                    0.8981579024796836, 
+                                    0.36966894052000765, 
+                                    2.4277022825582777, 
+                                    0.5876696153120361, 
+                                    0.28799523253829357, 
+                                    0.4014534234949084, 
+                                    0.9352232456111607, 
+                                    0.7972644813999047
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0863195, 
+                                        37.3895114
+                                    ], 
+                                    [
+                                        -122.0865573, 
+                                        37.389751733333334
+                                    ], 
+                                    [
+                                        -122.0866335, 
+                                        37.3900585
+                                    ], 
+                                    [
+                                        -122.08651935, 
+                                        37.39029358333334
+                                    ], 
+                                    [
+                                        -122.08643628, 
+                                        37.3904481
+                                    ], 
+                                    [
+                                        -122.0864294, 
+                                        37.3904543
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93bf6858f710e7567e0", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    33.99322802604324, 
+                                    34.76885737073619, 
+                                    28.017951493885036, 
+                                    18.683218427675378, 
+                                    0.9190924677307348
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1470792041, 
+                                "start_ts": 1470791912, 
+                                "start_fmt_time": "2016-08-09T18:18:32-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-09T18:20:41-07:00", 
+                                "end_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 41, 
+                                    "weekday": 1, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 9, 
+                                    "minute": 20
+                                }, 
+                                "duration": 129, 
+                                "start_stop": {
+                                    "$oid": "57b7b93bf6858f710e7567e7"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57b7b93af6858f710e7567c0"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 32, 
+                                    "weekday": 1, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 9, 
+                                    "minute": 18
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    1.133107600868108, 
+                                    1.1589619123578732, 
+                                    0.9339317164628346, 
+                                    0.6227739475891793, 
+                                    0.10212138530341498
+                                ], 
+                                "distance": 116.3823477860706
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57b7b93af6858f710e7567c0", 
+            "properties": {
+                "distance": 1308.9864632998, 
+                "end_place": {
+                    "$oid": "57b7b93df6858f710e75686f"
+                }, 
+                "raw_trip": {
+                    "$oid": "57b7b939f6858f710e756797"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0868957, 
+                        37.3904819
+                    ]
+                }, 
+                "end_ts": 1470792041, 
+                "start_ts": 1470791056.449, 
+                "start_fmt_time": "2016-08-09T18:04:16.449000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0864294, 
+                        37.3904543
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57b7b93df6858f710e75686e"
+                }, 
+                "end_fmt_time": "2016-08-09T18:20:41-07:00", 
+                "end_local_dt": {
+                    "hour": 18, 
+                    "month": 8, 
+                    "second": 41, 
+                    "weekday": 1, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 9, 
+                    "minute": 20
+                }, 
+                "duration": 984.5510001182556, 
+                "start_local_dt": {
+                    "hour": 18, 
+                    "month": 8, 
+                    "second": 16, 
+                    "weekday": 1, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 9, 
+                    "minute": 4
+                }
+            }
+        },
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0864294, 
+                            37.3904543
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93df6858f710e75686f", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-09T18:20:41-07:00", 
+                        "exit_local_dt": {
+                            "hour": 9, 
+                            "month": 8, 
+                            "second": 59, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 53
+                        }, 
+                        "display_name": "South Shoreline Boulevard, Mountain View", 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2016-08-10T09:53:59.425000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 41, 
+                            "weekday": 1, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 9, 
+                            "minute": 20
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93af6858f710e7567c0"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93bf6858f710e7567e8"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470792041, 
+                        "duration": 55998.424999952316, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e756798"
+                            }
+                        ], 
+                        "exit_ts": 1470848039.425
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.080127, 
+                            37.3915176
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93df6858f710e756870", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T10:02:11-07:00", 
+                        "exit_local_dt": {
+                            "hour": 11, 
+                            "month": 8, 
+                            "second": 5, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 7
+                        }, 
+                        "display_name": "Castro Street, Mountain View", 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2016-08-10T11:07:05.684000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 10, 
+                            "month": 8, 
+                            "second": 11, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 2
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93bf6858f710e7567e8"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93bf6858f710e7567fc"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470848531, 
+                        "duration": 3894.684000015259, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e75679a"
+                            }
+                        ], 
+                        "exit_ts": 1470852425.684
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0864294, 
+                                        37.3904543
+                                    ], 
+                                    [
+                                        -122.0858305, 
+                                        37.3917793
+                                    ], 
+                                    [
+                                        -122.08537282779167, 
+                                        37.391511841568104
+                                    ], 
+                                    [
+                                        -122.08510014585269, 
+                                        37.39142376579558
+                                    ], 
+                                    [
+                                        -122.0847154571162, 
+                                        37.391343179871924
+                                    ], 
+                                    [
+                                        -122.08430593330648, 
+                                        37.39125940960199
+                                    ], 
+                                    [
+                                        -122.0840818006048, 
+                                        37.3911368053587
+                                    ], 
+                                    [
+                                        -122.08301843890759, 
+                                        37.39086880156769
+                                    ], 
+                                    [
+                                        -122.08270862757168, 
+                                        37.39114337246399
+                                    ], 
+                                    [
+                                        -122.0824928682706, 
+                                        37.39122342811127
+                                    ], 
+                                    [
+                                        -122.08199921442373, 
+                                        37.39116680615346
+                                    ], 
+                                    [
+                                        -122.08163715369717, 
+                                        37.391414031885034
+                                    ], 
+                                    [
+                                        -122.08143302635243, 
+                                        37.39156943978985
+                                    ], 
+                                    [
+                                        -122.08092502884415, 
+                                        37.39148979082755
+                                    ], 
+                                    [
+                                        -122.0805555366669, 
+                                        37.39150387797626
+                                    ], 
+                                    [
+                                        -122.0804075366669, 
+                                        37.391460306547685
+                                    ], 
+                                    [
+                                        -122.08044281342046, 
+                                        37.391562174609206
+                                    ], 
+                                    [
+                                        -122.08028984746466, 
+                                        37.39161687266984
+                                    ], 
+                                    [
+                                        -122.080127, 
+                                        37.3915176
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93bf6858f710e7567e9", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    50.19253117592342, 
+                                    26.004721359874136, 
+                                    35.14680914560237, 
+                                    37.359301918018666, 
+                                    24.04037900897706, 
+                                    98.55660375838266, 
+                                    41.003362285350065, 
+                                    21.037475483697616, 
+                                    44.06409915828464, 
+                                    42.17626640781854, 
+                                    24.97657362678435, 
+                                    45.7445127934866, 
+                                    32.68031062234388, 
+                                    13.943820568329906, 
+                                    11.748124267230178, 
+                                    14.819372918227351, 
+                                    18.133643977259673
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1470848531, 
+                                "start_ts": 1470848039.425, 
+                                "start_fmt_time": "2016-08-10T09:53:59.425000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-10T10:02:11-07:00", 
+                                "end_local_dt": {
+                                    "hour": 10, 
+                                    "month": 8, 
+                                    "second": 11, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 2
+                                }, 
+                                "duration": 491.5750000476837, 
+                                "trip_id": {
+                                    "$oid": "57b7b93bf6858f710e7567e8"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 9, 
+                                    "month": 8, 
+                                    "second": 59, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 53
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    1.6730843725307807, 
+                                    0.8668240453291378, 
+                                    1.1715603048534122, 
+                                    1.2453100639339556, 
+                                    0.801345966965902, 
+                                    3.285220125279422, 
+                                    1.3667787428450022, 
+                                    0.7012491827899205, 
+                                    1.4688033052761547, 
+                                    1.4058755469272846, 
+                                    0.832552454226145, 
+                                    1.52481709311622, 
+                                    1.0893436874114628, 
+                                    0.4647940189443302, 
+                                    0.3916041422410059, 
+                                    0.49397909727424505, 
+                                    1.5666215034606772
+                                ], 
+                                "distance": 581.6279084755912
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57b7b93bf6858f710e7567e8", 
+            "properties": {
+                "distance": 581.6279084755912, 
+                "end_place": {
+                    "$oid": "57b7b93df6858f710e756870"
+                }, 
+                "raw_trip": {
+                    "$oid": "57b7b939f6858f710e756799"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0858305, 
+                        37.3917793
+                    ]
+                }, 
+                "end_ts": 1470848531, 
+                "start_ts": 1470848039.425, 
+                "start_fmt_time": "2016-08-10T09:53:59.425000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.080127, 
+                        37.3915176
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57b7b93df6858f710e75686f"
+                }, 
+                "end_fmt_time": "2016-08-10T10:02:11-07:00", 
+                "end_local_dt": {
+                    "hour": 10, 
+                    "month": 8, 
+                    "second": 11, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 2
+                }, 
+                "duration": 491.5750000476837, 
+                "start_local_dt": {
+                    "hour": 9, 
+                    "month": 8, 
+                    "second": 59, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 53
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.080127, 
+                            37.3915176
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93df6858f710e756870", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T10:02:11-07:00", 
+                        "exit_local_dt": {
+                            "hour": 11, 
+                            "month": 8, 
+                            "second": 5, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 7
+                        }, 
+                        "display_name": "Castro Street, Mountain View", 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2016-08-10T11:07:05.684000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 10, 
+                            "month": 8, 
+                            "second": 11, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 2
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93bf6858f710e7567e8"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93bf6858f710e7567fc"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470848531, 
+                        "duration": 3894.684000015259, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e75679a"
+                            }
+                        ], 
+                        "exit_ts": 1470852425.684
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0864519, 
+                            37.3908412
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93ef6858f710e756871", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T11:14:45.512000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 37, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 43
+                        }, 
+                        "display_name": "South Shoreline Boulevard, Mountain View", 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2016-08-10T17:43:37.535000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 11, 
+                            "month": 8, 
+                            "second": 45, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 14
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93bf6858f710e7567fc"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93bf6858f710e75680f"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470852885.512, 
+                        "duration": 23332.023000001907, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e75679c"
+                            }
+                        ], 
+                        "exit_ts": 1470876217.535
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.080127, 
+                                        37.3915176
+                                    ], 
+                                    [
+                                        -122.0817472, 
+                                        37.3918142
+                                    ], 
+                                    [
+                                        -122.0822610129342, 
+                                        37.39110181129342
+                                    ], 
+                                    [
+                                        -122.08253085703694, 
+                                        37.390891196594055
+                                    ], 
+                                    [
+                                        -122.0827323845224, 
+                                        37.39069831965175
+                                    ], 
+                                    [
+                                        -122.08296269740282, 
+                                        37.390918126798354
+                                    ], 
+                                    [
+                                        -122.08333276625503, 
+                                        37.39103371883557
+                                    ], 
+                                    [
+                                        -122.08378648877614, 
+                                        37.39109714803716
+                                    ], 
+                                    [
+                                        -122.08435327746311, 
+                                        37.39121180714294
+                                    ], 
+                                    [
+                                        -122.08453748253947, 
+                                        37.39132206801805
+                                    ], 
+                                    [
+                                        -122.08515739565426, 
+                                        37.391524193048674
+                                    ], 
+                                    [
+                                        -122.08547071784876, 
+                                        37.39164088357699
+                                    ], 
+                                    [
+                                        -122.08597019820867, 
+                                        37.39171160935963
+                                    ], 
+                                    [
+                                        -122.0862505652476, 
+                                        37.39129056969787
+                                    ], 
+                                    [
+                                        -122.08636964382985, 
+                                        37.3909126304454
+                                    ], 
+                                    [
+                                        -122.08638103883976, 
+                                        37.3910777526901
+                                    ], 
+                                    [
+                                        -122.08646849219957, 
+                                        37.39099682805972
+                                    ], 
+                                    [
+                                        -122.0864519, 
+                                        37.3908412
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93bf6858f710e7567fd", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    91.29821113377415, 
+                                    33.41833531215778, 
+                                    27.87394501781083, 
+                                    31.802368977252844, 
+                                    35.12973845097024, 
+                                    40.700073925610205, 
+                                    51.670756618749294, 
+                                    20.375220661792984, 
+                                    59.19861793464929, 
+                                    30.570649509031508, 
+                                    44.82176137365514, 
+                                    52.96582916588715, 
+                                    43.321654886770744, 
+                                    18.388333177380666, 
+                                    11.860187960227611, 
+                                    17.367023003543686
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1470852885.512, 
+                                "start_ts": 1470852425.684, 
+                                "start_fmt_time": "2016-08-10T11:07:05.684000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-10T11:14:45.512000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 11, 
+                                    "month": 8, 
+                                    "second": 45, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 14
+                                }, 
+                                "duration": 459.82800006866455, 
+                                "trip_id": {
+                                    "$oid": "57b7b93bf6858f710e7567fc"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 11, 
+                                    "month": 8, 
+                                    "second": 5, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 7
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    3.0432737044591383, 
+                                    1.1139445104052592, 
+                                    0.9291315005936943, 
+                                    1.0600789659084282, 
+                                    1.1709912816990078, 
+                                    1.3566691308536736, 
+                                    1.7223585539583097, 
+                                    0.6791740220597661, 
+                                    1.9732872644883097, 
+                                    1.0190216503010503, 
+                                    1.4940587124551714, 
+                                    1.765527638862905, 
+                                    1.4440551628923581, 
+                                    0.6129444392460222, 
+                                    0.3953395986742537, 
+                                    1.767096345360888
+                                ], 
+                                "distance": 610.7627071092639
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57b7b93bf6858f710e7567fc", 
+            "properties": {
+                "distance": 610.7627071092639, 
+                "end_place": {
+                    "$oid": "57b7b93ef6858f710e756871"
+                }, 
+                "raw_trip": {
+                    "$oid": "57b7b939f6858f710e75679b"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0817472, 
+                        37.3918142
+                    ]
+                }, 
+                "end_ts": 1470852885.512, 
+                "start_ts": 1470852425.684, 
+                "start_fmt_time": "2016-08-10T11:07:05.684000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0864519, 
+                        37.3908412
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57b7b93df6858f710e756870"
+                }, 
+                "end_fmt_time": "2016-08-10T11:14:45.512000-07:00", 
+                "end_local_dt": {
+                    "hour": 11, 
+                    "month": 8, 
+                    "second": 45, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 14
+                }, 
+                "duration": 459.82800006866455, 
+                "start_local_dt": {
+                    "hour": 11, 
+                    "month": 8, 
+                    "second": 5, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 7
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0864519, 
+                            37.3908412
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93ef6858f710e756871", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T11:14:45.512000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 37, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 43
+                        }, 
+                        "display_name": "South Shoreline Boulevard, Mountain View", 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2016-08-10T17:43:37.535000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 11, 
+                            "month": 8, 
+                            "second": 45, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 14
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93bf6858f710e7567fc"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93bf6858f710e75680f"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470852885.512, 
+                        "duration": 23332.023000001907, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e75679c"
+                            }
+                        ], 
+                        "exit_ts": 1470876217.535
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0928806, 
+                            37.3646657
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93ef6858f710e756872", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T18:00:18.899000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 4, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 11
+                        }, 
+                        "display_name": "Leonello Avenue, Los Altos", 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2016-08-10T18:11:04.989000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 18, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 0
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93bf6858f710e75680f"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93bf6858f710e756834"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470877218.899, 
+                        "duration": 646.0900001525879, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e75679e"
+                            }
+                        ], 
+                        "exit_ts": 1470877864.989
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0864519, 
+                                        37.3908412
+                                    ], 
+                                    [
+                                        -122.0872076, 
+                                        37.3886825
+                                    ], 
+                                    [
+                                        -122.08763927455159, 
+                                        37.38874295586749
+                                    ], 
+                                    [
+                                        -122.08795361605331, 
+                                        37.38831022724367
+                                    ], 
+                                    [
+                                        -122.08808041259773, 
+                                        37.388184929194985
+                                    ], 
+                                    [
+                                        -122.08816519850053, 
+                                        37.38813928743456
+                                    ], 
+                                    [
+                                        -122.08832992219713, 
+                                        37.38806485782792
+                                    ], 
+                                    [
+                                        -122.08798911087638, 
+                                        37.38727183896
+                                    ], 
+                                    [
+                                        -122.08770520508911, 
+                                        37.38652701591304
+                                    ], 
+                                    [
+                                        -122.08743304343955, 
+                                        37.38509498225636
+                                    ], 
+                                    [
+                                        -122.08726638557441, 
+                                        37.38368765038969
+                                    ], 
+                                    [
+                                        -122.08724672599995, 
+                                        37.382314735496074
+                                    ], 
+                                    [
+                                        -122.08715757862737, 
+                                        37.38112464033711
+                                    ], 
+                                    [
+                                        -122.08710278920606, 
+                                        37.379876094731074
+                                    ], 
+                                    [
+                                        -122.08716496567665, 
+                                        37.3784001535546
+                                    ], 
+                                    [
+                                        -122.08681147633361, 
+                                        37.37874695529093
+                                    ], 
+                                    [
+                                        -122.08707723519426, 
+                                        37.37573166330294
+                                    ], 
+                                    [
+                                        -122.08715898828004, 
+                                        37.37516007720236
+                                    ], 
+                                    [
+                                        -122.08712370477495, 
+                                        37.37380610917672
+                                    ], 
+                                    [
+                                        -122.08722226111007, 
+                                        37.37342123942944
+                                    ], 
+                                    [
+                                        -122.08744928914649, 
+                                        37.37297294170435
+                                    ], 
+                                    [
+                                        -122.08727555007498, 
+                                        37.371114150592994
+                                    ], 
+                                    [
+                                        -122.08717831922247, 
+                                        37.37046116857925
+                                    ], 
+                                    [
+                                        -122.08715362894155, 
+                                        37.368995624253394
+                                    ], 
+                                    [
+                                        -122.08705065668542, 
+                                        37.368115652610854
+                                    ], 
+                                    [
+                                        -122.08707326291378, 
+                                        37.36657466137815
+                                    ], 
+                                    [
+                                        -122.0871433570716, 
+                                        37.36613607838899
+                                    ], 
+                                    [
+                                        -122.08730306880462, 
+                                        37.36538707254975
+                                    ], 
+                                    [
+                                        -122.08821561325985, 
+                                        37.36506473394821
+                                    ], 
+                                    [
+                                        -122.08982049778825, 
+                                        37.36486944842835
+                                    ], 
+                                    [
+                                        -122.09155974042089, 
+                                        37.36514897914728
+                                    ], 
+                                    [
+                                        -122.09289403979128, 
+                                        37.36511780021137
+                                    ], 
+                                    [
+                                        -122.09311496110396, 
+                                        37.36488052157607
+                                    ], 
+                                    [
+                                        -122.09307750814384, 
+                                        37.36460768949195
+                                    ], 
+                                    [
+                                        -122.09288631886271, 
+                                        37.36465437848696
+                                    ], 
+                                    [
+                                        -122.0928806, 
+                                        37.3646657
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93bf6858f710e756810", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    38.725593708885896, 
+                                    55.55652602042763, 
+                                    17.877544090999397, 
+                                    9.04809809442829, 
+                                    16.741857107331324, 
+                                    93.17883876448568, 
+                                    86.53558648736245, 
+                                    161.04021947892983, 
+                                    157.1794011614434, 
+                                    152.67105270504166, 
+                                    132.56675770711865, 
+                                    138.91631569699746, 
+                                    164.2090998649367, 
+                                    49.625185579172154, 
+                                    336.10652024954516, 
+                                    63.96670187532135, 
+                                    150.58665529042904, 
+                                    43.67273032558671, 
+                                    53.73394265203236, 
+                                    207.25757065537258, 
+                                    73.11490709904957, 
+                                    162.97569989001477, 
+                                    98.27061259266151, 
+                                    171.3620528711278, 
+                                    49.16004422449743, 
+                                    84.47319201984809, 
+                                    88.25304464248507, 
+                                    143.48616205541202, 
+                                    156.81870856375826, 
+                                    117.9709393869513, 
+                                    32.82252423175112, 
+                                    30.51757485607158, 
+                                    17.676233859799616, 
+                                    1.356561317924306
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.BICYCLING", 
+                                "end_ts": 1470877218.899, 
+                                "start_ts": 1470876217.535, 
+                                "start_fmt_time": "2016-08-10T17:43:37.535000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-10T18:00:18.899000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 18, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 0
+                                }, 
+                                "duration": 1001.3639998435974, 
+                                "trip_id": {
+                                    "$oid": "57b7b93bf6858f710e75680f"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 37, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 43
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    1.2908531236295298, 
+                                    1.851884200680921, 
+                                    0.5959181363666466, 
+                                    0.3016032698142764, 
+                                    0.5580619035777108, 
+                                    3.1059612921495225, 
+                                    2.8845195495787483, 
+                                    5.368007315964328, 
+                                    5.239313372048113, 
+                                    5.089035090168055, 
+                                    4.418891923570622, 
+                                    4.6305438565665815, 
+                                    5.473636662164556, 
+                                    1.6541728526390718, 
+                                    11.203550674984838, 
+                                    2.132223395844045, 
+                                    5.019555176347635, 
+                                    1.455757677519557, 
+                                    1.791131421734412, 
+                                    6.908585688512419, 
+                                    2.437163569968319, 
+                                    5.432523329667159, 
+                                    3.2756870864220504, 
+                                    5.7120684290375925, 
+                                    1.638668140816581, 
+                                    2.8157730673282697, 
+                                    2.9417681547495023, 
+                                    4.7828720685137345, 
+                                    5.227290285458609, 
+                                    3.93236464623171, 
+                                    1.0940841410583706, 
+                                    1.017252495202386, 
+                                    0.5892077953266539, 
+                                    0.11937357766584322
+                                ], 
+                                "distance": 3357.4544551272
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57b7b93bf6858f710e75680f", 
+            "properties": {
+                "distance": 3357.4544551272, 
+                "end_place": {
+                    "$oid": "57b7b93ef6858f710e756872"
+                }, 
+                "raw_trip": {
+                    "$oid": "57b7b939f6858f710e75679d"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0872076, 
+                        37.3886825
+                    ]
+                }, 
+                "end_ts": 1470877218.899, 
+                "start_ts": 1470876217.535, 
+                "start_fmt_time": "2016-08-10T17:43:37.535000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0928806, 
+                        37.3646657
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57b7b93ef6858f710e756871"
+                }, 
+                "end_fmt_time": "2016-08-10T18:00:18.899000-07:00", 
+                "end_local_dt": {
+                    "hour": 18, 
+                    "month": 8, 
+                    "second": 18, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 0
+                }, 
+                "duration": 1001.3639998435974, 
+                "start_local_dt": {
+                    "hour": 17, 
+                    "month": 8, 
+                    "second": 37, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 43
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0928806, 
+                            37.3646657
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93ef6858f710e756872", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T18:00:18.899000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 4, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 11
+                        }, 
+                        "display_name": "Leonello Avenue, Los Altos", 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2016-08-10T18:11:04.989000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 18, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 0
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93bf6858f710e75680f"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93bf6858f710e756834"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470877218.899, 
+                        "duration": 646.0900001525879, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e75679e"
+                            }
+                        ], 
+                        "exit_ts": 1470877864.989
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0926289, 
+                            37.3610108
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93ff6858f710e756873", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T18:13:49.871000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 19, 
+                            "month": 8, 
+                            "second": 6, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 28
+                        }, 
+                        "display_name": "Altos Oaks Drive, Los Altos", 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2016-08-10T19:28:06.757000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 49, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 13
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93bf6858f710e756834"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93cf6858f710e756840"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470878029.871, 
+                        "duration": 4456.885999917984, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e7567a0"
+                            }
+                        ], 
+                        "exit_ts": 1470882486.757
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.0920884, 
+                                37.3611135
+                            ], 
+                            [
+                                -122.0925938, 
+                                37.3612622
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93cf6858f710e75683f", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T18:12:44.548000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 8, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 13
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57b7b93cf6858f710e756835"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57b7b93cf6858f710e75683b"
+                        }, 
+                        "exit_fmt_time": "2016-08-10T18:13:08-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 44, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 12
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0925938, 
+                                37.3612622
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0920884, 
+                                37.3611135
+                            ]
+                        }, 
+                        "enter_ts": 1470877964.548, 
+                        "duration": 23.45199990272522, 
+                        "_id": {
+                            "$oid": "57b7b93bf6858f710e756834"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57b7b93bf6858f710e756834"
+                        }, 
+                        "exit_ts": 1470877988
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0928806, 
+                                        37.3646657
+                                    ], 
+                                    [
+                                        -122.0921328, 
+                                        37.3630886
+                                    ], 
+                                    [
+                                        -122.09251236096115, 
+                                        37.36259085460517
+                                    ], 
+                                    [
+                                        -122.0922725445104, 
+                                        37.361705225530805
+                                    ], 
+                                    [
+                                        -122.09222299416257, 
+                                        37.36139129705387
+                                    ], 
+                                    [
+                                        -122.0920884, 
+                                        37.3611135
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93cf6858f710e756835", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    64.7189085678808, 
+                                    100.73247669671484, 
+                                    35.18088079458185, 
+                                    33.10093365113474
+                                ], 
+                                "end_ts": 1470877964.548, 
+                                "feature_type": "section", 
+                                "distance": 233.73319971031222, 
+                                "sensed_mode": "MotionTypes.BICYCLING", 
+                                "start_ts": 1470877864.989, 
+                                "start_fmt_time": "2016-08-10T18:11:04.989000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-10T18:12:44.548000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 44, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 12
+                                }, 
+                                "duration": 99.55900001525879, 
+                                "end_stop": {
+                                    "$oid": "57b7b93cf6858f710e75683f"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57b7b93bf6858f710e756834"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 4, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 11
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    2.1572969522626932, 
+                                    3.357749223223828, 
+                                    1.1726960264860617, 
+                                    3.4628029708438706
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0925938, 
+                                        37.3612622
+                                    ], 
+                                    [
+                                        -122.09253127475118, 
+                                        37.36103319926456
+                                    ], 
+                                    [
+                                        -122.0926289, 
+                                        37.3610108
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93cf6858f710e75683b", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    26.056437922331394, 
+                                    8.980495729992429
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1470878029.871, 
+                                "start_ts": 1470877988, 
+                                "start_fmt_time": "2016-08-10T18:13:08-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-10T18:13:49.871000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 49, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 13
+                                }, 
+                                "duration": 41.87100005149841, 
+                                "start_stop": {
+                                    "$oid": "57b7b93cf6858f710e75683f"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57b7b93bf6858f710e756834"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 18, 
+                                    "month": 8, 
+                                    "second": 8, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 13
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    0.8685479307443799, 
+                                    0.7565070921601814
+                                ], 
+                                "distance": 35.036933652323825
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57b7b93bf6858f710e756834", 
+            "properties": {
+                "distance": 268.77013336263605, 
+                "end_place": {
+                    "$oid": "57b7b93ff6858f710e756873"
+                }, 
+                "raw_trip": {
+                    "$oid": "57b7b939f6858f710e75679f"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0921328, 
+                        37.3630886
+                    ]
+                }, 
+                "end_ts": 1470878029.871, 
+                "start_ts": 1470877864.989, 
+                "start_fmt_time": "2016-08-10T18:11:04.989000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0926289, 
+                        37.3610108
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57b7b93ef6858f710e756872"
+                }, 
+                "end_fmt_time": "2016-08-10T18:13:49.871000-07:00", 
+                "end_local_dt": {
+                    "hour": 18, 
+                    "month": 8, 
+                    "second": 49, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 13
+                }, 
+                "duration": 164.88199996948242, 
+                "start_local_dt": {
+                    "hour": 18, 
+                    "month": 8, 
+                    "second": 4, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 11
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0926289, 
+                            37.3610108
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93ff6858f710e756873", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T18:13:49.871000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 19, 
+                            "month": 8, 
+                            "second": 6, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 28
+                        }, 
+                        "display_name": "Altos Oaks Drive, Los Altos", 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2016-08-10T19:28:06.757000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 18, 
+                            "month": 8, 
+                            "second": 49, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 13
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93bf6858f710e756834"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57b7b93cf6858f710e756840"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470878029.871, 
+                        "duration": 4456.885999917984, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e7567a0"
+                            }
+                        ], 
+                        "exit_ts": 1470882486.757
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0864577, 
+                            37.3906569
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57b7b93ff6858f710e756874", 
+                    "properties": {
+                        "enter_fmt_time": "2016-08-10T19:48:43.490000-07:00", 
+                        "display_name": "South Shoreline Boulevard, Mountain View", 
+                        "feature_type": "end_place", 
+                        "enter_local_dt": {
+                            "hour": 19, 
+                            "month": 8, 
+                            "second": 43, 
+                            "weekday": 2, 
+                            "year": 2016, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 10, 
+                            "minute": 48
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57b7b93cf6858f710e756840"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1470883723.49, 
+                        "raw_places": [
+                            {
+                                "$oid": "57b7b939f6858f710e7567a2"
+                            }
+                        ]
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0926289, 
+                                        37.3610108
+                                    ], 
+                                    [
+                                        -122.0918545, 
+                                        37.3648029
+                                    ], 
+                                    [
+                                        -122.0927971852223, 
+                                        37.36494739741023
+                                    ], 
+                                    [
+                                        -122.0932291666959, 
+                                        37.36452465236263
+                                    ], 
+                                    [
+                                        -122.09273729740679, 
+                                        37.36462104149214
+                                    ], 
+                                    [
+                                        -122.09276263127883, 
+                                        37.36456601235598
+                                    ], 
+                                    [
+                                        -122.09281149353751, 
+                                        37.36472868613147
+                                    ], 
+                                    [
+                                        -122.0931704810178, 
+                                        37.36470010215873
+                                    ], 
+                                    [
+                                        -122.09255163486196, 
+                                        37.36475578078486
+                                    ], 
+                                    [
+                                        -122.09179757873717, 
+                                        37.36477137229615
+                                    ], 
+                                    [
+                                        -122.09104352261238, 
+                                        37.36478696380743
+                                    ], 
+                                    [
+                                        -122.08985410439381, 
+                                        37.36502715786097
+                                    ], 
+                                    [
+                                        -122.08842103306844, 
+                                        37.36501061193198
+                                    ], 
+                                    [
+                                        -122.08719040927677, 
+                                        37.36501575471711
+                                    ], 
+                                    [
+                                        -122.08697504183442, 
+                                        37.36591985814943
+                                    ], 
+                                    [
+                                        -122.08694813901337, 
+                                        37.36746578791732
+                                    ], 
+                                    [
+                                        -122.08691767318807, 
+                                        37.36866443637508
+                                    ], 
+                                    [
+                                        -122.0869620875588, 
+                                        37.37027738101918
+                                    ], 
+                                    [
+                                        -122.08711870585819, 
+                                        37.371612459759305
+                                    ], 
+                                    [
+                                        -122.08704349128736, 
+                                        37.37307158715104
+                                    ], 
+                                    [
+                                        -122.08706743136196, 
+                                        37.37299791379574
+                                    ], 
+                                    [
+                                        -122.0870571185074, 
+                                        37.37375165167939
+                                    ], 
+                                    [
+                                        -122.08704985880361, 
+                                        37.37447771885513
+                                    ], 
+                                    [
+                                        -122.08690856870015, 
+                                        37.37642123849801
+                                    ], 
+                                    [
+                                        -122.08686323968101, 
+                                        37.3772968252685
+                                    ], 
+                                    [
+                                        -122.0866443135052, 
+                                        37.3794259722855
+                                    ], 
+                                    [
+                                        -122.08693140543323, 
+                                        37.380653297265255
+                                    ], 
+                                    [
+                                        -122.0870288669717, 
+                                        37.38204268188064
+                                    ], 
+                                    [
+                                        -122.08695447807135, 
+                                        37.38307829563428
+                                    ], 
+                                    [
+                                        -122.08704604746657, 
+                                        37.384780859165105
+                                    ], 
+                                    [
+                                        -122.08733996514911, 
+                                        37.38619619102141
+                                    ], 
+                                    [
+                                        -122.08820846514912, 
+                                        37.38726396602141
+                                    ], 
+                                    [
+                                        -122.08803441128492, 
+                                        37.38780970557292
+                                    ], 
+                                    [
+                                        -122.08799048795578, 
+                                        37.38774906425275
+                                    ], 
+                                    [
+                                        -122.0881342318127, 
+                                        37.387638787018474
+                                    ], 
+                                    [
+                                        -122.08806949652734, 
+                                        37.38775757441511
+                                    ], 
+                                    [
+                                        -122.08757198687903, 
+                                        37.388791336998985
+                                    ], 
+                                    [
+                                        -122.08694789438474, 
+                                        37.3897867909972
+                                    ], 
+                                    [
+                                        -122.08646932642507, 
+                                        37.39038797634451
+                                    ], 
+                                    [
+                                        -122.08646613101938, 
+                                        37.390362466178686
+                                    ], 
+                                    [
+                                        -122.08648946143907, 
+                                        37.390442589314944
+                                    ], 
+                                    [
+                                        -122.08648761119994, 
+                                        37.39051372384351
+                                    ], 
+                                    [
+                                        -122.08647347719439, 
+                                        37.39062504623371
+                                    ], 
+                                    [
+                                        -122.0864577, 
+                                        37.3906569
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57b7b93cf6858f710e756841", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    84.84623012707694, 
+                                    60.55699449924165, 
+                                    44.77157374149084, 
+                                    6.515707900318562, 
+                                    18.59680871724843, 
+                                    31.884851735589386, 
+                                    55.04072902813096, 
+                                    66.66330854667414, 
+                                    66.66329470414843, 
+                                    108.45631030736219, 
+                                    126.66260722068365, 
+                                    108.75923407833689, 
+                                    102.317589498751, 
+                                    171.91598784003088, 
+                                    133.31081732822054, 
+                                    179.39420302604054, 
+                                    149.0977418851146, 
+                                    162.38364460693447, 
+                                    8.460846007954622, 
+                                    83.81678298372094, 
+                                    80.73753495597381, 
+                                    216.4698591632299, 
+                                    97.44316121847424, 
+                                    237.5393278672427, 
+                                    138.80985381898603, 
+                                    154.73233334788745, 
+                                    115.34241569709022, 
+                                    189.48922338375212, 
+                                    159.5057842873831, 
+                                    141.3681493101836, 
+                                    62.601545658678816, 
+                                    7.779920216413184, 
+                                    17.653473471672303, 
+                                    14.393630233695923, 
+                                    123.0662062830131, 
+                                    123.66180039523955, 
+                                    79.0970354110783, 
+                                    2.8506139269580797, 
+                                    9.144601462421251, 
+                                    7.911487526694207, 
+                                    12.441306190499812, 
+                                    3.8063659633535734
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.BICYCLING", 
+                                "end_ts": 1470883723.49, 
+                                "start_ts": 1470882486.757, 
+                                "start_fmt_time": "2016-08-10T19:28:06.757000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2016-08-10T19:48:43.490000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 19, 
+                                    "month": 8, 
+                                    "second": 43, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 48
+                                }, 
+                                "duration": 1236.7330000400543, 
+                                "trip_id": {
+                                    "$oid": "57b7b93cf6858f710e756840"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 19, 
+                                    "month": 8, 
+                                    "second": 6, 
+                                    "weekday": 2, 
+                                    "year": 2016, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 10, 
+                                    "minute": 28
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    2.8282076709025645, 
+                                    2.0185664833080548, 
+                                    1.492385791383028, 
+                                    0.21719026334395206, 
+                                    0.619893623908281, 
+                                    1.0628283911863128, 
+                                    1.8346909676043655, 
+                                    2.2221102848891383, 
+                                    2.222109823471614, 
+                                    3.6152103435787395, 
+                                    4.222086907356122, 
+                                    3.6253078026112298, 
+                                    3.4105863166250336, 
+                                    5.730532928001029, 
+                                    4.443693910940684, 
+                                    5.979806767534685, 
+                                    4.96992472950382, 
+                                    5.412788153564482, 
+                                    0.28202820026515407, 
+                                    2.7938927661240314, 
+                                    2.691251165199127, 
+                                    7.215661972107664, 
+                                    3.2481053739491417, 
+                                    7.917977595574756, 
+                                    4.626995127299534, 
+                                    5.157744444929581, 
+                                    3.8447471899030075, 
+                                    6.31630744612507, 
+                                    5.316859476246104, 
+                                    4.712271643672787, 
+                                    2.086718188622627, 
+                                    0.25933067388043946, 
+                                    0.5884491157224101, 
+                                    0.47978767445653075, 
+                                    4.102206876100436, 
+                                    4.122060013174652, 
+                                    2.636567847035943, 
+                                    0.09502046423193598, 
+                                    0.30482004874737506, 
+                                    0.2637162508898069, 
+                                    0.4147102063499937, 
+                                    0.5653298590093078
+                                ], 
+                                "distance": 3765.9608935729907
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57b7b93cf6858f710e756840", 
+            "properties": {
+                "distance": 3765.9608935729907, 
+                "end_place": {
+                    "$oid": "57b7b93ff6858f710e756874"
+                }, 
+                "raw_trip": {
+                    "$oid": "57b7b939f6858f710e7567a1"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0918545, 
+                        37.3648029
+                    ]
+                }, 
+                "end_ts": 1470883723.49, 
+                "start_ts": 1470882486.757, 
+                "start_fmt_time": "2016-08-10T19:28:06.757000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0864577, 
+                        37.3906569
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57b7b93ff6858f710e756873"
+                }, 
+                "end_fmt_time": "2016-08-10T19:48:43.490000-07:00", 
+                "end_local_dt": {
+                    "hour": 19, 
+                    "month": 8, 
+                    "second": 43, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 48
+                }, 
+                "duration": 1236.7330000400543, 
+                "start_local_dt": {
+                    "hour": 19, 
+                    "month": 8, 
+                    "second": 6, 
+                    "weekday": 2, 
+                    "year": 2016, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 10, 
+                    "minute": 28
+                }
+            }
+        }
+    ], 
+    "_id": {
+        "$oid": "57b7b941115514afcd7934bd"
+    }, 
+    "user_id": {
+        "$uuid": "0763de67f61e3f5d90e7518e69793954"
+    }, 
+    "metadata": {
+        "type": "document", 
+        "key": "diary/trips-2016-08-09", 
+        "write_ts": 1471658305.043781
+    }
+}


### PR DESCRIPTION
…atch

This is the second fix for #352. More detail is in the bug, but
basically, this is 2(i) from
https://github.com/e-mission/e-mission-server/issues/352#issuecomment-240526292.

When we have finished looking at all points, if we haven't ended a trip, then:
(i) if there is a transition, end the trip (80%)

Also, enhance the test cases to check for this. In particular, we now:
- load the data into two chunks and run the intake pipeline after each. This
  simulates a sync between the chunks
- add a new check for "almost equal". This is needed because when we sync
  between two trips, and use the transition information to end the trip, the
  set of 10 points that are used to determine the end point are very slightly
  different from the case where we end the trip because of the large gap. This
  is because if when we use the transition information, the currPoint is the
  end point, while when we use the gap, the prevPoint is the end point. So if
  the trip ends at point 22, then in the first case, we will look at points 13 to
  22 while in the second case, we will look at points from 14 to 23.
  I made some weak attempts to fix this, e.g. by dropping the last point in the
  second case. But then we still had points 14 to 22, not 13 to 22. Fixing that
  would have increased the complexity without significantly affecting accuracy.
  So I use the new almost_equal method with a fuzz factor instead.
- load data from the prev day as well so that we would have at least some trips
  even when the trip to the optometrist was dropped. If we don't do that, then
  we don't have *any* trips during the first run and we hit this condition
  ```
    elif len(segmentation_points) == 0:
        # no new segments, no need to keep looking at these again
        logging.debug("len(segmentation_points) == 0, early return")
        epq.mark_segmentation_done(user_id, None)
   else:
  ```

With all these conditions in place, the new test fails without the code fix

```
======================================================================
FAIL: testAug10MultiSyncEndDetected (__main__.TestPipelineRealData)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "emission/tests/analysisTests/intakeTests/TestPipelineRealData.py", line 272, in testAug10MultiSyncEndDetected
    ad.AttrDict(ground_truth).data, time_fuzz=60, distance_fuzz=100)
  File "emission/tests/analysisTests/intakeTests/TestPipelineRealData.py", line 92, in compare_approx_result
    self.assertEqual(len(result), len(expect))
AssertionError: 6 != 7

----------------------------------------------------------------------
```

and passes with the code fix

```
----------------------------------------------------------------------
Ran 1 test in 14.797s

OK
```