### PR TITLE
Final server fixes to get invite your friends to work

### DIFF
--- a/emission/net/ext_service/habitica/proxy.py
+++ b/emission/net/ext_service/habitica/proxy.py
@@ -141,8 +141,9 @@ def setup_party(user_id, group_id_from_url, inviterId):
       invite_uri = "/api/v3/groups/"+group_id+"/invite"
       logging.debug("invite user to party api url = %s" % invite_uri)
       user_val = list(edb.get_habitica_db().find({"user_id": user_id}))[0]
-      method_args = {'uuids': [inviterId], 'inviter': group_id, 'emails': []}
-      response = habiticaProxy(inviterId, 'POST', invite_uri, method_args)
+      method_args = {'uuids': [user_val['habitica_id']], 'inviter': group_id, 'emails': []}
+      emInviterId = edb.get_habitica_db().find_one({"habitica_id": inviterId})["user_id"]
+      response = habiticaProxy(emInviterId, 'POST', invite_uri, method_args)
       logging.debug("invite user to party response = %s" % response)
       join_url = "/api/v3/groups/"+group_id+"/join"
       response2 = habiticaProxy(user_id, 'POST', join_url, {})


### PR DESCRIPTION
Companion to the phone fixes
https://github.com/e-mission/e-mission-phone/pull/132

- map the inviting user from habitica ID -> emission ID
- ensure that the UUID to be invited is the user, not the inviter

With this, the  call works

```
2016-09-17 14:01:51,679:DEBUG:140292657231616:START POST /join.group/751e5f9a-bd2d-4c4c
-ba81-6fb89bccdf5d
2016-09-17 14:01:51,681:DEBUG:140292657231616:e471711e-bd14-3dbe-80b6-9c7d92ecc296 abou
t to join party 751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d after invite from 4bf84e20-6fe7-4e
e2-ba21-2d2e1ffac26e
2016-09-17 14:01:51,681:DEBUG:140292657231616:For user e471711e-bd14-3dbe-80b6-9c7d92ec
c296, about to proxy GET method /api/v3/user with args None
2016-09-17 14:01:51,683:INFO:140292657231616:Starting new HTTP connection (1): 54.159.3
8.241
2016-09-17 14:01:51,717:DEBUG:140292657231616:"GET /api/v3/user HTTP/1.1" 200 None

2016-09-17 14:01:51,721:DEBUG:140292657231616:invite user to party api url = /api/v3/gr
oups/751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d/invite
2016-09-17 14:01:51,722:DEBUG:140292657231616:For user 95e70727-a04e-3e33-b7fe-34ab1919
4f8b, about to proxy POST method /api/v3/groups/751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d/in
vite with args {'inviter': '751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d', 'uuids': [u'f069977a
-c1d6-45ef-8f3e-fccf28498abc'], 'emails': []}

***** Note inviter = group id, uuid = invited users' habitica ID ********

2016-09-17 14:01:51,724:INFO:140292657231616:Starting new HTTP connection (1): 54.159.3
8.241
2016-09-17 14:01:51,798:DEBUG:140292657231616:"POST /api/v3/groups/751e5f9a-bd2d-4c4c-b
a81-6fb89bccdf5d/invite HTTP/1.1" 200 162

2016-09-17 14:01:51,800:DEBUG:140292657231616:For user e471711e-bd14-3dbe-80b6-9c7d92ec
c296, about to proxy POST method /api/v3/groups/751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d/jo
in with args {}
2016-09-17 14:01:51,802:INFO:140292657231616:Starting new HTTP connection (1): 54.159.38.241

2016-09-17 14:01:51,908:DEBUG:140292657231616:"POST /api/v3/groups/751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d/join HTTP/1.1" 200 900
2016-09-17 14:01:51,910:DEBUG:140292657231616:ret_val = "751e5f9a-bd2d-4c4c-ba81-6fb89bccdf5d" after joining group
```