### PR TITLE
Script(s) to delete all internal views (collections in mongodb) and exteral views (habitica)

### DIFF
--- a/bin/ext_service/reset_all_habitica_users.py
+++ b/bin/ext_service/reset_all_habitica_users.py
@@ -1,0 +1,20 @@
+import argparse
+import sys
+import logging
+
+import emission.core.get_database as edb
+import emission.net.ext_service.habitica.proxy as proxy
+
+def reset_user(reset_em_uuid):
+    del_result = proxy.habiticaProxy(reset_em_uuid, "POST",
+                                     "/api/v3/user/reset", {})
+    logging.debug("reset result for %s = %s" % (reset_em_uuid, del_result))
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
+    for creds in edb.get_habitica_db().find():
+        reset_uuid = creds["user_id"]
+        logging.debug("Processing emission user id %s" % reset_uuid)
+        reset_user(reset_uuid)
+

--- a/bin/reset_analysis_database.py
+++ b/bin/reset_analysis_database.py
@@ -1,0 +1,18 @@
+from pymongo import MongoClient
+import json
+import sys
+import emission.core.get_database as edb
+from emission.tests import common
+
+def purgeAnalysisData():
+  edb.get_analysis_timeseries_db().remove()
+  edb.get_common_place_db().remove()
+  edb.get_common_trip_db().remove()
+  edb.get_pipeline_state_db().remove()
+
+if __name__ == '__main__':
+  if len(sys.argv) == 0:
+    print "USAGE: %s [userName]" % sys.argv[0]
+    exit(1)
+
+  purgeAnalysisData()


### PR DESCRIPTION
Should be run every time we completely nuke the views and recreate them.