### PR TITLE
Add formatters for the client stats

### DIFF
--- a/emission/net/usercache/formatters/android/client_error.py
+++ b/emission/net/usercache/formatters/android/client_error.py
@@ -1,0 +1,26 @@
+import logging
+import copy
+import pytz
+
+import emission.core.wrapper.consentconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except pytz.UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+    formatted_entry.data = entry.data
+    return formatted_entry;

--- a/emission/net/usercache/formatters/android/client_nav_event.py
+++ b/emission/net/usercache/formatters/android/client_nav_event.py
@@ -1,0 +1,26 @@
+import logging
+import copy
+import pytz
+
+import emission.core.wrapper.consentconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except pytz.UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+    formatted_entry.data = entry.data
+    return formatted_entry;

--- a/emission/net/usercache/formatters/android/client_time.py
+++ b/emission/net/usercache/formatters/android/client_time.py
@@ -1,0 +1,26 @@
+import logging
+import copy
+import pytz
+
+import emission.core.wrapper.consentconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except pytz.UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+    formatted_entry.data = entry.data
+    return formatted_entry;

--- a/emission/net/usercache/formatters/ios/client_error.py
+++ b/emission/net/usercache/formatters/ios/client_error.py
@@ -1,0 +1,26 @@
+import logging
+import copy
+import pytz
+
+import emission.core.wrapper.consentconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except pytz.UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+    formatted_entry.data = entry.data
+    return formatted_entry;

--- a/emission/net/usercache/formatters/ios/client_nav_event.py
+++ b/emission/net/usercache/formatters/ios/client_nav_event.py
@@ -1,0 +1,26 @@
+import logging
+import copy
+import pytz
+
+import emission.core.wrapper.consentconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except pytz.UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+    formatted_entry.data = entry.data
+    return formatted_entry;

--- a/emission/net/usercache/formatters/ios/client_q
+++ b/emission/net/usercache/formatters/ios/client_q
@@ -1,0 +1,26 @@
+import logging
+import copy
+import pytz
+
+import emission.core.wrapper.consentconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except pytz.UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+    formatted_entry.data = entry.data
+    return formatted_entry;

--- a/emission/net/usercache/formatters/ios/client_time.py
+++ b/emission/net/usercache/formatters/ios/client_time.py
@@ -1,0 +1,26 @@
+import logging
+import copy
+import pytz
+
+import emission.core.wrapper.consentconfig as ecws
+import emission.net.usercache.formatters.common as fc
+
+# Currently, we just reflect this back to the user, so not much editing to do
+# here. Since we get the timezone from javascript guessing, though, let's just
+# verify that it is correct.
+def format(entry):
+    formatted_entry = entry
+
+    metadata = entry.metadata
+    try:
+        valid_tz = pytz.timezone(entry.metadata.time_zone)
+    except pytz.UnknownTimeZoneError, e:
+        logging.warn("Got error %s while checking format validity" % e)
+        # Default timezone in for the Bay Area, which is probably a fairly safe
+        # assumption for now
+        metadata.time_zone = "America/Los_Angeles"
+    # adds the python datetime and fmt_time entries. important for future searches!
+    fc.expand_metadata_times(metadata)
+    formatted_entry.metadata = metadata
+    formatted_entry.data = entry.data
+    return formatted_entry;


### PR DESCRIPTION
stats are basically just NOPs, with the standard filling in of the metadata entries.
I can confirm that the entries show up correctly in the timeseries

```
>>> esta.TimeSeries.get_time_series(UUID("...")).get_data_df("stats/client_time", time_query=None)
```

|idx|_id|client_app_version|client_os_version|metadata_write_ts|name|reading|ts|user_id|
|---|---|------|----|-----|-----|-----|----|----|
|0|5818e38e616eee1c496de45b|1.2.0|9.2|1478026111.91|push_duration|0.0430309772491|1478026111.91|480bdc1e-2415-4174-a699-c42c284ccda3|
|1|5818e38e616eee1c496de45c|1.2.0|9.2|1478026111.98|sync_pull_list_size|4.0|1478026111.98|480bdc1e-2415-4174-a699-c42c284ccda3|
|2|5818e38e616eee1c496de45d|1.2.0|9.2|1478026111.99|pull_duration|0.104228973389|1478026111.99|480bdc1e-2415-4174-a699-c42c284ccda3|
|3|5818f2ce616eee1c496de464|1.2.0|9.2|1478030027.95|push_duration|0.14977902174|1478030027.95|480bdc1e-2415-4174-a699-c42c284ccda3|
|4|5818f3f2616eee1c496de46c|1.2.0|9.2|1478030064.54|push_duration|0.0854989886284|1478030064.54|480bdc1e-2415-4174-a699-c42c284ccda3|
|5|5818f3f2616eee1c496de46d|1.2.0|9.2|1478030064.56|sync_pull_list_size|4.0|1478030064.56|480bdc1e-2415-4174-a699-c42c284ccda3|
|6|5818f3f2616eee1c496de46e|1.2.0|9.2|1478030064.56|pull_duration|0.0919269919395|1478030064.56|480bdc1e-2415-4174-a699-c42c284ccda3|

Related client changes are:
https://github.com/e-mission/cordova-usercache/pull/26/commits/67ae0c9d8d6fe454d3dfded1a46d95b262f75aac
https://github.com/e-mission/cordova-server-sync/pull/22/commits/8a4dfba133b07e26180a412906bdbe8ccddc4e2a
https://github.com/e-mission/e-mission-data-collection/pull/139/commits/dfb8bc98c4cf6ecd911920a8a1d179cd1ac2dc82