### PR TITLE
Enhance the habitica reset pipeline to reset all users

### DIFF
--- a/bin/ext_service/reset_all_habitica_users.py
+++ b/bin/ext_service/reset_all_habitica_users.py
@@ -4,17 +4,29 @@ import logging
 
 import emission.core.get_database as edb
 import emission.net.ext_service.habitica.proxy as proxy
+import emission.net.ext_service.habitica.sync_habitica as autocheck
 
 def reset_user(reset_em_uuid):
     del_result = proxy.habiticaProxy(reset_em_uuid, "POST",
                                      "/api/v3/user/reset", {})
-    logging.debug("reset result for %s = %s" % (reset_em_uuid, del_result))
+    update_result = edb.get_habitica_db().update({"user_id": reset_em_uuid},
+                                 {"$set": {'metrics_data':
+                                   {'last_timestamp': 0, 'bike_count': 0, 'walk_count': 0}}})
+    logging.debug("reset result for %s = %s, %s" % (reset_em_uuid, del_result, update_result))
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-r", "--restore",
+                        help="re-run pipeline and restore values", action="store_true")
+    args = parser.parse_args()
 
     for creds in edb.get_habitica_db().find():
         reset_uuid = creds["user_id"]
         logging.debug("Processing emission user id %s" % reset_uuid)
         reset_user(reset_uuid)
+        if args.restore:
+            autocheck.reward_active_transportation(reset_uuid)
+
 


### PR DESCRIPTION
Also reset the last timestamp since we have deleted all points so we need to
restore all points.
Also restore their points with an optional argument. This is useful when the trips/sections are correct but the habitica set is screwed up.