### PR TITLE
Add a rollover file-based log to the webserver as well

### DIFF
--- a/conf/log/webserver.conf.sample
+++ b/conf/log/webserver.conf.sample
@@ -1,0 +1,42 @@
+{
+    "handlers": {
+        "errors": {
+            "encoding": "bz2", 
+            "backupCount": 2, 
+            "mode": "a", 
+            "level": "ERROR", 
+            "formatter": "detailed", 
+            "class": "logging.handlers.RotatingFileHandler", 
+            "maxBytes": 1073741824, 
+            "filename": "/var/tmp/webserver-errors.log.gz"
+        }, 
+        "console": {
+            "class": "logging.StreamHandler", 
+            "level": "WARNING"
+        }, 
+        "file": {
+            "backupCount": 3, 
+            "encoding": "bz2", 
+            "filename": "/var/tmp/webserver.log.gz", 
+            "maxBytes": 1073741824, 
+            "mode": "a", 
+            "formatter": "detailed", 
+            "class": "logging.handlers.RotatingFileHandler"
+        }
+    }, 
+    "version": 1, 
+    "root": {
+        "handlers": [
+            "console", 
+            "file", 
+            "errors"
+        ], 
+        "level": "DEBUG"
+    }, 
+    "formatters": {
+        "detailed": {
+            "class": "logging.Formatter", 
+            "format": "%(asctime)s:%(levelname)s:%(thread)d:%(message)s"
+        }
+    }
+}

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -645,8 +645,12 @@ def getUUID(request, inHeader=False):
 # Auth helpers END
 
 if __name__ == '__main__':
-    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(thread)d:%(message)s',
-                        filename='webserver_debug.log', level=logging.DEBUG)
+    try:
+        webserver_log_config = json.load(open("conf/log/webserver.conf", "r"))
+    except:
+        webserver_log_config = json.load(open("conf/log/webserver.conf.sample", "r"))
+
+    logging.config.dictConfig(webserver_log_config)
     logging.debug("This should go to the log file")
 
     # We have see the sockets hang in practice. Let's set the socket timeout = 1


### PR DESCRIPTION
With this, all our ongoing files are logrotated, so we shouldn't have to worry
about running out of space like before.