### PR TITLE
Check to see that the requested UUIDs are actually public

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -41,6 +41,7 @@ from emission.core.wrapper.user import User
 from emission.core.get_database import get_uuid_db, get_mode_db
 import emission.core.wrapper.motionactivity as ecwm
 import emission.storage.timeseries.timequery as estt
+import emission.storage.timeseries.aggregate_timeseries as estag
 import emission.core.get_database as edb
 
 
@@ -420,7 +421,8 @@ def habiticaJoinGroup(group_id):
 @get('/eval/publicData/timeseries')
 def getPublicData():
   ids = request.json['phone_ids']
-  uuids = map(lambda id: UUID(id), ids)
+  all_uuids = map(lambda id: UUID(id), ids)
+  uuids = [uuid for uuid in all_uuids if uuid in estag.TEST_PHONE_IDS]
 
   from_ts = request.query.from_ts
   to_ts = request.query.to_ts


### PR DESCRIPTION
Even for the current UUID-based getPublicData API call, we want to check that
the requested UUIDs are actually public. We don't guarantee that UUIDs are private, for example, my UUID is strewn across the github repo in a bunch of tests. We are planning to share UUIDs with the bic2cal researchers, for example.

So let's add a simple check to see if the UUIDs are known to be private before returning them. This is required before I deploy https://github.com/e-mission/e-mission-server/commit/8e9f10e9fd8a470cde00a64243dbe9e385fd011c to the real server, which I plan to do in a little bit.