### PR TITLE
Add in a redirect URL

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -1,7 +1,7 @@
 # Standard imports
 import json
 from random import randrange
-from bottle import route, post, get, run, template, static_file, request, app, HTTPError, abort, BaseRequest, JSONPlugin
+from bottle import route, post, get, run, template, static_file, request, app, HTTPError, abort, BaseRequest, JSONPlugin, response
 import bottle as bt
 # To support dynamic loading of client-specific libraries
 import sys
@@ -414,7 +414,7 @@ def habiticaJoinGroup(group_id):
                   (user_uuid, group_id, inviter_id))
     ret_val = habitproxy.setup_party(user_uuid, group_id, inviter_id)
     logging.debug("ret_val = %s after joining group" % bson.json_util.dumps(ret_val))
-    return {'joined_group': ret_val}
+    return {'result': ret_val}
 
 # Pulling public data from the server  
 @get('/eval/publicData/timeseries')
@@ -444,6 +444,19 @@ def getPublicData():
     data_list = map(lambda q: list(edb.get_timeseries_db().find(q).sort("metadata.write_ts")), user_queries)
    
   return {'phone_data': data_list}
+
+# Redirect to custom URL. $%$%$$ gmail
+@get('/redirect/<route>')
+def getCustomURL(route):
+  # print route
+  # print urllib.urlencode(request.query)
+  redirected_url = 'emission://%s?%s' % (route, urllib.urlencode(request.query))
+  response.status = 303
+  response.set_header('Location', redirected_url)
+  # response.set_header('Location', 'mailto://%s@%s' % (route, urllib.urlencode(request.query)))
+  logging.debug("Redirecting to URL %s" % redirected_url)
+  return {'redirect': 'success'}
+
 
 # Client related code START
 @post("/client/<clientname>/<method>")


### PR DESCRIPTION
This is a workaround to sending custom URL schemes via gmail or social networks
such as facebook and twitter. All such custom URL schemes are stripped out by
the networks. In response, we use a redirect link on our server that redirects
to the custom URL with the same route and parameters.