### PR TITLE
Fix over extrapolation by ensuring that there is a gap during the tri…

### DIFF
--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -252,9 +252,6 @@ class TestPipelineRealData(unittest.TestCase):
                             ad.AttrDict(ground_truth).data)
 
     def testFeb22ShortTripsDistance(self):
-        # Re-run, but with multiple calls to sync data
-        # This tests the effect of online versus offline analysis and segmentation with potentially partial data
-
         dataFile = "emission/tests/data/real_examples/iphone_3_2016-02-22"
         start_ld = ecwl.LocalDate({'year': 2016, 'month': 2, 'day': 22})
         end_ld = ecwl.LocalDate({'year': 2016, 'month': 2, 'day': 22})
@@ -268,6 +265,21 @@ class TestPipelineRealData(unittest.TestCase):
         # Although we process the day's data in two batches, we should get the same result
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                                    ad.AttrDict(ground_truth).data)
+
+    def testAug27TooMuchExtrapolation(self):
+        dataFile = "emission/tests/data/real_examples/shankari_2015-aug-27"
+        start_ld = ecwl.LocalDate({'year': 2015, 'month': 8, 'day': 27})
+        end_ld = ecwl.LocalDate({'year': 2015, 'month': 8, 'day': 27})
+        cacheKey = "diary/trips-2015-08-27"
+        ground_truth = json.load(open(dataFile+".ground_truth"), object_hook=bju.object_hook)
+
+        etc.setupRealExample(self, dataFile)
+        etc.runIntakePipeline(self.testUUID)
+        api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, end_ld)
+
+        # Although we process the day's data in two batches, we should get the same result
+        self.compare_result(ad.AttrDict({'result': api_result}).result,
+                            ad.AttrDict(ground_truth).data)
 
     def testAug10MultiSyncEndDetected(self):
         # Re-run, but with multiple calls to sync data

--- a/emission/tests/data/real_examples/shankari_2015-aug-27.ground_truth
+++ b/emission/tests/data/real_examples/shankari_2015-aug-27.ground_truth
@@ -1,0 +1,5966 @@
+{
+    "data": [
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.084979, 
+                            37.3929098
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b82", 
+                    "properties": {
+                        "exit_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 27, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 18
+                        }, 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2015-08-27T08:18:27.867000-07:00", 
+                        "starting_trip": {
+                            "$oid": "57c0e41bf6858f03bbe4191f"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418f4"
+                            }
+                        ], 
+                        "exit_ts": 1440688707.867
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0835641, 
+                            37.4034802
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b83", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T08:30:08.302000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 20, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 32
+                        }, 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2015-08-27T08:32:20.701227-07:00", 
+                        "enter_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 8, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 30
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41bf6858f03bbe4191f"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41bf6858f03bbe4193c"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440689408.302, 
+                        "duration": 132.39922738075256, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418f6"
+                            }
+                        ], 
+                        "exit_ts": 1440689540.7012274
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.0847081, 
+                                37.4033491
+                            ], 
+                            [
+                                -122.0845296, 
+                                37.4034667
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e41bf6858f03bbe4193b", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T08:27:45.092000-07:00", 
+                        "distance": 20.484032507971882, 
+                        "exit_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 16, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 28
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57c0e41bf6858f03bbe41922"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57c0e41bf6858f03bbe41935"
+                        }, 
+                        "exit_fmt_time": "2015-08-27T08:28:16.912000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 45, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 27
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0845296, 
+                                37.4034667
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0847081, 
+                                37.4033491
+                            ]
+                        }, 
+                        "enter_ts": 1440689265.092, 
+                        "duration": 31.819999933242798, 
+                        "_id": {
+                            "$oid": "57c0e41bf6858f03bbe4191f"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57c0e41bf6858f03bbe4191f"
+                        }, 
+                        "exit_ts": 1440689296.912
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.08373150395536, 
+                                        37.39472329086414
+                                    ], 
+                                    [
+                                        -122.08310992136775, 
+                                        37.39568233514867
+                                    ], 
+                                    [
+                                        -122.08303234057223, 
+                                        37.395825285771444
+                                    ], 
+                                    [
+                                        -122.08298136528107, 
+                                        37.395925737007
+                                    ], 
+                                    [
+                                        -122.0828746679486, 
+                                        37.396029941667216
+                                    ], 
+                                    [
+                                        -122.08223143948844, 
+                                        37.39588620801155
+                                    ], 
+                                    [
+                                        -122.08127281096114, 
+                                        37.39654370052934
+                                    ], 
+                                    [
+                                        -122.08083407545955, 
+                                        37.39790401046231
+                                    ], 
+                                    [
+                                        -122.08072956761971, 
+                                        37.39922343648832
+                                    ], 
+                                    [
+                                        -122.08056831786651, 
+                                        37.39999153584625
+                                    ], 
+                                    [
+                                        -122.08067435901901, 
+                                        37.39996722466604
+                                    ], 
+                                    [
+                                        -122.08133588010556, 
+                                        37.39993467676685
+                                    ], 
+                                    [
+                                        -122.08295954022086, 
+                                        37.400145606698835
+                                    ], 
+                                    [
+                                        -122.08467786695799, 
+                                        37.400631170769344
+                                    ], 
+                                    [
+                                        -122.08483221991538, 
+                                        37.401626612025034
+                                    ], 
+                                    [
+                                        -122.08480876348638, 
+                                        37.402579633637856
+                                    ], 
+                                    [
+                                        -122.08471389346491, 
+                                        37.403066357254566
+                                    ], 
+                                    [
+                                        -122.0847081, 
+                                        37.4033491
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41bf6858f03bbe41922", 
+                            "properties": {
+                                "distances": [
+                                    171.18132140558205, 
+                                    119.9478368880287, 
+                                    17.309921903785423, 
+                                    12.043246333698331, 
+                                    14.936573094257053, 
+                                    59.02747934055344, 
+                                    111.87730099066168, 
+                                    156.14597923929568, 
+                                    147.0036481755346, 
+                                    86.5883818974232, 
+                                    9.74940677181159, 
+                                    58.54738901196658, 
+                                    145.33082291217283, 
+                                    161.10424119430996, 
+                                    111.52460707707851, 
+                                    105.99142203902183, 
+                                    54.766126524528495, 
+                                    31.443723394467938
+                                ], 
+                                "end_ts": 1440689265.092, 
+                                "feature_type": "section", 
+                                "distance": 1574.519428194178, 
+                                "sensed_mode": "MotionTypes.BICYCLING", 
+                                "start_ts": 1440688707.867, 
+                                "start_fmt_time": "2015-08-27T08:18:27.867000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T08:27:45.092000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 8, 
+                                    "month": 8, 
+                                    "second": 45, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 27
+                                }, 
+                                "duration": 557.2249999046326, 
+                                "end_stop": {
+                                    "$oid": "57c0e41bf6858f03bbe4193b"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41bf6858f03bbe4191f"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 8, 
+                                    "month": 8, 
+                                    "second": 27, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 18
+                                }, 
+                                "speeds": [
+                                    5.706044046852735, 
+                                    3.9982612296009568, 
+                                    0.5769973967928475, 
+                                    0.401441544456611, 
+                                    0.4978857698085684, 
+                                    1.9675826446851148, 
+                                    3.7292433663553894, 
+                                    5.204865974643189, 
+                                    4.900121605851154, 
+                                    2.8862793965807736, 
+                                    0.324980225727053, 
+                                    1.9515796337322193, 
+                                    4.844360763739094, 
+                                    5.370141373143666, 
+                                    3.717486902569284, 
+                                    3.5330474013007276, 
+                                    1.8255375508176166, 
+                                    1.8254701636318338
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0845296, 
+                                        37.4034667
+                                    ], 
+                                    [
+                                        -122.08442844992497, 
+                                        37.403380444344215
+                                    ], 
+                                    [
+                                        -122.08389589236029, 
+                                        37.4034029103248
+                                    ], 
+                                    [
+                                        -122.08405722269404, 
+                                        37.40343414535875
+                                    ], 
+                                    [
+                                        -122.0835641, 
+                                        37.4034802
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41bf6858f03bbe41935", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    13.107986040605232, 
+                                    47.107560490081966, 
+                                    14.667588016993776, 
+                                    43.857925823474915
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1440689408.302, 
+                                "start_ts": 1440689296.912, 
+                                "start_fmt_time": "2015-08-27T08:28:16.912000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T08:30:08.302000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 8, 
+                                    "month": 8, 
+                                    "second": 8, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 30
+                                }, 
+                                "duration": 111.39000010490417, 
+                                "start_stop": {
+                                    "$oid": "57c0e41bf6858f03bbe4193b"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41bf6858f03bbe4191f"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 8, 
+                                    "month": 8, 
+                                    "second": 16, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 28
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    0.4369328680201744, 
+                                    1.5702520163360656, 
+                                    0.48891960056645917, 
+                                    2.0503939040850883
+                                ], 
+                                "distance": 118.7410603711559
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57c0e41bf6858f03bbe4191f", 
+            "properties": {
+                "distance": 1713.744521073306, 
+                "end_place": {
+                    "$oid": "57c0e420f6858f03bbe41b83"
+                }, 
+                "raw_trip": {
+                    "$oid": "57c0e419f6858f03bbe418f5"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.084979, 
+                        37.3929098
+                    ]
+                }, 
+                "end_ts": 1440689408.302, 
+                "start_ts": 1440688707.867, 
+                "start_fmt_time": "2015-08-27T08:18:27.867000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0835641, 
+                        37.4034802
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57c0e420f6858f03bbe41b82"
+                }, 
+                "end_fmt_time": "2015-08-27T08:30:08.302000-07:00", 
+                "end_local_dt": {
+                    "hour": 8, 
+                    "month": 8, 
+                    "second": 8, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 30
+                }, 
+                "duration": 700.4349999427795, 
+                "start_local_dt": {
+                    "hour": 8, 
+                    "month": 8, 
+                    "second": 27, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 18
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0835641, 
+                            37.4034802
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b83", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T08:30:08.302000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 20, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 32
+                        }, 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2015-08-27T08:32:20.701227-07:00", 
+                        "enter_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 8, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 30
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41bf6858f03bbe4191f"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41bf6858f03bbe4193c"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440689408.302, 
+                        "duration": 132.39922738075256, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418f6"
+                            }
+                        ], 
+                        "exit_ts": 1440689540.7012274
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0778188, 
+                            37.3957356
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b84", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T08:41:16.784000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 18, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 51
+                        }, 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2015-08-27T08:51:18.159111-07:00", 
+                        "enter_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 16, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 41
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41bf6858f03bbe4193c"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41cf6858f03bbe41952"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440690076.784, 
+                        "duration": 601.3751113414764, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418f8"
+                            }
+                        ], 
+                        "exit_ts": 1440690678.1591113
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0835641, 
+                                        37.4034802
+                                    ], 
+                                    [
+                                        -122.08324947759913, 
+                                        37.403249485086526
+                                    ], 
+                                    [
+                                        -122.08293485519823, 
+                                        37.403018770173055
+                                    ], 
+                                    [
+                                        -122.08262023279735, 
+                                        37.402788055259585
+                                    ], 
+                                    [
+                                        -122.08230561039646, 
+                                        37.402557340346114
+                                    ], 
+                                    [
+                                        -122.08146304068424, 
+                                        37.40240305189178
+                                    ], 
+                                    [
+                                        -122.0798705375145, 
+                                        37.40192739503022
+                                    ], 
+                                    [
+                                        -122.0791330715329, 
+                                        37.401570416313966
+                                    ], 
+                                    [
+                                        -122.07900239094822, 
+                                        37.40154684580483
+                                    ], 
+                                    [
+                                        -122.07839491401299, 
+                                        37.40110036136816
+                                    ], 
+                                    [
+                                        -122.07793701515128, 
+                                        37.39922447059321
+                                    ], 
+                                    [
+                                        -122.07727089547438, 
+                                        37.39817899676297
+                                    ], 
+                                    [
+                                        -122.0763436450106, 
+                                        37.39786335105958
+                                    ], 
+                                    [
+                                        -122.07721299122628, 
+                                        37.39661146003307
+                                    ], 
+                                    [
+                                        -122.0778060271274, 
+                                        37.39579266489395
+                                    ], 
+                                    [
+                                        -122.0778487389895, 
+                                        37.39573904255864
+                                    ], 
+                                    [
+                                        -122.07784370441615, 
+                                        37.39575069197053
+                                    ], 
+                                    [
+                                        -122.07781181592573, 
+                                        37.395726926020124
+                                    ], 
+                                    [
+                                        -122.0778188, 
+                                        37.3957356
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41bf6858f03bbe4193e", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    37.821656471425634, 
+                                    37.82171934756227, 
+                                    37.82178222161217, 
+                                    37.82184509726472, 
+                                    76.37758376499968, 
+                                    150.2841583396648, 
+                                    76.28348087578676, 
+                                    11.837213039553651, 
+                                    73.10437219356047, 
+                                    212.47509056879474, 
+                                    130.29519720589417, 
+                                    89.11368730792431, 
+                                    158.98246624379556, 
+                                    105.04234777736924, 
+                                    7.056098167565988, 
+                                    1.3695808449654496, 
+                                    3.8625446169801814, 
+                                    1.144954240021904
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.BICYCLING", 
+                                "end_ts": 1440690076.784, 
+                                "start_ts": 1440689540.7012274, 
+                                "start_fmt_time": "2015-08-27T08:32:20.701227-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T08:41:16.784000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 8, 
+                                    "month": 8, 
+                                    "second": 16, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 41
+                                }, 
+                                "duration": 536.0827724933624, 
+                                "trip_id": {
+                                    "$oid": "57c0e41bf6858f03bbe4193c"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 8, 
+                                    "month": 8, 
+                                    "second": 20, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 32
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    1.2607218823808544, 
+                                    1.2607239782520758, 
+                                    1.260726074053739, 
+                                    1.260728169908824, 
+                                    2.545919458833323, 
+                                    5.009471944655493, 
+                                    2.5427826958595587, 
+                                    0.3945737679851217, 
+                                    2.4368124064520154, 
+                                    7.082503018959825, 
+                                    4.343173240196473, 
+                                    2.970456243597477, 
+                                    5.299415541459852, 
+                                    3.501411592578975, 
+                                    0.2352032722521996, 
+                                    0.04565269483218166, 
+                                    0.1287514872326727, 
+                                    0.04389695306790232
+                                ], 
+                                "distance": 1248.5157783247416
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57c0e41bf6858f03bbe4193c", 
+            "properties": {
+                "distance": 1248.5157783247416, 
+                "end_place": {
+                    "$oid": "57c0e420f6858f03bbe41b84"
+                }, 
+                "raw_trip": {
+                    "$oid": "57c0e419f6858f03bbe418f7"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0835641, 
+                        37.4034802
+                    ]
+                }, 
+                "end_ts": 1440690076.784, 
+                "start_ts": 1440689540.7012274, 
+                "start_fmt_time": "2015-08-27T08:32:20.701227-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0778188, 
+                        37.3957356
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57c0e420f6858f03bbe41b83"
+                }, 
+                "end_fmt_time": "2015-08-27T08:41:16.784000-07:00", 
+                "end_local_dt": {
+                    "hour": 8, 
+                    "month": 8, 
+                    "second": 16, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 41
+                }, 
+                "duration": 413.84099984169006, 
+                "start_local_dt": {
+                    "hour": 8, 
+                    "month": 8, 
+                    "second": 20, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 32
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0778188, 
+                            37.3957356
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b84", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T08:41:16.784000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 18, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 51
+                        }, 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2015-08-27T08:51:18.159111-07:00", 
+                        "enter_local_dt": {
+                            "hour": 8, 
+                            "month": 8, 
+                            "second": 16, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 41
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41bf6858f03bbe4193c"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41cf6858f03bbe41952"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440690076.784, 
+                        "duration": 601.3751113414764, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418f8"
+                            }
+                        ], 
+                        "exit_ts": 1440690678.1591113
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.3872605, 
+                            37.5995036
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b85", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T09:53:44.894000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 10, 
+                            "month": 8, 
+                            "second": 16, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 2
+                        }, 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2015-08-27T10:02:16.470599-07:00", 
+                        "enter_local_dt": {
+                            "hour": 9, 
+                            "month": 8, 
+                            "second": 44, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 53
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41cf6858f03bbe41952"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41cf6858f03bbe419d6"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440694424.894, 
+                        "duration": 511.57659935951233, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418fa"
+                            }
+                        ], 
+                        "exit_ts": 1440694936.4705994
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.3871681, 
+                                37.5992489
+                            ], 
+                            [
+                                -122.3872958, 
+                                37.5992574
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e41cf6858f03bbe419d5", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T09:52:14.783000-07:00", 
+                        "distance": 11.289935021388207, 
+                        "exit_local_dt": {
+                            "hour": 9, 
+                            "month": 8, 
+                            "second": 44, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 52
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57c0e41cf6858f03bbe41954"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57c0e41cf6858f03bbe419d0"
+                        }, 
+                        "exit_fmt_time": "2015-08-27T09:52:44.740000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 9, 
+                            "month": 8, 
+                            "second": 14, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 52
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.3872958, 
+                                37.5992574
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.3871681, 
+                                37.5992489
+                            ]
+                        }, 
+                        "enter_ts": 1440694334.783, 
+                        "duration": 29.957000017166138, 
+                        "_id": {
+                            "$oid": "57c0e41cf6858f03bbe41952"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57c0e41cf6858f03bbe41952"
+                        }, 
+                        "exit_ts": 1440694364.74
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0778188, 
+                                        37.3957356
+                                    ], 
+                                    [
+                                        -122.0766038443174, 
+                                        37.39455809917154
+                                    ], 
+                                    [
+                                        -122.0770353130046, 
+                                        37.39500304052637
+                                    ], 
+                                    [
+                                        -122.07693531707748, 
+                                        37.39489261735837
+                                    ], 
+                                    [
+                                        -122.0762128210082, 
+                                        37.39419051259477
+                                    ], 
+                                    [
+                                        -122.0769545209969, 
+                                        37.394981865750125
+                                    ], 
+                                    [
+                                        -122.07732228588873, 
+                                        37.39554466115155
+                                    ], 
+                                    [
+                                        -122.07655824346583, 
+                                        37.39476309591397
+                                    ], 
+                                    [
+                                        -122.07614651537205, 
+                                        37.39416155666122
+                                    ], 
+                                    [
+                                        -122.07698724646286, 
+                                        37.39496664098447
+                                    ], 
+                                    [
+                                        -122.07780350695421, 
+                                        37.395749833878824
+                                    ], 
+                                    [
+                                        -122.07693004450697, 
+                                        37.39537307787788
+                                    ], 
+                                    [
+                                        -122.0761330247527, 
+                                        37.39464261185781
+                                    ], 
+                                    [
+                                        -122.07695126228616, 
+                                        37.39492664307395
+                                    ], 
+                                    [
+                                        -122.07775589152685, 
+                                        37.39566615079005
+                                    ], 
+                                    [
+                                        -122.0777771208835, 
+                                        37.395692775249216
+                                    ], 
+                                    [
+                                        -122.07702697119527, 
+                                        37.39523313693752
+                                    ], 
+                                    [
+                                        -122.0761781625953, 
+                                        37.394445242796955
+                                    ], 
+                                    [
+                                        -122.07681063117613, 
+                                        37.39484751445247
+                                    ], 
+                                    [
+                                        -122.07766172087952, 
+                                        37.395674190718566
+                                    ], 
+                                    [
+                                        -122.07777866784738, 
+                                        37.39570213468878
+                                    ], 
+                                    [
+                                        -122.07745482824978, 
+                                        37.395467400302394
+                                    ], 
+                                    [
+                                        -122.07701490731795, 
+                                        37.39517499837474
+                                    ], 
+                                    [
+                                        -122.0767897075801, 
+                                        37.395118897555875
+                                    ], 
+                                    [
+                                        -122.07656450784226, 
+                                        37.39506279673701
+                                    ], 
+                                    [
+                                        -122.07633930810441, 
+                                        37.39500669591814
+                                    ], 
+                                    [
+                                        -122.07860315997253, 
+                                        37.395974092178186
+                                    ], 
+                                    [
+                                        -122.08370665179349, 
+                                        37.39810914731278
+                                    ], 
+                                    [
+                                        -122.08881014361445, 
+                                        37.40024420244737
+                                    ], 
+                                    [
+                                        -122.09391363543541, 
+                                        37.402379257581956
+                                    ], 
+                                    [
+                                        -122.09901712725637, 
+                                        37.40451431271654
+                                    ], 
+                                    [
+                                        -122.10412061907734, 
+                                        37.40664936785113
+                                    ], 
+                                    [
+                                        -122.10861007912008, 
+                                        37.408839469349395
+                                    ], 
+                                    [
+                                        -122.1124235079142, 
+                                        37.41109017530379
+                                    ], 
+                                    [
+                                        -122.11623693670833, 
+                                        37.413340881258186
+                                    ], 
+                                    [
+                                        -122.12005036550246, 
+                                        37.415591587212575
+                                    ], 
+                                    [
+                                        -122.12386379429658, 
+                                        37.41784229316697
+                                    ], 
+                                    [
+                                        -122.12767722309071, 
+                                        37.420092999121366
+                                    ], 
+                                    [
+                                        -122.13149065188485, 
+                                        37.42234370507576
+                                    ], 
+                                    [
+                                        -122.13599929958676, 
+                                        37.425515876203406
+                                    ], 
+                                    [
+                                        -122.14004468442947, 
+                                        37.428428869188046
+                                    ], 
+                                    [
+                                        -122.14147437329002, 
+                                        37.42922233199979
+                                    ], 
+                                    [
+                                        -122.1414820310038, 
+                                        37.42923139138403
+                                    ], 
+                                    [
+                                        -122.14145115066131, 
+                                        37.4291996013603
+                                    ], 
+                                    [
+                                        -122.1414762, 
+                                        37.4292348
+                                    ], 
+                                    [
+                                        -122.14411607043309, 
+                                        37.43084327315532
+                                    ], 
+                                    [
+                                        -122.14948926505777, 
+                                        37.43411716084457
+                                    ], 
+                                    [
+                                        -122.15432217773505, 
+                                        37.43709547099967
+                                    ], 
+                                    [
+                                        -122.15858307929437, 
+                                        37.43976084522094
+                                    ], 
+                                    [
+                                        -122.16284398085371, 
+                                        37.442426219442204
+                                    ], 
+                                    [
+                                        -122.16547396157587, 
+                                        37.443780262366566
+                                    ], 
+                                    [
+                                        -122.16545975729629, 
+                                        37.443772743677975
+                                    ], 
+                                    [
+                                        -122.16496847486711, 
+                                        37.443941808247494
+                                    ], 
+                                    [
+                                        -122.16665663901315, 
+                                        37.445061015232284
+                                    ], 
+                                    [
+                                        -122.16942755574102, 
+                                        37.446850791737965
+                                    ], 
+                                    [
+                                        -122.1721984724689, 
+                                        37.44864056824365
+                                    ], 
+                                    [
+                                        -122.17496938919679, 
+                                        37.45043034474932
+                                    ], 
+                                    [
+                                        -122.17774030592466, 
+                                        37.452220121255
+                                    ], 
+                                    [
+                                        -122.18051122265254, 
+                                        37.45400989776068
+                                    ], 
+                                    [
+                                        -122.18265352309774, 
+                                        37.45521795270686
+                                    ], 
+                                    [
+                                        -122.18297812616736, 
+                                        37.455234559134055
+                                    ], 
+                                    [
+                                        -122.18297685585138, 
+                                        37.45527248308116
+                                    ], 
+                                    [
+                                        -122.18715536720909, 
+                                        37.45782483895851
+                                    ], 
+                                    [
+                                        -122.1929199821255, 
+                                        37.461307357625465
+                                    ], 
+                                    [
+                                        -122.19868459704192, 
+                                        37.46478987629243
+                                    ], 
+                                    [
+                                        -122.20444921195832, 
+                                        37.46827239495939
+                                    ], 
+                                    [
+                                        -122.21021382687474, 
+                                        37.47175491362635
+                                    ], 
+                                    [
+                                        -122.22122353935477, 
+                                        37.47760911658927
+                                    ], 
+                                    [
+                                        -122.22527113976075, 
+                                        37.480997970713915
+                                    ], 
+                                    [
+                                        -122.22787051822483, 
+                                        37.483513127838364
+                                    ], 
+                                    [
+                                        -122.2310934873822, 
+                                        37.48560943996066
+                                    ], 
+                                    [
+                                        -122.23225796143683, 
+                                        37.486200842197015
+                                    ], 
+                                    [
+                                        -122.23215015097362, 
+                                        37.48620425248359
+                                    ], 
+                                    [
+                                        -122.2324141506964, 
+                                        37.48617265487802
+                                    ], 
+                                    [
+                                        -122.23399334263661, 
+                                        37.48713761788742
+                                    ], 
+                                    [
+                                        -122.2394488628466, 
+                                        37.49124070810776
+                                    ], 
+                                    [
+                                        -122.24555553392803, 
+                                        37.49586595138735
+                                    ], 
+                                    [
+                                        -122.25143932205968, 
+                                        37.50029134999388
+                                    ], 
+                                    [
+                                        -122.25703778975145, 
+                                        37.504460920283
+                                    ], 
+                                    [
+                                        -122.26027189790801, 
+                                        37.507438738414216
+                                    ], 
+                                    [
+                                        -122.26046058103992, 
+                                        37.50819925565507
+                                    ], 
+                                    [
+                                        -122.26064998952148, 
+                                        37.50795675593332
+                                    ], 
+                                    [
+                                        -122.26152903667162, 
+                                        37.508736203135264
+                                    ], 
+                                    [
+                                        -122.26404831441324, 
+                                        37.51126830352364
+                                    ], 
+                                    [
+                                        -122.26869290619383, 
+                                        37.514972535479295
+                                    ], 
+                                    [
+                                        -122.27400729460398, 
+                                        37.51913876528616
+                                    ], 
+                                    [
+                                        -122.27637210273848, 
+                                        37.52098211091113
+                                    ], 
+                                    [
+                                        -122.27631153860166, 
+                                        37.52099812973116
+                                    ], 
+                                    [
+                                        -122.27667783855777, 
+                                        37.521638394748514
+                                    ], 
+                                    [
+                                        -122.27859445259284, 
+                                        37.52374547384571
+                                    ], 
+                                    [
+                                        -122.28318334095576, 
+                                        37.5270295508561
+                                    ], 
+                                    [
+                                        -122.28960624755983, 
+                                        37.53105429763591
+                                    ], 
+                                    [
+                                        -122.29403241055141, 
+                                        37.534378473072174
+                                    ], 
+                                    [
+                                        -122.29531912372188, 
+                                        37.535790413072704
+                                    ], 
+                                    [
+                                        -122.29660583689235, 
+                                        37.53720235307323
+                                    ], 
+                                    [
+                                        -122.29789255006281, 
+                                        37.538614293073756
+                                    ], 
+                                    [
+                                        -122.29917926323328, 
+                                        37.540026233074286
+                                    ], 
+                                    [
+                                        -122.30046597640376, 
+                                        37.541438173074816
+                                    ], 
+                                    [
+                                        -122.3012202, 
+                                        37.5422658
+                                    ], 
+                                    [
+                                        -122.30524734303557, 
+                                        37.54756554210941
+                                    ], 
+                                    [
+                                        -122.31130285990125, 
+                                        37.55553463519694
+                                    ], 
+                                    [
+                                        -122.31642944732029, 
+                                        37.56158706721056
+                                    ], 
+                                    [
+                                        -122.32024803735499, 
+                                        37.56494070688814
+                                    ], 
+                                    [
+                                        -122.32296531086864, 
+                                        37.56735454494941
+                                    ], 
+                                    [
+                                        -122.32410410552099, 
+                                        37.56842139787352
+                                    ], 
+                                    [
+                                        -122.32494939253726, 
+                                        37.569116955333214
+                                    ], 
+                                    [
+                                        -122.32529131924638, 
+                                        37.56924863044455
+                                    ], 
+                                    [
+                                        -122.32651711711115, 
+                                        37.57047995135632
+                                    ], 
+                                    [
+                                        -122.32955802497663, 
+                                        37.57330226246332
+                                    ], 
+                                    [
+                                        -122.33314542692999, 
+                                        37.575417531422566
+                                    ], 
+                                    [
+                                        -122.33759508824772, 
+                                        37.57708866817016
+                                    ], 
+                                    [
+                                        -122.3428375254224, 
+                                        37.5793380077982
+                                    ], 
+                                    [
+                                        -122.34439539665098, 
+                                        37.579763161811144
+                                    ], 
+                                    [
+                                        -122.34447924234402, 
+                                        37.579791409982676
+                                    ], 
+                                    [
+                                        -122.34591446428269, 
+                                        37.580257652529546
+                                    ], 
+                                    [
+                                        -122.34984455160998, 
+                                        37.581969711691514
+                                    ], 
+                                    [
+                                        -122.35473564144557, 
+                                        37.5842374356506
+                                    ], 
+                                    [
+                                        -122.35962673128115, 
+                                        37.586505159609686
+                                    ], 
+                                    [
+                                        -122.3657163188463, 
+                                        37.5893269747447
+                                    ], 
+                                    [
+                                        -122.37314371298459, 
+                                        37.59276728651847
+                                    ], 
+                                    [
+                                        -122.38057110712288, 
+                                        37.59620759829224
+                                    ], 
+                                    [
+                                        -122.38714464867707, 
+                                        37.599250758406725
+                                    ], 
+                                    [
+                                        -122.3871681, 
+                                        37.5992489
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41cf6858f03bbe41954", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    169.30129626237616, 
+                                    62.45523591244797, 
+                                    15.126008454012725, 
+                                    100.84042374221578, 
+                                    109.70984318287226, 
+                                    70.51070450556891, 
+                                    110.03805021008299, 
+                                    76.13795646130396, 
+                                    116.31974148546853, 
+                                    113.06559382703769, 
+                                    87.80086230347175, 
+                                    107.49339869829082, 
+                                    78.88246459661927, 
+                                    108.69333340790244, 
+                                    3.5045279730780017, 
+                                    83.68796413934197, 
+                                    115.31768092713338, 
+                                    71.57247018848533, 
+                                    118.75426362314505, 
+                                    10.788247719010345, 
+                                    38.7258959342257, 
+                                    50.670021630140255, 
+                                    20.8493778717095, 
+                                    20.849392080059804, 
+                                    20.849406289590746, 
+                                    227.08335907849488, 
+                                    509.5229345078416, 
+                                    509.51157055754516, 
+                                    509.50020612401295, 
+                                    509.4888412069077, 
+                                    509.47747580626003, 
+                                    465.34493097831535, 
+                                    419.61560587100587, 
+                                    419.6074831739131, 
+                                    419.599360145003, 
+                                    419.5912367857202, 
+                                    419.5831130977042, 
+                                    419.5749890784349, 
+                                    531.917595475678, 
+                                    482.20719455490365, 
+                                    154.01820101580907, 
+                                    1.2132550007189082, 
+                                    4.464369405483149, 
+                                    4.495670072995577, 
+                                    293.8094156588115, 
+                                    598.0076701349717, 
+                                    540.146754039346, 
+                                    478.91549272386123, 
+                                    478.9049677164181, 
+                                    276.7293902076223, 
+                                    1.5071425876353237, 
+                                    47.27085868269058, 
+                                    194.1631248768278, 
+                                    315.34863645179064, 
+                                    315.3440970123475, 
+                                    315.33955742953765, 
+                                    315.33501770486873, 
+                                    315.3304778392769, 
+                                    231.95677179024634, 
+                                    28.712067351513497, 
+                                    4.2184410494334585, 
+                                    465.3845919258973, 
+                                    639.4081170644613, 
+                                    639.3892603596374, 
+                                    639.370402479783, 
+                                    639.3515434280666, 
+                                    1169.485859856247, 
+                                    519.1946736865066, 
+                                    361.6966176339577, 
+                                    367.7046308623606, 
+                                    121.98838569187397, 
+                                    9.520013739439475, 
+                                    23.557025028943507, 
+                                    175.86263499029096, 
+                                    663.2076030436184, 
+                                    744.8276632624406, 
+                                    715.241682302559, 
+                                    677.3910885013588, 
+                                    437.0630081108361, 
+                                    86.18787503010735, 
+                                    31.72109971737358, 
+                                    116.29251019083387, 
+                                    358.68204390945345, 
+                                    580.9265179281608, 
+                                    659.0172459486332, 
+                                    292.4212954806713, 
+                                    5.630448030373938, 
+                                    78.18059087594364, 
+                                    288.9026458686195, 
+                                    545.0841599209905, 
+                                    721.8587240137086, 
+                                    537.5449143900288, 
+                                    193.70478321745557, 
+                                    193.70352502547038, 
+                                    193.7022668074068, 
+                                    193.7010085673903, 
+                                    193.69975030130058, 
+                                    113.53903337583274, 
+                                    687.9962876534556, 
+                                    1034.4987347616077, 
+                                    810.6411889644583, 
+                                    502.3397328438508, 
+                                    359.7232431236136, 
+                                    155.3923634527282, 
+                                    107.38753489222758, 
+                                    33.50431333741912, 
+                                    174.40665547284772, 
+                                    412.6883220702896, 
+                                    394.0504109786311, 
+                                    433.9341414195543, 
+                                    525.3466879513509, 
+                                    145.19576939979265, 
+                                    8.028637703048949, 
+                                    136.6883228327708, 
+                                    395.19772744694603, 
+                                    499.3414388469476, 
+                                    499.330106755021, 
+                                    621.5796140819228, 
+                                    758.0293979299447, 
+                                    758.0032806668935, 
+                                    670.7487211577636, 
+                                    2.076357863143329
+                                ], 
+                                "end_ts": 1440694334.783, 
+                                "feature_type": "section", 
+                                "distance": 38089.075668793805, 
+                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
+                                "start_ts": 1440690678.1591113, 
+                                "start_fmt_time": "2015-08-27T08:51:18.159111-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T09:52:14.783000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 9, 
+                                    "month": 8, 
+                                    "second": 14, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 52
+                                }, 
+                                "duration": 3656.623888731003, 
+                                "end_stop": {
+                                    "$oid": "57c0e41cf6858f03bbe419d5"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41cf6858f03bbe41952"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 8, 
+                                    "month": 8, 
+                                    "second": 18, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 51
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    5.6433765420792055, 
+                                    2.081841197081599, 
+                                    0.5042002818004242, 
+                                    3.361347458073859, 
+                                    3.656994772762409, 
+                                    2.350356816852297, 
+                                    3.6679350070027663, 
+                                    2.5379318820434653, 
+                                    3.8773247161822844, 
+                                    3.768853127567923, 
+                                    2.926695410115725, 
+                                    3.5831132899430274, 
+                                    2.6294154865539756, 
+                                    3.623111113596748, 
+                                    0.11681759910260006, 
+                                    2.7895988046447324, 
+                                    3.8439226975711125, 
+                                    2.385749006282844, 
+                                    3.958475454104835, 
+                                    0.35960825730034485, 
+                                    1.2908631978075233, 
+                                    1.6890007210046751, 
+                                    0.6949792623903167, 
+                                    0.6949797360019935, 
+                                    0.6949802096530249, 
+                                    7.569445302616496, 
+                                    16.984097816928053, 
+                                    16.98371901858484, 
+                                    16.983340204133764, 
+                                    16.98296137356359, 
+                                    16.982582526875333, 
+                                    15.511497699277179, 
+                                    13.987186862366862, 
+                                    13.986916105797103, 
+                                    13.986645338166767, 
+                                    13.986374559524005, 
+                                    13.986103769923472, 
+                                    13.985832969281164, 
+                                    17.730586515855933, 
+                                    16.07357315183012, 
+                                    5.133940033860302, 
+                                    0.04044183335729694, 
+                                    0.14881231351610497, 
+                                    0.14985566909985257, 
+                                    9.79364718862705, 
+                                    19.93358900449906, 
+                                    18.004891801311533, 
+                                    15.963849757462041, 
+                                    15.963498923880604, 
+                                    9.224313006920744, 
+                                    0.05023808625451079, 
+                                    1.5756952894230194, 
+                                    6.472104162560926, 
+                                    10.511621215059687, 
+                                    10.511469900411583, 
+                                    10.511318580984588, 
+                                    10.511167256828958, 
+                                    10.511015927975897, 
+                                    7.731892393008211, 
+                                    0.9570689117171166, 
+                                    0.14061470164778195, 
+                                    15.512819730863244, 
+                                    21.31360390214871, 
+                                    21.31297534532125, 
+                                    21.3123467493261, 
+                                    21.31171811426889, 
+                                    38.98286199520824, 
+                                    17.30648912288355, 
+                                    12.056553921131924, 
+                                    12.256821028745353, 
+                                    4.066279523062466, 
+                                    0.31733379131464917, 
+                                    0.7852341676314503, 
+                                    5.862087833009698, 
+                                    22.106920101453948, 
+                                    24.82758877541469, 
+                                    23.8413894100853, 
+                                    22.579702950045295, 
+                                    14.56876693702787, 
+                                    2.872929167670245, 
+                                    1.0573699905791194, 
+                                    3.876417006361129, 
+                                    11.956068130315115, 
+                                    19.36421726427203, 
+                                    21.967241531621106, 
+                                    9.747376516022376, 
+                                    0.18768160101246462, 
+                                    2.606019695864788, 
+                                    9.630088195620651, 
+                                    18.16947199736635, 
+                                    24.061957467123623, 
+                                    17.91816381300096, 
+                                    6.456826107248519, 
+                                    6.456784167515679, 
+                                    6.45674222691356, 
+                                    6.456700285579676, 
+                                    6.456658343376686, 
+                                    3.7846344458610917, 
+                                    22.93320958844852, 
+                                    34.483291158720256, 
+                                    27.02137296548194, 
+                                    16.744657761461692, 
+                                    11.99077477078712, 
+                                    5.179745448424273, 
+                                    3.579584496407586, 
+                                    1.1168104445806373, 
+                                    5.813555182428257, 
+                                    13.756277402342986, 
+                                    13.135013699287702, 
+                                    14.46447138065181, 
+                                    17.51155626504503, 
+                                    4.839858979993088, 
+                                    0.2676212567682983, 
+                                    4.556277427759027, 
+                                    13.173257581564867, 
+                                    16.644714628231586, 
+                                    16.644336891834033, 
+                                    20.719320469397427, 
+                                    25.267646597664825, 
+                                    25.266776022229784, 
+                                    22.35829070525879, 
+                                    0.07798852692489906
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.3872958, 
+                                        37.5992574
+                                    ], 
+                                    [
+                                        -122.38706284639784, 
+                                        37.59921186544218
+                                    ], 
+                                    [
+                                        -122.3872594825592, 
+                                        37.59950210382384
+                                    ], 
+                                    [
+                                        -122.3872605, 
+                                        37.5995036
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41cf6858f03bbe419d0", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    21.138437284785873, 
+                                    36.62858311901798, 
+                                    0.18897778418604586
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1440694424.894, 
+                                "start_ts": 1440694364.74, 
+                                "start_fmt_time": "2015-08-27T09:52:44.740000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T09:53:44.894000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 9, 
+                                    "month": 8, 
+                                    "second": 44, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 53
+                                }, 
+                                "duration": 60.15400004386902, 
+                                "start_stop": {
+                                    "$oid": "57c0e41cf6858f03bbe419d5"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41cf6858f03bbe41952"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 9, 
+                                    "month": 8, 
+                                    "second": 44, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 52
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    0.704614576159529, 
+                                    1.2209527706339327, 
+                                    1.2271281191762313
+                                ], 
+                                "distance": 57.9559981879899
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57c0e41cf6858f03bbe41952", 
+            "properties": {
+                "distance": 38158.321602003176, 
+                "end_place": {
+                    "$oid": "57c0e420f6858f03bbe41b85"
+                }, 
+                "raw_trip": {
+                    "$oid": "57c0e419f6858f03bbe418f9"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0778188, 
+                        37.3957356
+                    ]
+                }, 
+                "end_ts": 1440694424.894, 
+                "start_ts": 1440690678.1591113, 
+                "start_fmt_time": "2015-08-27T08:51:18.159111-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.3872605, 
+                        37.5995036
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57c0e420f6858f03bbe41b84"
+                }, 
+                "end_fmt_time": "2015-08-27T09:53:44.894000-07:00", 
+                "end_local_dt": {
+                    "hour": 9, 
+                    "month": 8, 
+                    "second": 44, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 53
+                }, 
+                "duration": 3706.1260001659393, 
+                "start_local_dt": {
+                    "hour": 8, 
+                    "month": 8, 
+                    "second": 18, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 51
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.3872605, 
+                            37.5995036
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b85", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T09:53:44.894000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 10, 
+                            "month": 8, 
+                            "second": 16, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 2
+                        }, 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2015-08-27T10:02:16.470599-07:00", 
+                        "enter_local_dt": {
+                            "hour": 9, 
+                            "month": 8, 
+                            "second": 44, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 53
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41cf6858f03bbe41952"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41cf6858f03bbe419d6"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440694424.894, 
+                        "duration": 511.57659935951233, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418fa"
+                            }
+                        ], 
+                        "exit_ts": 1440694936.4705994
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.2603947, 
+                            37.875023
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b86", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T11:14:26.669000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 15, 
+                            "month": 8, 
+                            "second": 49, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 54
+                        }, 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2015-08-27T15:54:49.467144-07:00", 
+                        "enter_local_dt": {
+                            "hour": 11, 
+                            "month": 8, 
+                            "second": 26, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 14
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41cf6858f03bbe419d6"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41df6858f03bbe41a66"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440699266.669, 
+                        "duration": 16822.798144340515, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418fc"
+                            }, 
+                            {
+                                "$oid": "57c0e419f6858f03bbe418fc"
+                            }
+                        ], 
+                        "exit_ts": 1440716089.4671443
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.2705638, 
+                                37.8440278
+                            ], 
+                            [
+                                -122.2682605, 
+                                37.8700849
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e41df6858f03bbe41a65", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T10:54:26.704000-07:00", 
+                        "distance": 2904.4651460936093, 
+                        "exit_local_dt": {
+                            "hour": 10, 
+                            "month": 8, 
+                            "second": 26, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 58
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57c0e41df6858f03bbe419d8"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57c0e41df6858f03bbe41a43"
+                        }, 
+                        "exit_fmt_time": "2015-08-27T10:58:26.892000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 10, 
+                            "month": 8, 
+                            "second": 26, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 54
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.2682605, 
+                                37.8700849
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.2705638, 
+                                37.8440278
+                            ]
+                        }, 
+                        "enter_ts": 1440698066.704, 
+                        "duration": 240.18799996376038, 
+                        "_id": {
+                            "$oid": "57c0e41cf6858f03bbe419d6"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57c0e41cf6858f03bbe419d6"
+                        }, 
+                        "exit_ts": 1440698306.892
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.3872605, 
+                                        37.5995036
+                                    ], 
+                                    [
+                                        -122.38943533594255, 
+                                        37.60181732483102
+                                    ], 
+                                    [
+                                        -122.3916101718851, 
+                                        37.60413104966203
+                                    ], 
+                                    [
+                                        -122.39378500782767, 
+                                        37.60644477449305
+                                    ], 
+                                    [
+                                        -122.39595984377023, 
+                                        37.60875849932406
+                                    ], 
+                                    [
+                                        -122.39813467971278, 
+                                        37.61107222415508
+                                    ], 
+                                    [
+                                        -122.40030951565534, 
+                                        37.61338594898609
+                                    ], 
+                                    [
+                                        -122.4024843515979, 
+                                        37.61569967381711
+                                    ], 
+                                    [
+                                        -122.40331094109018, 
+                                        37.616812007175135
+                                    ], 
+                                    [
+                                        -122.40570766227482, 
+                                        37.6199361687232
+                                    ], 
+                                    [
+                                        -122.40864891099417, 
+                                        37.62371713795991
+                                    ], 
+                                    [
+                                        -122.41159015971351, 
+                                        37.627498107196615
+                                    ], 
+                                    [
+                                        -122.41453140843286, 
+                                        37.63127907643332
+                                    ], 
+                                    [
+                                        -122.4174726571522, 
+                                        37.63506004567003
+                                    ], 
+                                    [
+                                        -122.42041390587156, 
+                                        37.63884101490673
+                                    ], 
+                                    [
+                                        -122.4233551545909, 
+                                        37.64262198414344
+                                    ], 
+                                    [
+                                        -122.42629640331025, 
+                                        37.64640295338015
+                                    ], 
+                                    [
+                                        -122.4292376520296, 
+                                        37.650183922616854
+                                    ], 
+                                    [
+                                        -122.43217890074894, 
+                                        37.65396489185356
+                                    ], 
+                                    [
+                                        -122.43512014946829, 
+                                        37.65774586109026
+                                    ], 
+                                    [
+                                        -122.43806139818763, 
+                                        37.66152683032697
+                                    ], 
+                                    [
+                                        -122.44100264690698, 
+                                        37.66530779956368
+                                    ], 
+                                    [
+                                        -122.44394389562632, 
+                                        37.669088768800385
+                                    ], 
+                                    [
+                                        -122.44688514434567, 
+                                        37.67286973803709
+                                    ], 
+                                    [
+                                        -122.44982639306501, 
+                                        37.6766507072738
+                                    ], 
+                                    [
+                                        -122.45276764178436, 
+                                        37.6804316765105
+                                    ], 
+                                    [
+                                        -122.45570889050371, 
+                                        37.68421264574721
+                                    ], 
+                                    [
+                                        -122.45865013922305, 
+                                        37.68799361498392
+                                    ], 
+                                    [
+                                        -122.4615913879424, 
+                                        37.691774584220624
+                                    ], 
+                                    [
+                                        -122.46453263666174, 
+                                        37.69555555345733
+                                    ], 
+                                    [
+                                        -122.4674738853811, 
+                                        37.69933652269403
+                                    ], 
+                                    [
+                                        -122.47041513410043, 
+                                        37.70311749193074
+                                    ], 
+                                    [
+                                        -122.46988285724983, 
+                                        37.705054130998384
+                                    ], 
+                                    [
+                                        -122.46899244325444, 
+                                        37.70585630401584
+                                    ], 
+                                    [
+                                        -122.46876146114758, 
+                                        37.70591455518281
+                                    ], 
+                                    [
+                                        -122.46658232620851, 
+                                        37.709378060124166
+                                    ], 
+                                    [
+                                        -122.46053254893589, 
+                                        37.7104573330376
+                                    ], 
+                                    [
+                                        -122.455106031357, 
+                                        37.71116024632176
+                                    ], 
+                                    [
+                                        -122.45065720092147, 
+                                        37.714107179215546
+                                    ], 
+                                    [
+                                        -122.44684381666558, 
+                                        37.71665440785618
+                                    ], 
+                                    [
+                                        -122.44318181304111, 
+                                        37.71888092335173
+                                    ], 
+                                    [
+                                        -122.43951980941664, 
+                                        37.72110743884728
+                                    ], 
+                                    [
+                                        -122.43585780579217, 
+                                        37.72333395434282
+                                    ], 
+                                    [
+                                        -122.43219580216768, 
+                                        37.72556046983837
+                                    ], 
+                                    [
+                                        -122.42853379854321, 
+                                        37.727786985333914
+                                    ], 
+                                    [
+                                        -122.42487179491874, 
+                                        37.73001350082946
+                                    ], 
+                                    [
+                                        -122.42120979129427, 
+                                        37.73224001632501
+                                    ], 
+                                    [
+                                        -122.4175477876698, 
+                                        37.73446653182055
+                                    ], 
+                                    [
+                                        -122.41388578404533, 
+                                        37.736693047316095
+                                    ], 
+                                    [
+                                        -122.41022378042086, 
+                                        37.738919562811645
+                                    ], 
+                                    [
+                                        -122.40656177679638, 
+                                        37.74114607830719
+                                    ], 
+                                    [
+                                        -122.40289977317191, 
+                                        37.74337259380273
+                                    ], 
+                                    [
+                                        -122.39923776954744, 
+                                        37.74559910929828
+                                    ], 
+                                    [
+                                        -122.39557576592297, 
+                                        37.747825624793826
+                                    ], 
+                                    [
+                                        -122.3919137622985, 
+                                        37.75005214028937
+                                    ], 
+                                    [
+                                        -122.38825175867403, 
+                                        37.75227865578492
+                                    ], 
+                                    [
+                                        -122.38458975504955, 
+                                        37.754505171280464
+                                    ], 
+                                    [
+                                        -122.38092775142508, 
+                                        37.75673168677601
+                                    ], 
+                                    [
+                                        -122.3772657478006, 
+                                        37.75895820227156
+                                    ], 
+                                    [
+                                        -122.37360374417614, 
+                                        37.7611847177671
+                                    ], 
+                                    [
+                                        -122.36994174055167, 
+                                        37.763411233262644
+                                    ], 
+                                    [
+                                        -122.3662797369272, 
+                                        37.765637748758195
+                                    ], 
+                                    [
+                                        -122.36261773330273, 
+                                        37.76786426425374
+                                    ], 
+                                    [
+                                        -122.35895572967824, 
+                                        37.77009077974928
+                                    ], 
+                                    [
+                                        -122.35529372605377, 
+                                        37.772317295244825
+                                    ], 
+                                    [
+                                        -122.3516317224293, 
+                                        37.774543810740376
+                                    ], 
+                                    [
+                                        -122.34796971880483, 
+                                        37.77677032623592
+                                    ], 
+                                    [
+                                        -122.34430771518036, 
+                                        37.77899684173146
+                                    ], 
+                                    [
+                                        -122.3406457115559, 
+                                        37.78122335722701
+                                    ], 
+                                    [
+                                        -122.33698370793142, 
+                                        37.78344987272256
+                                    ], 
+                                    [
+                                        -122.33332170430694, 
+                                        37.7856763882181
+                                    ], 
+                                    [
+                                        -122.32965970068247, 
+                                        37.78790290371365
+                                    ], 
+                                    [
+                                        -122.325997697058, 
+                                        37.790129419209194
+                                    ], 
+                                    [
+                                        -122.32233569343353, 
+                                        37.79235593470474
+                                    ], 
+                                    [
+                                        -122.31867368980906, 
+                                        37.79458245020029
+                                    ], 
+                                    [
+                                        -122.31501168618459, 
+                                        37.79680896569583
+                                    ], 
+                                    [
+                                        -122.31134968256012, 
+                                        37.799035481191375
+                                    ], 
+                                    [
+                                        -122.30768767893564, 
+                                        37.801261996686925
+                                    ], 
+                                    [
+                                        -122.30402567531117, 
+                                        37.80348851218247
+                                    ], 
+                                    [
+                                        -122.3003636716867, 
+                                        37.80571502767801
+                                    ], 
+                                    [
+                                        -122.29597842061877, 
+                                        37.80514412592476
+                                    ], 
+                                    [
+                                        -122.29439563243965, 
+                                        37.804597291353716
+                                    ], 
+                                    [
+                                        -122.29182482779107, 
+                                        37.803846995704056
+                                    ], 
+                                    [
+                                        -122.28839774168254, 
+                                        37.80285221098052
+                                    ], 
+                                    [
+                                        -122.28303842241617, 
+                                        37.80095777802297
+                                    ], 
+                                    [
+                                        -122.2795278210576, 
+                                        37.79952285061273
+                                    ], 
+                                    [
+                                        -122.27804294114121, 
+                                        37.80045905348325
+                                    ], 
+                                    [
+                                        -122.2769538873445, 
+                                        37.80222882974804
+                                    ], 
+                                    [
+                                        -122.2758648335478, 
+                                        37.803998606012826
+                                    ], 
+                                    [
+                                        -122.2747757797511, 
+                                        37.80576838227761
+                                    ], 
+                                    [
+                                        -122.27368672595439, 
+                                        37.8075381585424
+                                    ], 
+                                    [
+                                        -122.27259767215769, 
+                                        37.80930793480719
+                                    ], 
+                                    [
+                                        -122.27150861836098, 
+                                        37.81107771107197
+                                    ], 
+                                    [
+                                        -122.27041956456428, 
+                                        37.812847487336754
+                                    ], 
+                                    [
+                                        -122.26933051076757, 
+                                        37.81461726360154
+                                    ], 
+                                    [
+                                        -122.27011423274739, 
+                                        37.81493704552863
+                                    ], 
+                                    [
+                                        -122.271685548239, 
+                                        37.81464703414952
+                                    ], 
+                                    [
+                                        -122.27148344702869, 
+                                        37.81745342519405
+                                    ], 
+                                    [
+                                        -122.27045693334298, 
+                                        37.82169924825931
+                                    ], 
+                                    [
+                                        -122.26943041965728, 
+                                        37.825945071324554
+                                    ], 
+                                    [
+                                        -122.26912589543251, 
+                                        37.82924899416199
+                                    ], 
+                                    [
+                                        -122.26918657340711, 
+                                        37.83207647786365
+                                    ], 
+                                    [
+                                        -122.26924725138171, 
+                                        37.83490396156531
+                                    ], 
+                                    [
+                                        -122.26930792935632, 
+                                        37.83773144526697
+                                    ], 
+                                    [
+                                        -122.27014330571282, 
+                                        37.84221082079968
+                                    ], 
+                                    [
+                                        -122.2705638, 
+                                        37.8440278
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41df6858f03bbe419d8", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    320.78037466966975, 
+                                    320.7768156437519, 
+                                    320.7732565044456, 
+                                    320.7696972469924, 
+                                    320.7661378761896, 
+                                    320.76257838877405, 
+                                    320.7590187880474, 
+                                    143.52288218962568, 
+                                    406.49944461902413, 
+                                    493.8223819091249, 
+                                    493.8154706327788, 
+                                    493.80855902087734, 
+                                    493.80164707090114, 
+                                    493.7947347849095, 
+                                    493.7878221624011, 
+                                    493.78090920408926, 
+                                    493.77399590878446, 
+                                    493.76708227659293, 
+                                    493.76016830891666, 
+                                    493.7532540052559, 
+                                    493.74633936632273, 
+                                    493.7394243902724, 
+                                    493.732509079835, 
+                                    493.72559343249327, 
+                                    493.7186774503041, 
+                                    493.71176113342494, 
+                                    493.70484447994403, 
+                                    493.69792749260716, 
+                                    493.6910101688985, 
+                                    493.68409251087377, 
+                                    493.67717451803617, 
+                                    220.37697303752472, 
+                                    118.71077917888171, 
+                                    21.327568512609602, 
+                                    430.19734497982296, 
+                                    545.5518897526107, 
+                                    483.71214921437246, 
+                                    510.4165217284997, 
+                                    439.020456596289, 
+                                    406.2594722352683, 
+                                    406.25179684403207, 
+                                    406.2441211533155, 
+                                    406.2364451641393, 
+                                    406.2287688721151, 
+                                    406.22109228168983, 
+                                    406.213415391902, 
+                                    406.20573820133615, 
+                                    406.1980607114664, 
+                                    406.1903829223221, 
+                                    406.1827048334788, 
+                                    406.17502644343836, 
+                                    406.1673477552021, 
+                                    406.15966876636435, 
+                                    406.15198947839883, 
+                                    406.1443098913353, 
+                                    406.13663000474855, 
+                                    406.12894981714163, 
+                                    406.1212693315152, 
+                                    406.11358854546336, 
+                                    406.1059074604604, 
+                                    406.0982260765357, 
+                                    406.0905443922738, 
+                                    406.08286241013906, 
+                                    406.07518012670914, 
+                                    406.0674975454652, 
+                                    406.0598146640017, 
+                                    406.05213148379295, 
+                                    406.0444480048686, 
+                                    406.03676422581276, 
+                                    406.0290801490898, 
+                                    406.0213957717599, 
+                                    406.0137110953766, 
+                                    406.00602612042474, 
+                                    405.99834084693384, 
+                                    405.990655273488, 
+                                    405.9829694015622, 
+                                    405.97528323217506, 
+                                    405.9675967609423, 
+                                    405.9599099923072, 
+                                    390.46021278333865, 
+                                    151.7695565532854, 
+                                    240.77721191964739, 
+                                    320.77014146564096, 
+                                    515.8363194934051, 
+                                    347.2700458252823, 
+                                    166.90630983364224, 
+                                    218.81901591627837, 
+                                    218.81801338975063, 
+                                    218.81701084273502, 
+                                    218.81600827523513, 
+                                    218.8150056872544, 
+                                    218.81400307808585, 
+                                    218.8130004498647, 
+                                    218.81199780046288, 
+                                    77.48557438226604, 
+                                    141.74701811064563, 
+                                    312.5610256599072, 
+                                    480.6471409948956, 
+                                    480.6461680138889, 
+                                    368.35174433601503, 
+                                    314.4470023504811, 
+                                    314.4469988895449, 
+                                    314.44699542852135, 
+                                    503.4568720449231, 
+                                    205.38513667072613
+                                ], 
+                                "end_ts": 1440698066.704, 
+                                "feature_type": "section", 
+                                "distance": 40069.54392210929, 
+                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
+                                "start_ts": 1440694936.4705994, 
+                                "start_fmt_time": "2015-08-27T10:02:16.470599-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T10:54:26.704000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 10, 
+                                    "month": 8, 
+                                    "second": 26, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 54
+                                }, 
+                                "duration": 3130.233400583267, 
+                                "end_stop": {
+                                    "$oid": "57c0e41df6858f03bbe41a65"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41cf6858f03bbe419d6"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 10, 
+                                    "month": 8, 
+                                    "second": 16, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 2
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    10.692679155655659, 
+                                    10.692560521458397, 
+                                    10.69244188348152, 
+                                    10.692323241566413, 
+                                    10.692204595872987, 
+                                    10.692085946292469, 
+                                    10.691967292934914, 
+                                    4.784096072987523, 
+                                    13.549981487300805, 
+                                    16.460746063637497, 
+                                    16.460515687759294, 
+                                    16.46028530069591, 
+                                    16.46005490236337, 
+                                    16.459824492830318, 
+                                    16.459594072080037, 
+                                    16.45936364013631, 
+                                    16.45913319695948, 
+                                    16.458902742553096, 
+                                    16.45867227696389, 
+                                    16.458441800175198, 
+                                    16.458211312210757, 
+                                    16.45798081300908, 
+                                    16.457750302661164, 
+                                    16.45751978108311, 
+                                    16.457289248343468, 
+                                    16.457058704447498, 
+                                    16.456828149331468, 
+                                    16.456597583086907, 
+                                    16.45636700562995, 
+                                    16.456136417029125, 
+                                    16.455905817267872, 
+                                    7.345899101250824, 
+                                    3.95702597262939, 
+                                    0.71091895042032, 
+                                    14.339911499327432, 
+                                    18.18506299175369, 
+                                    16.12373830714575, 
+                                    17.013884057616657, 
+                                    14.6340152198763, 
+                                    13.541982407842276, 
+                                    13.541726561467735, 
+                                    13.541470705110518, 
+                                    13.541214838804644, 
+                                    13.540958962403836, 
+                                    13.540703076056328, 
+                                    13.540447179730068, 
+                                    13.540191273377872, 
+                                    13.53993535704888, 
+                                    13.53967943074407, 
+                                    13.539423494449293, 
+                                    13.539167548114612, 
+                                    13.53891159184007, 
+                                    13.538655625545479, 
+                                    13.538399649279961, 
+                                    13.53814366304451, 
+                                    13.537887666824952, 
+                                    13.537631660571387, 
+                                    13.53737564438384, 
+                                    13.537119618182112, 
+                                    13.536863582015346, 
+                                    13.536607535884523, 
+                                    13.536351479742459, 
+                                    13.536095413671301, 
+                                    13.535839337556972, 
+                                    13.535583251515506, 
+                                    13.535327155466723, 
+                                    13.535071049459765, 
+                                    13.534814933495621, 
+                                    13.534558807527093, 
+                                    13.534302671636327, 
+                                    13.53404652572533, 
+                                    13.533790369845887, 
+                                    13.533534204014158, 
+                                    13.533278028231129, 
+                                    13.533021842449601, 
+                                    13.532765646718738, 
+                                    13.532509441072502, 
+                                    13.532253225364743, 
+                                    13.531996999743573, 
+                                    13.015340426111289, 
+                                    5.058985218442847, 
+                                    8.025907063988246, 
+                                    10.6923380488547, 
+                                    17.1945439831135, 
+                                    11.575668194176076, 
+                                    5.563543661121408, 
+                                    7.293967197209279, 
+                                    7.293933779658355, 
+                                    7.293900361424501, 
+                                    7.2938669425078375, 
+                                    7.29383352290848, 
+                                    7.293800102602861, 
+                                    7.293766681662157, 
+                                    7.293733260015429, 
+                                    2.582852479408868, 
+                                    4.724900603688187, 
+                                    10.41870085533024, 
+                                    16.02157136649652, 
+                                    16.021538933796297, 
+                                    12.278391477867167, 
+                                    10.481566745016037, 
+                                    10.481566629651496, 
+                                    10.481566514284046, 
+                                    16.78189573483077, 
+                                    20.070076901568232
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.2682605, 
+                                        37.8700849
+                                    ], 
+                                    [
+                                        -122.26819713283284, 
+                                        37.87040193716121
+                                    ], 
+                                    [
+                                        -122.26813583015814, 
+                                        37.87072068746613
+                                    ], 
+                                    [
+                                        -122.26822581879796, 
+                                        37.871164182922286
+                                    ], 
+                                    [
+                                        -122.2678958443703, 
+                                        37.871162158361095
+                                    ], 
+                                    [
+                                        -122.26752496394688, 
+                                        37.871170518780445
+                                    ], 
+                                    [
+                                        -122.2669616471382, 
+                                        37.87132428027256
+                                    ], 
+                                    [
+                                        -122.26657931456204, 
+                                        37.871792773695766
+                                    ], 
+                                    [
+                                        -122.2664828, 
+                                        37.8716111
+                                    ], 
+                                    [
+                                        -122.2664828, 
+                                        37.8716111
+                                    ], 
+                                    [
+                                        -122.26619605942552, 
+                                        37.871492407385894
+                                    ], 
+                                    [
+                                        -122.2661958, 
+                                        37.8714923
+                                    ], 
+                                    [
+                                        -122.2661958, 
+                                        37.8714923
+                                    ], 
+                                    [
+                                        -122.26409632726971, 
+                                        37.871776108026324
+                                    ], 
+                                    [
+                                        -122.2641226811183, 
+                                        37.87187549738821
+                                    ], 
+                                    [
+                                        -122.26394716215142, 
+                                        37.87200684391983
+                                    ], 
+                                    [
+                                        -122.26372716993468, 
+                                        37.87218280433579
+                                    ], 
+                                    [
+                                        -122.26348596700898, 
+                                        37.87218426858689
+                                    ], 
+                                    [
+                                        -122.26296046716568, 
+                                        37.87245086295697
+                                    ], 
+                                    [
+                                        -122.26268984968807, 
+                                        37.87243670371433
+                                    ], 
+                                    [
+                                        -122.2623930020699, 
+                                        37.872318311399944
+                                    ], 
+                                    [
+                                        -122.26245328889898, 
+                                        37.87233859482948
+                                    ], 
+                                    [
+                                        -122.26216949578131, 
+                                        37.87320924283683
+                                    ], 
+                                    [
+                                        -122.26160711654842, 
+                                        37.873411856018265
+                                    ], 
+                                    [
+                                        -122.26155910696049, 
+                                        37.87337117829105
+                                    ], 
+                                    [
+                                        -122.2616393, 
+                                        37.8734842
+                                    ], 
+                                    [
+                                        -122.2616393, 
+                                        37.8734842
+                                    ], 
+                                    [
+                                        -122.2616393, 
+                                        37.8734842
+                                    ], 
+                                    [
+                                        -122.26014501737879, 
+                                        37.87502184101186
+                                    ], 
+                                    [
+                                        -122.26029657300413, 
+                                        37.87508383032673
+                                    ], 
+                                    [
+                                        -122.26032112597528, 
+                                        37.87506468030227
+                                    ], 
+                                    [
+                                        -122.2603292252078, 
+                                        37.87501589130828
+                                    ], 
+                                    [
+                                        -122.2603947, 
+                                        37.875023
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41df6858f03bbe41a43", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    35.68903075935187, 
+                                    35.84955687109811, 
+                                    49.94304035632598, 
+                                    28.964879745489064, 
+                                    32.56785993557204, 
+                                    52.31848941633157, 
+                                    61.96808756733756, 
+                                    21.905639925456928, 
+                                    0.0, 
+                                    28.41942905117402, 
+                                    0.025712195801050677, 
+                                    0.0, 
+                                    186.9658067554721, 
+                                    11.291090645740372, 
+                                    21.228789016482626, 
+                                    27.489945730117572, 
+                                    21.172284757276913, 
+                                    54.83023500327235, 
+                                    23.805567390137107, 
+                                    29.192688767792855, 
+                                    5.752287699973198, 
+                                    99.96496045507438, 
+                                    54.260599607708755, 
+                                    6.181960287587016, 
+                                    14.40437296303708, 
+                                    0.0, 
+                                    0.0, 
+                                    215.48945127443346, 
+                                    14.982116212565153, 
+                                    3.0296147639092896, 
+                                    5.471466335730012, 
+                                    5.800954737773264
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1440699266.669, 
+                                "start_ts": 1440698306.892, 
+                                "start_fmt_time": "2015-08-27T10:58:26.892000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T11:14:26.669000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 11, 
+                                    "month": 8, 
+                                    "second": 26, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 14
+                                }, 
+                                "duration": 959.7769999504089, 
+                                "start_stop": {
+                                    "$oid": "57c0e41df6858f03bbe41a65"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41cf6858f03bbe419d6"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 10, 
+                                    "month": 8, 
+                                    "second": 26, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 58
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    1.1896343586450624, 
+                                    1.1949852290366036, 
+                                    1.6647680118775328, 
+                                    0.9654959915163022, 
+                                    1.0855953311857347, 
+                                    1.7439496472110525, 
+                                    2.065602918911252, 
+                                    0.7301879975152309, 
+                                    0.0, 
+                                    0.9473143017058007, 
+                                    0.0008570731933683559, 
+                                    0.0, 
+                                    6.232193558515736, 
+                                    0.37636968819134575, 
+                                    0.7076263005494209, 
+                                    0.9163315243372524, 
+                                    0.7057428252425637, 
+                                    1.8276745001090784, 
+                                    0.7935189130045702, 
+                                    0.9730896255930952, 
+                                    0.19174292333243995, 
+                                    3.332165348502479, 
+                                    1.808686653590292, 
+                                    0.20606534291956718, 
+                                    0.4801457654345693, 
+                                    0.0, 
+                                    0.0, 
+                                    7.182981709147782, 
+                                    0.49940387375217177, 
+                                    0.10098715879697633, 
+                                    0.1823822111910004, 
+                                    0.194813270223134
+                                ], 
+                                "distance": 1148.9659182280216
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57c0e41cf6858f03bbe419d6", 
+            "properties": {
+                "distance": 44122.97498643092, 
+                "end_place": {
+                    "$oid": "57c0e420f6858f03bbe41b86"
+                }, 
+                "raw_trip": {
+                    "$oid": "57c0e419f6858f03bbe418fb"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.3872605, 
+                        37.5995036
+                    ]
+                }, 
+                "end_ts": 1440699266.669, 
+                "start_ts": 1440694936.4705994, 
+                "start_fmt_time": "2015-08-27T10:02:16.470599-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.2603947, 
+                        37.875023
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57c0e420f6858f03bbe41b85"
+                }, 
+                "end_fmt_time": "2015-08-27T11:14:26.669000-07:00", 
+                "end_local_dt": {
+                    "hour": 11, 
+                    "month": 8, 
+                    "second": 26, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 14
+                }, 
+                "duration": 4113.679999828339, 
+                "start_local_dt": {
+                    "hour": 10, 
+                    "month": 8, 
+                    "second": 16, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 2
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.2603947, 
+                            37.875023
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b86", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T11:14:26.669000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 15, 
+                            "month": 8, 
+                            "second": 49, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 54
+                        }, 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2015-08-27T15:54:49.467144-07:00", 
+                        "enter_local_dt": {
+                            "hour": 11, 
+                            "month": 8, 
+                            "second": 26, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 14
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41cf6858f03bbe419d6"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41df6858f03bbe41a66"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440699266.669, 
+                        "duration": 16822.798144340515, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe418fc"
+                            }, 
+                            {
+                                "$oid": "57c0e419f6858f03bbe418fc"
+                            }
+                        ], 
+                        "exit_ts": 1440716089.4671443
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.3871046, 
+                            37.5993148
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b87", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T16:54:59.470000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 16, 
+                            "month": 8, 
+                            "second": 59, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 57
+                        }, 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2015-08-27T16:57:59.470000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 16, 
+                            "month": 8, 
+                            "second": 59, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 54
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41df6858f03bbe41a66"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440719699.47, 
+                        "duration": 180.0, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe41900"
+                            }
+                        ], 
+                        "exit_ts": 1440719879.47
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.3872753, 
+                                37.5992646
+                            ], 
+                            [
+                                -122.3872511, 
+                                37.5992711
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e41ef6858f03bbe41ae4", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T16:51:59.226000-07:00", 
+                        "distance": 2.251187528064414, 
+                        "exit_local_dt": {
+                            "hour": 16, 
+                            "month": 8, 
+                            "second": 59, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 52
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57c0e41ef6858f03bbe41a68"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57c0e41ef6858f03bbe41add"
+                        }, 
+                        "exit_fmt_time": "2015-08-27T16:52:59.435000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 16, 
+                            "month": 8, 
+                            "second": 59, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 51
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.3872511, 
+                                37.5992711
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.3872753, 
+                                37.5992646
+                            ]
+                        }, 
+                        "enter_ts": 1440719519.226, 
+                        "duration": 60.20899987220764, 
+                        "_id": {
+                            "$oid": "57c0e41df6858f03bbe41a66"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57c0e41df6858f03bbe41a66"
+                        }, 
+                        "exit_ts": 1440719579.435
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.2589186, 
+                                        37.8752735
+                                    ], 
+                                    [
+                                        -122.26027390046023, 
+                                        37.872236029322984
+                                    ], 
+                                    [
+                                        -122.26162920092045, 
+                                        37.86919855864598
+                                    ], 
+                                    [
+                                        -122.26298450138069, 
+                                        37.86616108796896
+                                    ], 
+                                    [
+                                        -122.2643398018409, 
+                                        37.86312361729195
+                                    ], 
+                                    [
+                                        -122.26569510230114, 
+                                        37.86008614661493
+                                    ], 
+                                    [
+                                        -122.26705040276137, 
+                                        37.857048675937925
+                                    ], 
+                                    [
+                                        -122.26840570322159, 
+                                        37.85401120526091
+                                    ], 
+                                    [
+                                        -122.26976100368182, 
+                                        37.850973734583896
+                                    ], 
+                                    [
+                                        -122.27111630414204, 
+                                        37.84793626390689
+                                    ], 
+                                    [
+                                        -122.27047906424573, 
+                                        37.84305482651795
+                                    ], 
+                                    [
+                                        -122.26848797826918, 
+                                        37.83750619452613
+                                    ], 
+                                    [
+                                        -122.26749552099173, 
+                                        37.83337242158392
+                                    ], 
+                                    [
+                                        -122.26754294174897, 
+                                        37.82997456692428
+                                    ], 
+                                    [
+                                        -122.2675635, 
+                                        37.8285015
+                                    ], 
+                                    [
+                                        -122.26759160353716, 
+                                        37.82823209367825
+                                    ], 
+                                    [
+                                        -122.26827456844036, 
+                                        37.82494684519473
+                                    ], 
+                                    [
+                                        -122.26923731947537, 
+                                        37.82013178727551
+                                    ], 
+                                    [
+                                        -122.27003706290702, 
+                                        37.81581849070599
+                                    ], 
+                                    [
+                                        -122.27086075125969, 
+                                        37.813102997787034
+                                    ], 
+                                    [
+                                        -122.27170310600239, 
+                                        37.81163308117149
+                                    ], 
+                                    [
+                                        -122.2725454607451, 
+                                        37.81016316455596
+                                    ], 
+                                    [
+                                        -122.27338781548782, 
+                                        37.808693247940425
+                                    ], 
+                                    [
+                                        -122.27423017023054, 
+                                        37.80722333132489
+                                    ], 
+                                    [
+                                        -122.27507252497324, 
+                                        37.80575341470936
+                                    ], 
+                                    [
+                                        -122.27591487971596, 
+                                        37.80428349809382
+                                    ], 
+                                    [
+                                        -122.27675723445867, 
+                                        37.80281358147828
+                                    ], 
+                                    [
+                                        -122.27759958920139, 
+                                        37.80134366486275
+                                    ], 
+                                    [
+                                        -122.27844194394409, 
+                                        37.799873748247215
+                                    ], 
+                                    [
+                                        -122.28073034634791, 
+                                        37.7999230435577
+                                    ], 
+                                    [
+                                        -122.28496134825374, 
+                                        37.80152749951458
+                                    ], 
+                                    [
+                                        -122.28981401768344, 
+                                        37.80338266607286
+                                    ], 
+                                    [
+                                        -122.29311568500833, 
+                                        37.80453339132447
+                                    ], 
+                                    [
+                                        -122.29419231991496, 
+                                        37.8047096045723
+                                    ], 
+                                    [
+                                        -122.297520233528, 
+                                        37.80565990994512
+                                    ], 
+                                    [
+                                        -122.30391248979782, 
+                                        37.8073855360997
+                                    ], 
+                                    [
+                                        -122.30894183737323, 
+                                        37.80686746272269
+                                    ], 
+                                    [
+                                        -122.31245126738035, 
+                                        37.804555472523965
+                                    ], 
+                                    [
+                                        -122.31596069738747, 
+                                        37.80224348232524
+                                    ], 
+                                    [
+                                        -122.31947012739458, 
+                                        37.79993149212651
+                                    ], 
+                                    [
+                                        -122.3229795574017, 
+                                        37.79761950192778
+                                    ], 
+                                    [
+                                        -122.32648898740881, 
+                                        37.79530751172905
+                                    ], 
+                                    [
+                                        -122.32999841741594, 
+                                        37.79299552153032
+                                    ], 
+                                    [
+                                        -122.33350784742305, 
+                                        37.790683531331595
+                                    ], 
+                                    [
+                                        -122.33701727743016, 
+                                        37.78837154113287
+                                    ], 
+                                    [
+                                        -122.34052670743728, 
+                                        37.786059550934134
+                                    ], 
+                                    [
+                                        -122.34403613744439, 
+                                        37.78374756073541
+                                    ], 
+                                    [
+                                        -122.34754556745152, 
+                                        37.78143557053668
+                                    ], 
+                                    [
+                                        -122.35105499745863, 
+                                        37.77912358033795
+                                    ], 
+                                    [
+                                        -122.35456442746575, 
+                                        37.77681159013922
+                                    ], 
+                                    [
+                                        -122.35807385747286, 
+                                        37.77449959994049
+                                    ], 
+                                    [
+                                        -122.36158328747997, 
+                                        37.77218760974176
+                                    ], 
+                                    [
+                                        -122.3650927174871, 
+                                        37.769875619543036
+                                    ], 
+                                    [
+                                        -122.36860214749422, 
+                                        37.76756362934431
+                                    ], 
+                                    [
+                                        -122.37211157750133, 
+                                        37.765251639145575
+                                    ], 
+                                    [
+                                        -122.37562100750844, 
+                                        37.76293964894685
+                                    ], 
+                                    [
+                                        -122.37913043751556, 
+                                        37.76062765874812
+                                    ], 
+                                    [
+                                        -122.38263986752268, 
+                                        37.75831566854939
+                                    ], 
+                                    [
+                                        -122.3861492975298, 
+                                        37.756003678350666
+                                    ], 
+                                    [
+                                        -122.38965872753691, 
+                                        37.75369168815193
+                                    ], 
+                                    [
+                                        -122.39316815754403, 
+                                        37.751379697953205
+                                    ], 
+                                    [
+                                        -122.39667758755114, 
+                                        37.74906770775448
+                                    ], 
+                                    [
+                                        -122.40018701755827, 
+                                        37.74675571755575
+                                    ], 
+                                    [
+                                        -122.40369644756538, 
+                                        37.74444372735702
+                                    ], 
+                                    [
+                                        -122.4072058775725, 
+                                        37.74213173715829
+                                    ], 
+                                    [
+                                        -122.41071530757961, 
+                                        37.73981974695956
+                                    ], 
+                                    [
+                                        -122.41422473758672, 
+                                        37.737507756760834
+                                    ], 
+                                    [
+                                        -122.41773416759385, 
+                                        37.73519576656211
+                                    ], 
+                                    [
+                                        -122.42124359760096, 
+                                        37.73288377636337
+                                    ], 
+                                    [
+                                        -122.42475302760808, 
+                                        37.730571786164646
+                                    ], 
+                                    [
+                                        -122.42826245761519, 
+                                        37.72825979596592
+                                    ], 
+                                    [
+                                        -122.4317718876223, 
+                                        37.72594780576719
+                                    ], 
+                                    [
+                                        -122.43528131762943, 
+                                        37.723635815568464
+                                    ], 
+                                    [
+                                        -122.43879074763655, 
+                                        37.72132382536973
+                                    ], 
+                                    [
+                                        -122.44230017764366, 
+                                        37.719011835171
+                                    ], 
+                                    [
+                                        -122.44580960765077, 
+                                        37.716699844972275
+                                    ], 
+                                    [
+                                        -122.44931903765789, 
+                                        37.71438785477355
+                                    ], 
+                                    [
+                                        -122.45282846766501, 
+                                        37.71207586457482
+                                    ], 
+                                    [
+                                        -122.45533439420115, 
+                                        37.710830883916785
+                                    ], 
+                                    [
+                                        -122.45705186910484, 
+                                        37.710424251544055
+                                    ], 
+                                    [
+                                        -122.4578115, 
+                                        37.7102444
+                                    ], 
+                                    [
+                                        -122.4578115, 
+                                        37.7102444
+                                    ], 
+                                    [
+                                        -122.4578115, 
+                                        37.7102444
+                                    ], 
+                                    [
+                                        -122.45651092540835, 
+                                        37.708198110179076
+                                    ], 
+                                    [
+                                        -122.45430071078852, 
+                                        37.70472061668685
+                                    ], 
+                                    [
+                                        -122.45209049616868, 
+                                        37.70124312319463
+                                    ], 
+                                    [
+                                        -122.44988028154886, 
+                                        37.6977656297024
+                                    ], 
+                                    [
+                                        -122.44767006692902, 
+                                        37.69428813621018
+                                    ], 
+                                    [
+                                        -122.44545985230918, 
+                                        37.690810642717956
+                                    ], 
+                                    [
+                                        -122.44324963768935, 
+                                        37.687333149225736
+                                    ], 
+                                    [
+                                        -122.44103942306951, 
+                                        37.68385565573351
+                                    ], 
+                                    [
+                                        -122.43882920844969, 
+                                        37.68037816224129
+                                    ], 
+                                    [
+                                        -122.43661899382985, 
+                                        37.67690066874906
+                                    ], 
+                                    [
+                                        -122.43440877921002, 
+                                        37.67342317525684
+                                    ], 
+                                    [
+                                        -122.43219856459018, 
+                                        37.66994568176462
+                                    ], 
+                                    [
+                                        -122.42998834997036, 
+                                        37.6664681882724
+                                    ], 
+                                    [
+                                        -122.42777813535052, 
+                                        37.66299069478017
+                                    ], 
+                                    [
+                                        -122.42556792073069, 
+                                        37.65951320128795
+                                    ], 
+                                    [
+                                        -122.42335770611085, 
+                                        37.65603570779572
+                                    ], 
+                                    [
+                                        -122.42114749149101, 
+                                        37.652558214303504
+                                    ], 
+                                    [
+                                        -122.41893727687119, 
+                                        37.64908072081128
+                                    ], 
+                                    [
+                                        -122.41672706225135, 
+                                        37.64560322731906
+                                    ], 
+                                    [
+                                        -122.41451684763152, 
+                                        37.64212573382683
+                                    ], 
+                                    [
+                                        -122.41230663301168, 
+                                        37.63864824033461
+                                    ], 
+                                    [
+                                        -122.41009641839184, 
+                                        37.635170746842384
+                                    ], 
+                                    [
+                                        -122.40788620377202, 
+                                        37.63169325335016
+                                    ], 
+                                    [
+                                        -122.40567598915219, 
+                                        37.62821575985794
+                                    ], 
+                                    [
+                                        -122.40346577453235, 
+                                        37.62473826636571
+                                    ], 
+                                    [
+                                        -122.40125555991251, 
+                                        37.62126077287349
+                                    ], 
+                                    [
+                                        -122.39904534529268, 
+                                        37.617783279381264
+                                    ], 
+                                    [
+                                        -122.39683513067286, 
+                                        37.614305785889044
+                                    ], 
+                                    [
+                                        -122.39462491605302, 
+                                        37.61082829239682
+                                    ], 
+                                    [
+                                        -122.39241470143318, 
+                                        37.6073507989046
+                                    ], 
+                                    [
+                                        -122.39020448681335, 
+                                        37.60387330541237
+                                    ], 
+                                    [
+                                        -122.38799427219352, 
+                                        37.60039581192015
+                                    ], 
+                                    [
+                                        -122.3872753, 
+                                        37.5992646
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41ef6858f03bbe41a68", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    358.0883840297351, 
+                                    358.09001342205386, 
+                                    358.0916427653755, 
+                                    358.0932720557891, 
+                                    358.09490129568, 
+                                    358.09653048304205, 
+                                    358.0981596200931, 
+                                    358.0997887058236, 
+                                    358.1014177385577, 
+                                    545.6674978911908, 
+                                    641.2755606439994, 
+                                    467.84464933461356, 
+                                    377.8471519104518, 
+                                    163.80751971382054, 
+                                    30.058129918133474, 
+                                    370.1950827076632, 
+                                    542.0467935207242, 
+                                    484.73409636414726, 
+                                    310.49738412270847, 
+                                    179.41767912787387, 
+                                    179.41828672555445, 
+                                    179.4188943133905, 
+                                    179.41950189117563, 
+                                    179.42010945839334, 
+                                    179.42071701730677, 
+                                    179.42132456421032, 
+                                    179.4219321017767, 
+                                    179.42253962876958, 
+                                    201.13682675716535, 
+                                    412.332224583864, 
+                                    473.6302242304946, 
+                                    317.04066036354175, 
+                                    96.59668108966284, 
+                                    310.8835050448085, 
+                                    593.4580773012291, 
+                                    445.58158955559287, 
+                                    401.43684168531, 
+                                    401.44425495539934, 
+                                    401.45166793602266, 
+                                    401.4590806266949, 
+                                    401.4664930258658, 
+                                    401.47390513598043, 
+                                    401.48131695362315, 
+                                    401.48872848163927, 
+                                    401.4961397195432, 
+                                    401.50355066578516, 
+                                    401.51096132281, 
+                                    401.51837168720164, 
+                                    401.5257817623118, 
+                                    401.53319154563144, 
+                                    401.5406010386459, 
+                                    401.54801024177664, 
+                                    401.5554191521131, 
+                                    401.56282777300737, 
+                                    401.57023610195034, 
+                                    401.57764414042737, 
+                                    401.5850518888603, 
+                                    401.59245934433756, 
+                                    401.5998665102121, 
+                                    401.60727338397487, 
+                                    401.61467996711093, 
+                                    401.6220862600423, 
+                                    401.62949225985705, 
+                                    401.63689796990855, 
+                                    401.64430338768767, 
+                                    401.65170851467934, 
+                                    401.659113351306, 
+                                    401.6665178951607, 
+                                    401.6739221475747, 
+                                    401.68132610907276, 
+                                    401.68872977911724, 
+                                    401.6961331586363, 
+                                    401.7035362452224, 
+                                    401.71093904020756, 
+                                    401.7183415441164, 
+                                    401.725743756411, 
+                                    401.7331456780199, 
+                                    260.30188052693643, 
+                                    157.702768257335, 
+                                    69.75142975792811, 
+                                    0.0, 
+                                    0.0, 
+                                    254.68184286330717, 
+                                    432.8131347763498, 
+                                    432.81723316807467, 
+                                    432.82133139231377, 
+                                    432.825429447873, 
+                                    432.8295273358353, 
+                                    432.83362505388305, 
+                                    432.83772260478435, 
+                                    432.8418199850982, 
+                                    432.8459171992781, 
+                                    432.8500142427595, 
+                                    432.8541111188718, 
+                                    432.85820782417443, 
+                                    432.862304363121, 
+                                    432.86640073114654, 
+                                    432.8704969315808, 
+                                    432.87459296154515, 
+                                    432.8786888232446, 
+                                    432.88278451548786, 
+                                    432.8868800393551, 
+                                    432.8909753925302, 
+                                    432.8950705777807, 
+                                    432.89916559237116, 
+                                    432.9032604379338, 
+                                    432.90735511484263, 
+                                    432.9114496207817, 
+                                    432.91554395851836, 
+                                    432.91963812461154, 
+                                    432.92373212351697, 
+                                    432.9278259506678, 
+                                    432.93191960939413, 
+                                    432.93601309625484, 
+                                    140.83288672334058
+                                ], 
+                                "end_ts": 1440719519.226, 
+                                "feature_type": "section", 
+                                "distance": 42389.63802238451, 
+                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
+                                "start_ts": 1440716089.4671443, 
+                                "start_fmt_time": "2015-08-27T15:54:49.467144-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T16:51:59.226000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 16, 
+                                    "month": 8, 
+                                    "second": 59, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 51
+                                }, 
+                                "duration": 3429.758855819702, 
+                                "end_stop": {
+                                    "$oid": "57c0e41ef6858f03bbe41ae4"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41df6858f03bbe41a66"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 15, 
+                                    "month": 8, 
+                                    "second": 49, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 54
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    11.936279467657837, 
+                                    11.93633378073513, 
+                                    11.936388092179184, 
+                                    11.936442401859637, 
+                                    11.936496709856, 
+                                    11.9365510161014, 
+                                    11.93660532066977, 
+                                    11.936659623527452, 
+                                    11.93671392461859, 
+                                    18.188916596373026, 
+                                    21.375852021466645, 
+                                    15.59482164448712, 
+                                    12.594905063681727, 
+                                    5.460250657127351, 
+                                    1.0019376639377824, 
+                                    12.339836090255439, 
+                                    18.06822645069081, 
+                                    16.15780321213824, 
+                                    10.349912804090282, 
+                                    5.9805893042624625, 
+                                    5.9806095575184814, 
+                                    5.98062981044635, 
+                                    5.980650063039188, 
+                                    5.980670315279778, 
+                                    5.980690567243559, 
+                                    5.980710818807011, 
+                                    5.980731070059223, 
+                                    5.980751320958986, 
+                                    6.704560891905512, 
+                                    13.7444074861288, 
+                                    15.787674141016486, 
+                                    10.568022012118059, 
+                                    3.219889369655428, 
+                                    10.362783501493617, 
+                                    19.781935910040968, 
+                                    14.852719651853096, 
+                                    13.381228056177001, 
+                                    13.381475165179978, 
+                                    13.381722264534089, 
+                                    13.381969354223164, 
+                                    13.382216434195527, 
+                                    13.382463504532682, 
+                                    13.382710565120771, 
+                                    13.382957616054643, 
+                                    13.383204657318107, 
+                                    13.383451688859505, 
+                                    13.383698710760333, 
+                                    13.383945722906722, 
+                                    13.384192725410394, 
+                                    13.384439718187714, 
+                                    13.384686701288196, 
+                                    13.384933674725888, 
+                                    13.385180638403769, 
+                                    13.38542759243358, 
+                                    13.385674536731678, 
+                                    13.38592147134758, 
+                                    13.386168396295343, 
+                                    13.386415311477919, 
+                                    13.38666221700707, 
+                                    13.386909112799163, 
+                                    13.387155998903697, 
+                                    13.387402875334743, 
+                                    13.387649741995235, 
+                                    13.387896598996951, 
+                                    13.388143446256256, 
+                                    13.388390283822645, 
+                                    13.388637111710201, 
+                                    13.388883929838691, 
+                                    13.389130738252488, 
+                                    13.389377536969091, 
+                                    13.389624325970575, 
+                                    13.389871105287877, 
+                                    13.390117874840746, 
+                                    13.390364634673585, 
+                                    13.390611384803881, 
+                                    13.3908581252137, 
+                                    13.391104855933998, 
+                                    8.676729350897881, 
+                                    5.256758941911167, 
+                                    2.3250476585976037, 
+                                    0.0, 
+                                    0.0, 
+                                    8.489394762110239, 
+                                    14.427104492544993, 
+                                    14.427241105602489, 
+                                    14.427377713077126, 
+                                    14.4275143149291, 
+                                    14.42765091119451, 
+                                    14.427787501796102, 
+                                    14.427924086826145, 
+                                    14.428060666169939, 
+                                    14.428197239975937, 
+                                    14.428333808091985, 
+                                    14.42847037062906, 
+                                    14.428606927472481, 
+                                    14.4287434787707, 
+                                    14.428880024371551, 
+                                    14.429016564386027, 
+                                    14.42915309871817, 
+                                    14.429289627441486, 
+                                    14.429426150516262, 
+                                    14.429562667978503, 
+                                    14.429699179751006, 
+                                    14.429835685926024, 
+                                    14.429972186412373, 
+                                    14.43010868126446, 
+                                    14.430245170494754, 
+                                    14.430381654026057, 
+                                    14.430518131950612, 
+                                    14.430654604153718, 
+                                    14.430791070783899, 
+                                    14.430927531688926, 
+                                    14.431063986979805, 
+                                    14.431200436541827, 
+                                    14.431290852664628
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.3872511, 
+                                        37.5992711
+                                    ], 
+                                    [
+                                        -122.38714270190331, 
+                                        37.599294846561044
+                                    ], 
+                                    [
+                                        -122.387077826848, 
+                                        37.59928960783066
+                                    ], 
+                                    [
+                                        -122.3870880172632, 
+                                        37.59929320387766
+                                    ], 
+                                    [
+                                        -122.38710458067597, 
+                                        37.59931477483382
+                                    ], 
+                                    [
+                                        -122.3871046, 
+                                        37.5993148
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41ef6858f03bbe41add", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    9.908134151186015, 
+                                    5.745063782479622, 
+                                    0.982792086356484, 
+                                    2.8075850020833313, 
+                                    0.0032755242536713644
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1440719699.47, 
+                                "start_ts": 1440719579.435, 
+                                "start_fmt_time": "2015-08-27T16:52:59.435000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T16:54:59.470000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 16, 
+                                    "month": 8, 
+                                    "second": 59, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 54
+                                }, 
+                                "duration": 120.03500008583069, 
+                                "start_stop": {
+                                    "$oid": "57c0e41ef6858f03bbe41ae4"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41df6858f03bbe41a66"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 16, 
+                                    "month": 8, 
+                                    "second": 59, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 52
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    0.3302711383728672, 
+                                    0.19150212608265405, 
+                                    0.0327597362118828, 
+                                    0.09358616673611105, 
+                                    0.09358617774586561
+                                ], 
+                                "distance": 19.446850546359123
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57c0e41df6858f03bbe41a66", 
+            "properties": {
+                "distance": 42411.33606045893, 
+                "end_place": {
+                    "$oid": "57c0e420f6858f03bbe41b87"
+                }, 
+                "raw_trip": {
+                    "$oid": "57c0e419f6858f03bbe418ff"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.2589186, 
+                        37.8752735
+                    ]
+                }, 
+                "end_ts": 1440719699.47, 
+                "start_ts": 1440716089.4671443, 
+                "start_fmt_time": "2015-08-27T15:54:49.467144-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.3871046, 
+                        37.5993148
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57c0e420f6858f03bbe41b86"
+                }, 
+                "end_fmt_time": "2015-08-27T16:54:59.470000-07:00", 
+                "end_local_dt": {
+                    "hour": 16, 
+                    "month": 8, 
+                    "second": 59, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 54
+                }, 
+                "duration": 3332.0940001010895, 
+                "start_local_dt": {
+                    "hour": 15, 
+                    "month": 8, 
+                    "second": 49, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 54
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.3871046, 
+                            37.5993148
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b87", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T16:54:59.470000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 16, 
+                            "month": 8, 
+                            "second": 59, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 57
+                        }, 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2015-08-27T16:57:59.470000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 16, 
+                            "month": 8, 
+                            "second": 59, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 54
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41df6858f03bbe41a66"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440719699.47, 
+                        "duration": 180.0, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe41900"
+                            }
+                        ], 
+                        "exit_ts": 1440719879.47
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.083702, 
+                            37.4036219
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b88", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T17:55:34.898000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 19, 
+                            "month": 8, 
+                            "second": 58, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 20
+                        }, 
+                        "feature_type": "end_place", 
+                        "exit_fmt_time": "2015-08-27T19:20:58.752785-07:00", 
+                        "enter_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 34, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 55
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41ff6858f03bbe41b64"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440723334.898, 
+                        "duration": 5123.854784727097, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe41902"
+                            }
+                        ], 
+                        "exit_ts": 1440728458.7527847
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.0779499, 
+                                37.3959236
+                            ], 
+                            [
+                                -122.0761413, 
+                                37.3940933
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e41ff6858f03bbe41b61", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T17:43:04.229000-07:00", 
+                        "distance": 258.74285107438715, 
+                        "exit_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 34, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 43
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57c0e41ef6858f03bbe41ae7"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57c0e41ff6858f03bbe41b44"
+                        }, 
+                        "exit_fmt_time": "2015-08-27T17:43:34.285000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 4, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 43
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0761413, 
+                                37.3940933
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0779499, 
+                                37.3959236
+                            ]
+                        }, 
+                        "enter_ts": 1440722584.229, 
+                        "duration": 30.055999994277954, 
+                        "_id": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "exit_ts": 1440722614.285
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.0784937, 
+                                37.4012462
+                            ], 
+                            [
+                                -122.078664, 
+                                37.4015876
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e41ff6858f03bbe41b62", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T17:51:04.721000-07:00", 
+                        "distance": 40.833879313803244, 
+                        "exit_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 34, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 51
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57c0e41ff6858f03bbe41b44"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57c0e41ff6858f03bbe41b56"
+                        }, 
+                        "exit_fmt_time": "2015-08-27T17:51:34.715000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 4, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 51
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.078664, 
+                                37.4015876
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0784937, 
+                                37.4012462
+                            ]
+                        }, 
+                        "enter_ts": 1440723064.721, 
+                        "duration": 29.99399995803833, 
+                        "_id": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "exit_ts": 1440723094.715
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.0796973, 
+                                37.4021489
+                            ], 
+                            [
+                                -122.0827923, 
+                                37.4027524
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e41ff6858f03bbe41b63", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T17:52:04.657000-07:00", 
+                        "distance": 281.50303421327163, 
+                        "exit_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 4, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 53
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57c0e41ff6858f03bbe41b56"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57c0e41ff6858f03bbe41b59"
+                        }, 
+                        "exit_fmt_time": "2015-08-27T17:53:04.822000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 4, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 52
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0827923, 
+                                37.4027524
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0796973, 
+                                37.4021489
+                            ]
+                        }, 
+                        "enter_ts": 1440723124.657, 
+                        "duration": 60.16499996185303, 
+                        "_id": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "exit_ts": 1440723184.822
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.3871046, 
+                                        37.5993148
+                                    ], 
+                                    [
+                                        -122.38356472983239, 
+                                        37.597689832680715
+                                    ], 
+                                    [
+                                        -122.38002485966477, 
+                                        37.596064865361434
+                                    ], 
+                                    [
+                                        -122.37648498949716, 
+                                        37.59443989804215
+                                    ], 
+                                    [
+                                        -122.37294511932954, 
+                                        37.59281493072287
+                                    ], 
+                                    [
+                                        -122.36940524916193, 
+                                        37.59118996340358
+                                    ], 
+                                    [
+                                        -122.36586537899431, 
+                                        37.58956499608429
+                                    ], 
+                                    [
+                                        -122.3623255088267, 
+                                        37.58794002876501
+                                    ], 
+                                    [
+                                        -122.35878563865909, 
+                                        37.586315061445724
+                                    ], 
+                                    [
+                                        -122.35524576849147, 
+                                        37.58469009412644
+                                    ], 
+                                    [
+                                        -122.35170589832386, 
+                                        37.583065126807156
+                                    ], 
+                                    [
+                                        -122.34816602815624, 
+                                        37.58144015948787
+                                    ], 
+                                    [
+                                        -122.34468019543081, 
+                                        37.579840004569185
+                                    ], 
+                                    [
+                                        -122.3446799, 
+                                        37.5798403
+                                    ], 
+                                    [
+                                        -122.3443736419912, 
+                                        37.579722681714536
+                                    ], 
+                                    [
+                                        -122.33791026916391, 
+                                        37.57723340408836
+                                    ], 
+                                    [
+                                        -122.33398028165144, 
+                                        37.5751987973484
+                                    ], 
+                                    [
+                                        -122.33005863073234, 
+                                        37.573161716056795
+                                    ], 
+                                    [
+                                        -122.32691923359984, 
+                                        37.570914755153574
+                                    ], 
+                                    [
+                                        -122.32589190226538, 
+                                        37.57005352294679
+                                    ], 
+                                    [
+                                        -122.32486457093093, 
+                                        37.56919229074001
+                                    ], 
+                                    [
+                                        -122.32383723959647, 
+                                        37.56833105853323
+                                    ], 
+                                    [
+                                        -122.32280990826203, 
+                                        37.56746982632645
+                                    ], 
+                                    [
+                                        -122.32178257692757, 
+                                        37.566608594119664
+                                    ], 
+                                    [
+                                        -122.32025392263087, 
+                                        37.565028860690916
+                                    ], 
+                                    [
+                                        -122.31803730704107, 
+                                        37.56246313406625
+                                    ], 
+                                    [
+                                        -122.31582069145126, 
+                                        37.559897407441575
+                                    ], 
+                                    [
+                                        -122.31360407586146, 
+                                        37.5573316808169
+                                    ], 
+                                    [
+                                        -122.31138746027166, 
+                                        37.55476595419223
+                                    ], 
+                                    [
+                                        -122.30917084468187, 
+                                        37.55220022756755
+                                    ], 
+                                    [
+                                        -122.30695422909207, 
+                                        37.54963450094288
+                                    ], 
+                                    [
+                                        -122.30473761350227, 
+                                        37.547068774318205
+                                    ], 
+                                    [
+                                        -122.30263492397924, 
+                                        37.54479855763969
+                                    ], 
+                                    [
+                                        -122.30054415183042, 
+                                        37.542559253136986
+                                    ], 
+                                    [
+                                        -122.29845337968159, 
+                                        37.54031994863429
+                                    ], 
+                                    [
+                                        -122.29636260753276, 
+                                        37.53808064413159
+                                    ], 
+                                    [
+                                        -122.29427183538394, 
+                                        37.53584133962889
+                                    ], 
+                                    [
+                                        -122.2921810632351, 
+                                        37.533602035126194
+                                    ], 
+                                    [
+                                        -122.29009029108629, 
+                                        37.53136273062349
+                                    ], 
+                                    [
+                                        -122.28583339531868, 
+                                        37.52814620955099
+                                    ], 
+                                    [
+                                        -122.28131059815135, 
+                                        37.52480973075702
+                                    ], 
+                                    [
+                                        -122.27678780098404, 
+                                        37.521473251963045
+                                    ], 
+                                    [
+                                        -122.2762817, 
+                                        37.5210999
+                                    ], 
+                                    [
+                                        -122.2762375793434, 
+                                        37.52088455961841
+                                    ], 
+                                    [
+                                        -122.2762314, 
+                                        37.5208544
+                                    ], 
+                                    [
+                                        -122.27190235041846, 
+                                        37.51774628698037
+                                    ], 
+                                    [
+                                        -122.26900497555006, 
+                                        37.51533189577263
+                                    ], 
+                                    [
+                                        -122.26634534296603, 
+                                        37.51304445885486
+                                    ], 
+                                    [
+                                        -122.26368571038202, 
+                                        37.510757021937074
+                                    ], 
+                                    [
+                                        -122.261026077798, 
+                                        37.5084695850193
+                                    ], 
+                                    [
+                                        -122.2607763981307, 
+                                        37.508067325232936
+                                    ], 
+                                    [
+                                        -122.26069785505071, 
+                                        37.50768587599611
+                                    ], 
+                                    [
+                                        -122.25802192791353, 
+                                        37.50533151677355
+                                    ], 
+                                    [
+                                        -122.25368760994891, 
+                                        37.50141057763227
+                                    ], 
+                                    [
+                                        -122.2491692241119, 
+                                        37.49730603465813
+                                    ], 
+                                    [
+                                        -122.24506563348574, 
+                                        37.494624532059746
+                                    ], 
+                                    [
+                                        -122.2410265395756, 
+                                        37.49216429872531
+                                    ], 
+                                    [
+                                        -122.23698744566546, 
+                                        37.48970406539087
+                                    ], 
+                                    [
+                                        -122.23294835175531, 
+                                        37.48724383205642
+                                    ], 
+                                    [
+                                        -122.23215338841807, 
+                                        37.48681525585265
+                                    ], 
+                                    [
+                                        -122.23215648899297, 
+                                        37.48688647218231
+                                    ], 
+                                    [
+                                        -122.2321573, 
+                                        37.4869051
+                                    ], 
+                                    [
+                                        -122.23100467307621, 
+                                        37.48604193056071
+                                    ], 
+                                    [
+                                        -122.22951517026158, 
+                                        37.48492648437185
+                                    ], 
+                                    [
+                                        -122.22802566744696, 
+                                        37.483811038182985
+                                    ], 
+                                    [
+                                        -122.22177042271733, 
+                                        37.47987803754828
+                                    ], 
+                                    [
+                                        -122.21473140092638, 
+                                        37.47548166004949
+                                    ], 
+                                    [
+                                        -122.20769237913545, 
+                                        37.471085282550696
+                                    ], 
+                                    [
+                                        -122.2006533573445, 
+                                        37.46668890505191
+                                    ], 
+                                    [
+                                        -122.19361433555358, 
+                                        37.46229252755312
+                                    ], 
+                                    [
+                                        -122.18657531376265, 
+                                        37.457896150054324
+                                    ], 
+                                    [
+                                        -122.1844298341005, 
+                                        37.455406106328304
+                                    ], 
+                                    [
+                                        -122.184236, 
+                                        37.4550829
+                                    ], 
+                                    [
+                                        -122.184236, 
+                                        37.4550829
+                                    ], 
+                                    [
+                                        -122.184236, 
+                                        37.4550829
+                                    ], 
+                                    [
+                                        -122.17839683012052, 
+                                        37.4518327929526
+                                    ], 
+                                    [
+                                        -122.17177044580883, 
+                                        37.44814451896936
+                                    ], 
+                                    [
+                                        -122.16514406149714, 
+                                        37.444456244986114
+                                    ], 
+                                    [
+                                        -122.15851767718546, 
+                                        37.44076797100287
+                                    ], 
+                                    [
+                                        -122.15189129287377, 
+                                        37.43707969701963
+                                    ], 
+                                    [
+                                        -122.14526490856208, 
+                                        37.43339142303638
+                                    ], 
+                                    [
+                                        -122.1386385242504, 
+                                        37.42970314905314
+                                    ], 
+                                    [
+                                        -122.13201213993871, 
+                                        37.426014875069896
+                                    ], 
+                                    [
+                                        -122.12538575562702, 
+                                        37.42232660108665
+                                    ], 
+                                    [
+                                        -122.11875937131533, 
+                                        37.41863832710341
+                                    ], 
+                                    [
+                                        -122.11213298700365, 
+                                        37.414950053120165
+                                    ], 
+                                    [
+                                        -122.10550660269196, 
+                                        37.41126177913692
+                                    ], 
+                                    [
+                                        -122.09888021838027, 
+                                        37.40757350515368
+                                    ], 
+                                    [
+                                        -122.09225383406859, 
+                                        37.403885231170435
+                                    ], 
+                                    [
+                                        -122.0856274497569, 
+                                        37.40019695718719
+                                    ], 
+                                    [
+                                        -122.07900106544521, 
+                                        37.39650868320395
+                                    ], 
+                                    [
+                                        -122.0779499, 
+                                        37.3959236
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41ef6858f03bbe41ae7", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    360.4264896593399, 
+                                    360.43238290068666, 
+                                    360.438275958114, 
+                                    360.44416883002754, 
+                                    360.4500615180019, 
+                                    360.4559540208389, 
+                                    360.46184633852846, 
+                                    360.46773847224904, 
+                                    360.47363042080264, 
+                                    360.47952218417913, 
+                                    360.48541376355695, 
+                                    354.98785469460546, 
+                                    0.0419156658554899, 
+                                    29.990217410595957, 
+                                    633.2735523401939, 
+                                    413.68215949806023, 
+                                    413.22595047162224, 
+                                    372.79669478915827, 
+                                    131.79067828888057, 
+                                    131.79139757175113, 
+                                    131.7921168449584, 
+                                    131.79283610764134, 
+                                    131.79355536295515, 
+                                    221.38008100745762, 
+                                    345.78229659619893, 
+                                    345.7860984883869, 
+                                    345.7899002476667, 
+                                    345.79370187466407, 
+                                    345.7975033686449, 
+                                    345.80130473170686, 
+                                    345.8051059617002, 
+                                    313.19230297004475, 
+                                    309.80552269868343, 
+                                    309.8088170398643, 
+                                    309.81211127794194, 
+                                    309.81540541099434, 
+                                    309.8186994412415, 
+                                    309.82199336758913, 
+                                    518.4897727160508, 
+                                    544.7185953118097, 
+                                    544.7316566258119, 
+                                    60.956282625892165, 
+                                    24.25885459424381, 
+                                    3.397587685147023, 
+                                    514.9876860599126, 
+                                    370.64288541343853, 
+                                    346.00915739550663, 
+                                    346.0140317350037, 
+                                    346.0189059022652, 
+                                    49.85720558083278, 
+                                    42.97731213662191, 
+                                    352.4925240086861, 
+                                    579.8895901710931, 
+                                    605.9603154068149, 
+                                    469.0069079898968, 
+                                    449.24577491755, 
+                                    449.25508567359026, 
+                                    449.26439602363376, 
+                                    84.79891661933465, 
+                                    7.923618625525281, 
+                                    2.0725544797846385, 
+                                    139.8390908758519, 
+                                    180.71083891041695, 
+                                    180.7122659791398, 
+                                    704.2077453807702, 
+                                    790.443837099406, 
+                                    790.4725516487979, 
+                                    790.5012639715675, 
+                                    790.5299740648048, 
+                                    790.5586819295677, 
+                                    335.44959325865807, 
+                                    39.80384400009374, 
+                                    0.0, 
+                                    0.0, 
+                                    629.5069771525089, 
+                                    714.3969006481499, 
+                                    714.4205151815936, 
+                                    714.4441281138162, 
+                                    714.4677394445847, 
+                                    714.4913491736667, 
+                                    714.5149573008296, 
+                                    714.5385638258407, 
+                                    714.5621687484678, 
+                                    714.5857720684783, 
+                                    714.6093737856398, 
+                                    714.63297389972, 
+                                    714.6565724104865, 
+                                    714.680169317707, 
+                                    714.7037646211494, 
+                                    714.7273583205813, 
+                                    113.38175294462827
+                                ], 
+                                "end_ts": 1440722584.229, 
+                                "feature_type": "section", 
+                                "distance": 35813.505599370765, 
+                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
+                                "start_ts": 1440719879.47, 
+                                "start_fmt_time": "2015-08-27T16:57:59.470000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T17:43:04.229000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 4, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 43
+                                }, 
+                                "duration": 2704.7590000629425, 
+                                "end_stop": {
+                                    "$oid": "57c0e41ff6858f03bbe41b61"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41ef6858f03bbe41ae5"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 16, 
+                                    "month": 8, 
+                                    "second": 59, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 57
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    12.014216321977996, 
+                                    12.014412763356223, 
+                                    12.0146091986038, 
+                                    12.014805627667585, 
+                                    12.015002050600064, 
+                                    12.015198467361296, 
+                                    12.015394877950948, 
+                                    12.015591282408302, 
+                                    12.015787680693421, 
+                                    12.01598407280597, 
+                                    12.016180458785232, 
+                                    11.832928489820182, 
+                                    0.0013971888618496632, 
+                                    0.9996739136865319, 
+                                    21.109118411339796, 
+                                    13.789405316602007, 
+                                    13.774198349054075, 
+                                    12.426556492971942, 
+                                    4.3930226096293525, 
+                                    4.393046585725037, 
+                                    4.393070561498614, 
+                                    4.393094536921378, 
+                                    4.393118512098505, 
+                                    7.379336033581921, 
+                                    11.52607655320663, 
+                                    11.52620328294623, 
+                                    11.526330008255558, 
+                                    11.526456729155468, 
+                                    11.526583445621498, 
+                                    11.526710157723562, 
+                                    11.526836865390006, 
+                                    10.439743432334826, 
+                                    10.32685075662278, 
+                                    10.326960567995478, 
+                                    10.327070375931397, 
+                                    10.327180180366478, 
+                                    10.327289981374717, 
+                                    10.327399778919638, 
+                                    17.282992423868357, 
+                                    18.157286510393657, 
+                                    18.157721887527064, 
+                                    2.031876087529739, 
+                                    0.8086284864747937, 
+                                    0.1132529228382341, 
+                                    17.166256201997086, 
+                                    12.354762847114618, 
+                                    11.533638579850221, 
+                                    11.533801057833456, 
+                                    11.533963530075507, 
+                                    1.661906852694426, 
+                                    1.4325770712207304, 
+                                    11.749750800289537, 
+                                    19.329653005703104, 
+                                    20.19867718022716, 
+                                    15.633563599663226, 
+                                    14.974859163918333, 
+                                    14.975169522453008, 
+                                    14.975479867454458, 
+                                    2.8266305539778216, 
+                                    0.2641206208508427, 
+                                    0.06908514932615462, 
+                                    4.6613030291950635, 
+                                    6.023694630347232, 
+                                    6.02374219930466, 
+                                    23.47359151269234, 
+                                    26.348127903313532, 
+                                    26.34908505495993, 
+                                    26.350042132385582, 
+                                    26.350999135493495, 
+                                    26.351956064318923, 
+                                    11.181653108621935, 
+                                    1.3267948000031247, 
+                                    0.0, 
+                                    0.0, 
+                                    20.98356590508363, 
+                                    23.813230021604998, 
+                                    23.814017172719787, 
+                                    23.814804270460538, 
+                                    23.81559131481949, 
+                                    23.816378305788888, 
+                                    23.817165243360986, 
+                                    23.817952127528024, 
+                                    23.81873895828226, 
+                                    23.819525735615944, 
+                                    23.82031245952133, 
+                                    23.821099129990667, 
+                                    23.821885747016218, 
+                                    23.822672310590235, 
+                                    23.823458820704978, 
+                                    23.82424527735271, 
+                                    23.824700870990107
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0761413, 
+                                        37.3940933
+                                    ], 
+                                    [
+                                        -122.07681653698792, 
+                                        37.39485958970722
+                                    ], 
+                                    [
+                                        -122.07749177397585, 
+                                        37.39562587941444
+                                    ], 
+                                    [
+                                        -122.0774038971201, 
+                                        37.395543394782024
+                                    ], 
+                                    [
+                                        -122.07773661925353, 
+                                        37.39566341923015
+                                    ], 
+                                    [
+                                        -122.0775389, 
+                                        37.3955742
+                                    ], 
+                                    [
+                                        -122.07754851506421, 
+                                        37.39558215039109
+                                    ], 
+                                    [
+                                        -122.07788707366433, 
+                                        37.39586209374013
+                                    ], 
+                                    [
+                                        -122.07776704019916, 
+                                        37.39603098246543
+                                    ], 
+                                    [
+                                        -122.07782146185397, 
+                                        37.39587792038169
+                                    ], 
+                                    [
+                                        -122.0777432635118, 
+                                        37.395666441480564
+                                    ], 
+                                    [
+                                        -122.07694010707229, 
+                                        37.397029427800916
+                                    ], 
+                                    [
+                                        -122.07620646420425, 
+                                        37.39786924498624
+                                    ], 
+                                    [
+                                        -122.07673273001728, 
+                                        37.398083304785615
+                                    ], 
+                                    [
+                                        -122.07788984311638, 
+                                        37.39899611121382
+                                    ], 
+                                    [
+                                        -122.07848517813805, 
+                                        37.40121367494206
+                                    ], 
+                                    [
+                                        -122.0784937, 
+                                        37.4012462
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41ff6858f03bbe41b44", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    104.0125419939131, 
+                                    104.01219225042587, 
+                                    12.016162828262692, 
+                                    32.28078397018566, 
+                                    20.087318220175707, 
+                                    1.225971127925706, 
+                                    43.167957779737904, 
+                                    21.566432084607676, 
+                                    17.685701311709384, 
+                                    24.509060042473088, 
+                                    167.34246971335793, 
+                                    113.66880587941668, 
+                                    52.22804341142004, 
+                                    144.0490606828309, 
+                                    252.12731062944542, 
+                                    3.694131307129653
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1440723064.721, 
+                                "start_ts": 1440722614.285, 
+                                "start_fmt_time": "2015-08-27T17:43:34.285000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T17:51:04.721000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 4, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 51
+                                }, 
+                                "duration": 450.4359998703003, 
+                                "start_stop": {
+                                    "$oid": "57c0e41ff6858f03bbe41b61"
+                                }, 
+                                "end_stop": {
+                                    "$oid": "57c0e41ff6858f03bbe41b62"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41ef6858f03bbe41ae5"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 34, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 43
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    3.4670847331304366, 
+                                    3.467073075014196, 
+                                    0.40053876094208973, 
+                                    1.076026132339522, 
+                                    0.6695772740058569, 
+                                    0.0408657042641902, 
+                                    1.4389319259912634, 
+                                    0.7188810694869225, 
+                                    0.5895233770569794, 
+                                    0.8169686680824363, 
+                                    5.578082323778598, 
+                                    3.788960195980556, 
+                                    1.740934780380668, 
+                                    4.801635356094364, 
+                                    8.404243687648181, 
+                                    8.472780747813838
+                                ], 
+                                "distance": 1113.6739432330176
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.078664, 
+                                        37.4015876
+                                    ], 
+                                    [
+                                        -122.0796973, 
+                                        37.4021489
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41ff6858f03bbe41b56", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    110.57324346353148
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.BICYCLING", 
+                                "end_ts": 1440723124.657, 
+                                "start_ts": 1440723094.715, 
+                                "start_fmt_time": "2015-08-27T17:51:34.715000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T17:52:04.657000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 4, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 52
+                                }, 
+                                "duration": 29.942000150680542, 
+                                "start_stop": {
+                                    "$oid": "57c0e41ff6858f03bbe41b62"
+                                }, 
+                                "end_stop": {
+                                    "$oid": "57c0e41ff6858f03bbe41b63"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41ef6858f03bbe41ae5"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 34, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 51
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    3.692914398072311
+                                ], 
+                                "distance": 110.57324346353148
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0827923, 
+                                        37.4027524
+                                    ], 
+                                    [
+                                        -122.08334456138144, 
+                                        37.40279351329594
+                                    ], 
+                                    [
+                                        -122.08327243415631, 
+                                        37.403089763180404
+                                    ], 
+                                    [
+                                        -122.08313602743902, 
+                                        37.4037621002979
+                                    ], 
+                                    [
+                                        -122.08366698391958, 
+                                        37.4036582635619
+                                    ], 
+                                    [
+                                        -122.08370191463239, 
+                                        37.4036219914472
+                                    ], 
+                                    [
+                                        -122.083702, 
+                                        37.4036219
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41ff6858f03bbe41b59", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    48.995878864870875, 
+                                    33.551934165615684, 
+                                    75.72519595148405, 
+                                    48.30000252282387, 
+                                    5.078120884812968, 
+                                    0.01265930221646351
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.ON_FOOT", 
+                                "end_ts": 1440723334.898, 
+                                "start_ts": 1440723184.822, 
+                                "start_fmt_time": "2015-08-27T17:53:04.822000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T17:55:34.898000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 34, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 55
+                                }, 
+                                "duration": 150.07599997520447, 
+                                "start_stop": {
+                                    "$oid": "57c0e41ff6858f03bbe41b63"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41ef6858f03bbe41ae5"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 17, 
+                                    "month": 8, 
+                                    "second": 4, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 53
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    1.6331959621623624, 
+                                    1.1183978055205228, 
+                                    2.524173198382802, 
+                                    1.6100000840941289, 
+                                    0.16927069616043228, 
+                                    0.1665698203506692
+                                ], 
+                                "distance": 211.66379169182392
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57c0e41ef6858f03bbe41ae5", 
+            "properties": {
+                "distance": 37830.496342360595, 
+                "end_place": {
+                    "$oid": "57c0e420f6858f03bbe41b88"
+                }, 
+                "raw_trip": {
+                    "$oid": "57c0e419f6858f03bbe41901"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.3871046, 
+                        37.5993148
+                    ]
+                }, 
+                "end_ts": 1440723334.898, 
+                "start_ts": 1440719879.47, 
+                "start_fmt_time": "2015-08-27T16:57:59.470000-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.083702, 
+                        37.4036219
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57c0e420f6858f03bbe41b87"
+                }, 
+                "end_fmt_time": "2015-08-27T17:55:34.898000-07:00", 
+                "end_local_dt": {
+                    "hour": 17, 
+                    "month": 8, 
+                    "second": 34, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 55
+                }, 
+                "duration": 3095.885999917984, 
+                "start_local_dt": {
+                    "hour": 16, 
+                    "month": 8, 
+                    "second": 59, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 57
+                }
+            }
+        }, 
+        {
+            "features": [
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.083702, 
+                            37.4036219
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b88", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T17:55:34.898000-07:00", 
+                        "exit_local_dt": {
+                            "hour": 19, 
+                            "month": 8, 
+                            "second": 58, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 20
+                        }, 
+                        "feature_type": "start_place", 
+                        "exit_fmt_time": "2015-08-27T19:20:58.752785-07:00", 
+                        "enter_local_dt": {
+                            "hour": 17, 
+                            "month": 8, 
+                            "second": 34, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 55
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41ef6858f03bbe41ae5"
+                        }, 
+                        "starting_trip": {
+                            "$oid": "57c0e41ff6858f03bbe41b64"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440723334.898, 
+                        "duration": 5123.854784727097, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe41902"
+                            }
+                        ], 
+                        "exit_ts": 1440728458.7527847
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "Point", 
+                        "coordinates": [
+                            -122.0862609, 
+                            37.3909709
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e420f6858f03bbe41b89", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T19:32:22.709000-07:00", 
+                        "feature_type": "end_place", 
+                        "enter_local_dt": {
+                            "hour": 19, 
+                            "month": 8, 
+                            "second": 22, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 32
+                        }, 
+                        "ending_trip": {
+                            "$oid": "57c0e41ff6858f03bbe41b64"
+                        }, 
+                        "source": "DwellSegmentationTimeFilter", 
+                        "enter_ts": 1440729142.709, 
+                        "raw_places": [
+                            {
+                                "$oid": "57c0e419f6858f03bbe41904"
+                            }
+                        ]
+                    }
+                }, 
+                {
+                    "geometry": {
+                        "type": "LineString", 
+                        "coordinates": [
+                            [
+                                -122.0777742, 
+                                37.3955849
+                            ], 
+                            [
+                                -122.0804791, 
+                                37.3959724
+                            ]
+                        ]
+                    }, 
+                    "type": "Feature", 
+                    "id": "57c0e41ff6858f03bbe41b81", 
+                    "properties": {
+                        "enter_fmt_time": "2015-08-27T19:26:34.308000-07:00", 
+                        "distance": 242.80424743721912, 
+                        "exit_local_dt": {
+                            "hour": 19, 
+                            "month": 8, 
+                            "second": 4, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 27
+                        }, 
+                        "feature_type": "stop", 
+                        "ending_section": {
+                            "$oid": "57c0e41ff6858f03bbe41b66"
+                        }, 
+                        "starting_section": {
+                            "$oid": "57c0e41ff6858f03bbe41b74"
+                        }, 
+                        "exit_fmt_time": "2015-08-27T19:27:04.315000-07:00", 
+                        "enter_local_dt": {
+                            "hour": 19, 
+                            "month": 8, 
+                            "second": 34, 
+                            "weekday": 3, 
+                            "year": 2015, 
+                            "timezone": "America/Los_Angeles", 
+                            "day": 27, 
+                            "minute": 26
+                        }, 
+                        "exit_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0804791, 
+                                37.3959724
+                            ]
+                        }, 
+                        "source": "SmoothedHighConfidenceMotion", 
+                        "enter_loc": {
+                            "type": "Point", 
+                            "coordinates": [
+                                -122.0777742, 
+                                37.3955849
+                            ]
+                        }, 
+                        "enter_ts": 1440728794.308, 
+                        "duration": 30.006999969482422, 
+                        "_id": {
+                            "$oid": "57c0e41ff6858f03bbe41b64"
+                        }, 
+                        "trip_id": {
+                            "$oid": "57c0e41ff6858f03bbe41b64"
+                        }, 
+                        "exit_ts": 1440728824.315
+                    }
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.083702, 
+                                        37.4036219
+                                    ], 
+                                    [
+                                        -122.08271856721326, 
+                                        37.40312155872271
+                                    ], 
+                                    [
+                                        -122.08173513442652, 
+                                        37.40262121744543
+                                    ], 
+                                    [
+                                        -122.08061129166808, 
+                                        37.40246282089569
+                                    ], 
+                                    [
+                                        -122.07890393814768, 
+                                        37.40169780162328
+                                    ], 
+                                    [
+                                        -122.07911927031948, 
+                                        37.40150701266636
+                                    ], 
+                                    [
+                                        -122.07987231983891, 
+                                        37.40084555096012
+                                    ], 
+                                    [
+                                        -122.0805644442542, 
+                                        37.40006152575013
+                                    ], 
+                                    [
+                                        -122.08080548792987, 
+                                        37.39957786426277
+                                    ], 
+                                    [
+                                        -122.08073820432466, 
+                                        37.39946707959165
+                                    ], 
+                                    [
+                                        -122.0809439887394, 
+                                        37.39853002366731
+                                    ], 
+                                    [
+                                        -122.07836928154167, 
+                                        37.396090606598584
+                                    ], 
+                                    [
+                                        -122.0777742, 
+                                        37.3955849
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41ff6858f03bbe41b66", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    103.15649413095906, 
+                                    103.15698258378497, 
+                                    100.8214943793987, 
+                                    173.1511904019273, 
+                                    28.493194605945177, 
+                                    99.1696509990419, 
+                                    106.48091598932703, 
+                                    57.842367727468385, 
+                                    13.677562533982883, 
+                                    105.76967709389955, 
+                                    353.9887635523016, 
+                                    76.97777440013144
+                                ], 
+                                "end_ts": 1440728794.308, 
+                                "feature_type": "section", 
+                                "distance": 1322.686068398168, 
+                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
+                                "start_ts": 1440728458.7527847, 
+                                "start_fmt_time": "2015-08-27T19:20:58.752785-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T19:26:34.308000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 19, 
+                                    "month": 8, 
+                                    "second": 34, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 26
+                                }, 
+                                "duration": 335.55521535873413, 
+                                "end_stop": {
+                                    "$oid": "57c0e41ff6858f03bbe41b81"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41ff6858f03bbe41b64"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 19, 
+                                    "month": 8, 
+                                    "second": 58, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 20
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    3.438549804365302, 
+                                    3.4385660861261655, 
+                                    3.36071647931329, 
+                                    5.77170634673091, 
+                                    0.9497731535315059, 
+                                    3.305655033301397, 
+                                    3.549363866310901, 
+                                    1.9280789242489462, 
+                                    0.45591875113276276, 
+                                    3.525655903129985, 
+                                    11.799625451743387, 
+                                    13.856847922034905
+                                ]
+                            }
+                        }
+                    ]
+                }, 
+                {
+                    "type": "FeatureCollection", 
+                    "features": [
+                        {
+                            "geometry": {
+                                "type": "LineString", 
+                                "coordinates": [
+                                    [
+                                        -122.0804791, 
+                                        37.3959724
+                                    ], 
+                                    [
+                                        -122.08297204509547, 
+                                        37.3959456445923
+                                    ], 
+                                    [
+                                        -122.08297270839385, 
+                                        37.39598051606153
+                                    ], 
+                                    [
+                                        -122.0836783940137, 
+                                        37.39483405888615
+                                    ], 
+                                    [
+                                        -122.08441549613816, 
+                                        37.39375391129058
+                                    ], 
+                                    [
+                                        -122.08488551380876, 
+                                        37.393052509223544
+                                    ], 
+                                    [
+                                        -122.08547548499102, 
+                                        37.3920663815419
+                                    ], 
+                                    [
+                                        -122.08607344217683, 
+                                        37.39113822877281
+                                    ], 
+                                    [
+                                        -122.08622899782469, 
+                                        37.39095885504853
+                                    ], 
+                                    [
+                                        -122.08622857893772, 
+                                        37.39099206421023
+                                    ], 
+                                    [
+                                        -122.08626055360769, 
+                                        37.39097112682174
+                                    ], 
+                                    [
+                                        -122.0862609, 
+                                        37.3909709
+                                    ]
+                                ]
+                            }, 
+                            "type": "Feature", 
+                            "id": "57c0e41ff6858f03bbe41b74", 
+                            "properties": {
+                                "distances": [
+                                    0.0, 
+                                    220.24596296887037, 
+                                    3.877973172190887, 
+                                    141.90680484160671, 
+                                    136.62309664044253, 
+                                    88.356854647153, 
+                                    121.40907514813513, 
+                                    115.93998950371376, 
+                                    24.221494143581648, 
+                                    3.6928757286553218, 
+                                    3.660572969430462, 
+                                    0.03965621641830557
+                                ], 
+                                "feature_type": "section", 
+                                "sensed_mode": "MotionTypes.BICYCLING", 
+                                "end_ts": 1440729142.709, 
+                                "start_ts": 1440728824.315, 
+                                "start_fmt_time": "2015-08-27T19:27:04.315000-07:00", 
+                                "source": "SmoothedHighConfidenceMotion", 
+                                "end_fmt_time": "2015-08-27T19:32:22.709000-07:00", 
+                                "end_local_dt": {
+                                    "hour": 19, 
+                                    "month": 8, 
+                                    "second": 22, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 32
+                                }, 
+                                "duration": 318.39400005340576, 
+                                "start_stop": {
+                                    "$oid": "57c0e41ff6858f03bbe41b81"
+                                }, 
+                                "trip_id": {
+                                    "$oid": "57c0e41ff6858f03bbe41b64"
+                                }, 
+                                "start_local_dt": {
+                                    "hour": 19, 
+                                    "month": 8, 
+                                    "second": 4, 
+                                    "weekday": 3, 
+                                    "year": 2015, 
+                                    "timezone": "America/Los_Angeles", 
+                                    "day": 27, 
+                                    "minute": 27
+                                }, 
+                                "speeds": [
+                                    0.0, 
+                                    7.341532098962346, 
+                                    0.12926577240636292, 
+                                    4.730226828053557, 
+                                    4.554103221348084, 
+                                    2.9452284882384334, 
+                                    4.046969171604505, 
+                                    3.864666316790459, 
+                                    0.8073831381193882, 
+                                    0.12309585762184407, 
+                                    0.1220190989810154, 
+                                    0.0021559321682704346
+                                ], 
+                                "distance": 859.974355980198
+                            }
+                        }
+                    ]
+                }
+            ], 
+            "type": "FeatureCollection", 
+            "id": "57c0e41ff6858f03bbe41b64", 
+            "properties": {
+                "distance": 2425.464671815585, 
+                "end_place": {
+                    "$oid": "57c0e420f6858f03bbe41b89"
+                }, 
+                "raw_trip": {
+                    "$oid": "57c0e419f6858f03bbe41903"
+                }, 
+                "feature_type": "trip", 
+                "start_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.083702, 
+                        37.4036219
+                    ]
+                }, 
+                "end_ts": 1440729142.709, 
+                "start_ts": 1440728458.7527847, 
+                "start_fmt_time": "2015-08-27T19:20:58.752785-07:00", 
+                "end_loc": {
+                    "type": "Point", 
+                    "coordinates": [
+                        -122.0862609, 
+                        37.3909709
+                    ]
+                }, 
+                "source": "DwellSegmentationTimeFilter", 
+                "start_place": {
+                    "$oid": "57c0e420f6858f03bbe41b88"
+                }, 
+                "end_fmt_time": "2015-08-27T19:32:22.709000-07:00", 
+                "end_local_dt": {
+                    "hour": 19, 
+                    "month": 8, 
+                    "second": 22, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 32
+                }, 
+                "duration": 622.7380001544952, 
+                "start_local_dt": {
+                    "hour": 19, 
+                    "month": 8, 
+                    "second": 58, 
+                    "weekday": 3, 
+                    "year": 2015, 
+                    "timezone": "America/Los_Angeles", 
+                    "day": 27, 
+                    "minute": 20
+                }
+            }
+        }
+    ], 
+    "_id": {
+        "$oid": "57c0e422115514afcd793603"
+    }, 
+    "user_id": {
+        "$uuid": "0763de67f61e3f5d90e7518e69793954"
+    }, 
+    "metadata": {
+        "type": "document", 
+        "key": "diary/trips-2015-08-27", 
+        "write_ts": 1472259106.499904
+    }
+}


### PR DESCRIPTION
…p end

As seen in
https://github.com/e-mission/e-mission-server/issues/288#issuecomment-242531798,
if a trip was slow earlier and fast later and there was no tracking for the
slow part, we will end up with an extrapolated start time that is before the
end of the previous trip.

We check and fix this condition and add a new test case for it.