### PR TITLE
Make the UUID really non identifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,19 +100,17 @@ You may also want to load some test data.
 
 1. Sample timeline data from the data collection eval is available in the [data-collection-eval repo](https://github.com/shankari/data-collection-eval).
 2. You can choose to load either android data `results_dec_2015/ucb.sdb.android.{1,2,3}/timeseries/*` or iOS data `results_dec_2015/ucb.sdb.ios.{1,2,3}/timeseries/*`
-3. Data is loaded using the `bin/debug/load_timeline_for_day_and_user.py`.
-  * Running it with just a timeline file loads the data with the original user - e.g.
+3. Data is loaded using the `bin/debug/load_timeline_for_day_and_user.py`. It
+requires a timeline file and a user that the timeline is being loaded as. If
+you wish to view this timeline in the UI after processing it, you need to
+login with this email.
 
             $ cd ..../e-mission-server
-            $ ./e-mission-py.bash bin/debug/load_timeline_for_day_and_user.py /tmp/data-collection-eval/results_dec_2015/ucb.sdb.android.1/timeseries/active_day_2.2015-11-27
+            $ ./e-mission-py.bash bin/debug/load_timeline_for_day_and_user.py /tmp/data-collection-eval/results_dec_2015/ucb.sdb.android.1/timeseries/active_day_2.2015-11-27 shankari@eecs.berkeley.edu
         
-  * Running it with a timeline file and a user relabels the data as being from the specified user and then loads it - e.g.
+4. Note that loading the data retains the object IDs. This means that if you load the same data twice with different user IDs, then only the second one will stick. In other words, if you load the file as `user1@foo.edu` and then load the same file as `user2@foo.edu`, you will only have data for `user2@foo.edu` in the database. This can be overwritten using the `--make-new` flag - e.g.
 
-            $ cd ..../e-mission-server
-            $ ./e-mission-py.bash bin/debug/load_timeline_for_day_and_user.py /tmp/data-collection-eval/results_dec_2015/ucb.sdb.android.1/timeseries/active_day_2.2015-11-27 -u shankari@eecs.berkeley.edu
-        
-4. Note that loading the data retains the object IDs. This means that if you load the same data twice with different user IDs, then only the second one will stick. In other words, if you load the file as `user1@foo.edu` and then load the same file as `user2@foo.edu`, you will only have data for `user2@foo.edu` in the database.
-
+            $ ./e-mission-py.bash bin/debug/load_timeline_for_day_and_user.py -n /tmp/data-collection-eval/results_dec_2015/ucb.sdb.android.1/timeseries/active_day_2.2015-11-27 shankari@eecs.berkeley.edu
 
 ### Creating fake user data ###
 

--- a/bin/debug/load_timeline_for_day_and_user.py
+++ b/bin/debug/load_timeline_for_day_and_user.py
@@ -10,6 +10,10 @@ if __name__ == '__main__':
         help="the name of the file that contains the json representation of the timeline")
     parser.add_argument("user_email",
         help="specify the user email to load the data as")
+
+    parser.add_argument("-n", "--make_new", action="store_true",
+        help="specify whether the entries should overwrite existing ones (default) or create new ones")
+
     args = parser.parse_args()
     fn = args.timeline_filename
     print fn
@@ -21,4 +25,6 @@ if __name__ == '__main__':
     entries = json.load(open(fn), object_hook = bju.object_hook)
     for entry in entries:
         entry["user_id"] = override_uuid
+        if args.make_new:
+            del entry["_id"]
         tsdb.save(entry)

--- a/bin/debug/load_timeline_for_day_and_user.py
+++ b/bin/debug/load_timeline_for_day_and_user.py
@@ -1,26 +1,24 @@
 import json
 import bson.json_util as bju
 import emission.core.get_database as edb
-import sys
 import argparse
-import uuid
+import emission.core.wrapper.user as ecwu
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("timeline_filename",
         help="the name of the file that contains the json representation of the timeline")
-    parser.add_argument("-u", "--user_uuid",
-        help="overwrite the user UUID from the file")
+    parser.add_argument("user_email",
+        help="specify the user email to load the data as")
     args = parser.parse_args()
     fn = args.timeline_filename
     print fn
     print "Loading file " + fn
     tsdb = edb.get_timeseries_db()
-    override_uuid = None
-    if args.user_uuid is not None:
-        override_uuid = uuid.uuid3(uuid.NAMESPACE_URL, "mailto:%s" % args.user_uuid.encode("UTF-8"))
+    user = ecwu.User.register(args.user_email)
+    override_uuid = user.uuid
+    print("After registration, %s -> %s" % (args.user_email, override_uuid))
     entries = json.load(open(fn), object_hook = bju.object_hook)
     for entry in entries:
-        if args.user_uuid is not None:
-            entry["user_id"] = override_uuid
+        entry["user_id"] = override_uuid
         tsdb.save(entry)

--- a/bin/historical/before_bic2cal/reset_uuids.py
+++ b/bin/historical/before_bic2cal/reset_uuids.py
@@ -1,0 +1,50 @@
+import logging
+import attrdict as ad
+import uuid
+
+import emission.core.get_database as edb
+import emission.storage.timeseries.aggregate_timeseries as estag
+
+def reset_collection(coll, old_uuid, new_uuid):
+    logging.debug(coll.update({"user_id": user.uuid},
+              {"$set": {"user_id": new_uuid}}, multi=True))
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    for user_dict in edb.get_uuid_db().find():
+        user = ad.AttrDict(user_dict)
+        if user.uuid in estag.TEST_PHONE_IDS:
+            logging.debug("Found test phone, skipping reset")
+        else:
+            new_uuid = uuid.uuid4()
+            logging.debug("Mapping %s -> %s" % (new_uuid, user.uuid))
+            edb.get_uuid_db().update({"uuid" : user.uuid},
+                                     {"$set": {"uuid" : new_uuid}})
+            logging.debug("Resetting alternatives...")
+            reset_collection(edb.get_alternatives_db(), user.uuid, new_uuid)
+            logging.debug("Resetting analysis...")
+            reset_collection(edb.get_analysis_timeseries_db(), user.uuid, new_uuid)
+            logging.debug("Resetting client...")
+            reset_collection(edb.get_client_db(), user.uuid, new_uuid)
+            logging.debug("Resetting client_stats_backup...")
+            reset_collection(edb.get_client_stats_db_backup(), user.uuid, new_uuid)
+            logging.debug("Resetting server_stats_backup...")
+            reset_collection(edb.get_server_stats_db_backup(), user.uuid, new_uuid)
+            logging.debug("Resetting result_stats_backup...")
+            reset_collection(edb.get_result_stats_db_backup(), user.uuid, new_uuid)
+            logging.debug("Resetting edb.get_common_place_db...")
+            reset_collection(edb.get_common_place_db(), user.uuid, new_uuid)
+            logging.debug("Resetting edb.get_common_trip_db...")
+            reset_collection(edb.get_common_trip_db(), user.uuid, new_uuid)
+            logging.debug("Resetting edb.get_habitica_db...")
+            reset_collection(edb.get_habitica_db(), user.uuid, new_uuid)
+            logging.debug("Resetting edb.get_pipeline_state_db...")
+            reset_collection(edb.get_pipeline_state_db(), user.uuid, new_uuid)
+            logging.debug("Resetting edb.get_profile_db...")
+            reset_collection(edb.get_profile_db(), user.uuid, new_uuid)
+            logging.debug("Resetting edb.get_timeseries_db...")
+            reset_collection(edb.get_timeseries_db(), user.uuid, new_uuid)
+            logging.debug("Resetting edb.get_timeseries_error_db...")
+            reset_collection(edb.get_timeseries_error_db(), user.uuid, new_uuid)
+            logging.debug("Resetting edb.get_usercache_db...")
+            reset_collection(edb.get_usercache_db(), user.uuid, new_uuid)


### PR DESCRIPTION
While we have always had the uuid separate from the email, and used the UUID
exclusively through our code, for historical reasons, we have generated the
UUID using the uuid3 scheme from the email address. What this means is that,
while it is not possible in principle to go from the UUID -> email, if you had
the list of UUIDs, and some idea of the email of some people who were on the
list, you could re-generate the UUIDs and match them up.

Now that we are moving to our first deployment on top of e-mission, and are
going to release limited data to people who are not part of the protocol, it is
time to fix this. It does not have any practical implications any more because,
unlike when we first designed the system without an explicit mapping, we now do
have an explicit mapping in the uuid_db.

This has a couple of minor fallout issues.
- All existing UUIDs have been generated using the old scheme, and should be reset
    - EXCEPT that UUIDs for the public data from the test phones are used in a
      bunch of places - e.g.
        - to decide whether to filter
        - to decide whether to return via public interface
        - to strip out of aggregate data
      so they should NOT be reset
- The load_timeline_for_day_and_user script needs to create the email -> UUID
  mapping, since we can no longer rely on the same email to map to the same UUID.

A bonus of this change is that we can now periodically switch the email -> UUID
mapping on an ongoing basis. So if we do have issues with an email -> UUID
mapping getting leaked, we can just reset the UUID on the fly.

Woo!