### PR TITLE
Enhance the pipeline to run separately for the public phones

### DIFF
--- a/bin/intake_multiprocess.py
+++ b/bin/intake_multiprocess.py
@@ -11,18 +11,22 @@ if __name__ == '__main__':
     except:
         intake_log_config = json.load(open("conf/log/intake.conf.sample", "r"))
 
-    intake_log_config["handlers"]["file"]["filename"] = intake_log_config["handlers"]["file"]["filename"].replace("intake", "intake_launcher")
-    intake_log_config["handlers"]["errors"]["filename"] = intake_log_config["handlers"]["errors"]["filename"].replace("intake", "intake_launcher")
-
-    logging.config.dictConfig(intake_log_config)
-    np.random.seed(61297777)
-
     parser = argparse.ArgumentParser()
     parser.add_argument("n_workers", type=int,
                         help="the number of worker processors to use")
     parser.add_argument("-p", "--public", action="store_true",
         help="pipeline for public (as opposed to regular) phones")
     args = parser.parse_args()
+
+    if args.public:
+        intake_log_config["handlers"]["file"]["filename"] = intake_log_config["handlers"]["file"]["filename"].replace("intake", "intake_launcher_public")
+        intake_log_config["handlers"]["errors"]["filename"] = intake_log_config["handlers"]["errors"]["filename"].replace("intake", "intake_launcher_public")
+    else:
+        intake_log_config["handlers"]["file"]["filename"] = intake_log_config["handlers"]["file"]["filename"].replace("intake", "intake_launcher")
+        intake_log_config["handlers"]["errors"]["filename"] = intake_log_config["handlers"]["errors"]["filename"].replace("intake", "intake_launcher")
+
+    logging.config.dictConfig(intake_log_config)
+    np.random.seed(61297777)
 
     split_lists = eps.get_split_uuid_lists(args.n_workers, args.public)
     logging.info("Finished generating split lists %s" % split_lists)

--- a/bin/intake_multiprocess.py
+++ b/bin/intake_multiprocess.py
@@ -26,4 +26,4 @@ if __name__ == '__main__':
 
     split_lists = eps.get_split_uuid_lists(args.n_workers, args.public)
     logging.info("Finished generating split lists %s" % split_lists)
-    eps.dispatch(split_lists)
+    eps.dispatch(split_lists, args.public)

--- a/bin/intake_multiprocess.py
+++ b/bin/intake_multiprocess.py
@@ -20,8 +20,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("n_workers", type=int,
                         help="the number of worker processors to use")
+    parser.add_argument("-p", "--public", action="store_true",
+        help="pipeline for public (as opposed to regular) phones")
     args = parser.parse_args()
 
-    split_lists = eps.get_split_uuid_lists(args.n_workers)
+    split_lists = eps.get_split_uuid_lists(args.n_workers, args.public)
     logging.info("Finished generating split lists %s" % split_lists)
     eps.dispatch(split_lists)

--- a/emission/pipeline/intake_stage.py
+++ b/emission/pipeline/intake_stage.py
@@ -53,13 +53,6 @@ def run_intake_pipeline(process_number, uuid_list):
         if uuid == UUID("2c3996d1-49b1-4dce-82f8-d0cda85d3475"):
             continue
 
-        # Hack until we delete these spurious entries
-        # https://github.com/e-mission/e-mission-server/issues/407#issuecomment-2484868
-
-        if edb.get_timeseries_db().find({"user_id": uuid}).count() == 0:
-            logging.debug("Found no entries for %s, skipping" % uuid)
-            continue
-
         try:
             run_intake_pipeline_for_user(uuid)
         except Exception as e:
@@ -74,6 +67,12 @@ def run_intake_pipeline_for_user(uuid):
 
         uh.moveToLongTerm()
 
+        # Hack until we delete these spurious entries
+        # https://github.com/e-mission/e-mission-server/issues/407#issuecomment-2484868
+
+        if edb.get_timeseries_db().find({"user_id": uuid}).count() == 0:
+            logging.debug("Found no entries for %s, skipping" % uuid)
+            return
 
         logging.info("*" * 10 + "UUID %s: filter accuracy if needed" % uuid + "*" * 10)
         print(str(arrow.now()) + "*" * 10 + "UUID %s: filter accuracy if needed" % uuid + "*" * 10)

--- a/emission/pipeline/scheduler.py
+++ b/emission/pipeline/scheduler.py
@@ -55,11 +55,12 @@ def get_split_uuid_lists(n_splits, is_public_pipeline):
     logging.debug("Split values are %s" % ret_splits)
     return ret_splits
 
-def dispatch(split_lists):
+def dispatch(split_lists, is_public_pipeline):
     process_list = []
     for i, uuid_list in enumerate(split_lists):
         logging.debug("Dispatching list %s" % uuid_list)
-        p = mp.Process(target=epi.run_intake_pipeline, args=(i, uuid_list))
+        pid = "public_%s" % i if is_public_pipeline else i
+        p = mp.Process(target=epi.run_intake_pipeline, args=(pid, uuid_list))
         logging.info("Created process %s to process %s list of size %s" %
                      (p, i, len(uuid_list)))
         p.start()

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -183,6 +183,16 @@ class BuiltinTimeSeries(esta.TimeSeries):
                 ts_db_result = ts_db_cursor
             else:
                 ts_db_result = ts_db_cursor.sort(sort_key, pymongo.ASCENDING)
+            # We send the results from the phone in batches of 10,000
+            # And we support reading upto 100 times that amount at a time, so over
+            # This is more than the number of entries across all metadata types for
+            # normal user processing for over a year
+            # In [590]: edb.get_timeseries_db().find({"user_id": UUID('08b31565-f990-4d15-a4a7-89b3ba6b1340')}).count()
+            # Out[590]: 625272
+            #
+            # In [593]: edb.get_timeseries_db().find({"user_id": UUID('ea59084e-11d4-4076-9252-3b9a29ce35e0')}).count()
+            # Out[593]: 449869
+            ts_db_result.limit(100 * 10000)
         else:
             ts_db_result = [].__iter__()
 


### PR DESCRIPTION
- This involves passing in a public or not flag to the scheduler
- Adding a command line option to the invoking script
- Ensuring that the public logs are separate so that they don't overlap each other
