### PR TITLE
Add support for the new parse open source server

### DIFF
--- a/bin/remotePush.py
+++ b/bin/remotePush.py
@@ -18,17 +18,33 @@ silent_push_msg = {
 }
 
 parse_headers = {
-   "X-Parse-Application-Id": config_data["emission_id"],
-   "X-Parse-REST-API-Key": config_data["emission_key"],
+   "X-Parse-Application-Id": config_data["emission_id_legacy"],
+   "X-Parse-REST-API-Key": config_data["emission_key_legacy"],
    "Content-Type": "application/json"
 }
 
+# Sending messages to standard parse.com
+# This is obsolete after 30th Jan
 connection = httplib.HTTPSConnection('api.parse.com', 443)
 connection.connect()
 
 connection.request('POST', '/1/push', json.dumps(silent_push_msg), parse_headers)
 
 result = json.loads(connection.getresponse().read())
-print result
+print "parse.com %s" % result
 
+# Sending messages to open source parse server
+# This is the long-term one used while going forward
+parse_headers = {
+   "X-Parse-Application-Id": config_data["emission_id"],
+   "X-Parse-REST-API-Key": config_data["emission_key"],
+   "Content-Type": "application/json"
+}
 
+connection = httplib.HTTPConnection('aws-parse-push-server', 1337)
+connection.connect()
+
+connection.request('POST', '/parse/push', json.dumps(silent_push_msg), parse_headers)
+
+result = json.loads(connection.getresponse().read())
+print "open parse server %s" % result

--- a/conf/net/ext_service/parse.json.sample
+++ b/conf/net/ext_service/parse.json.sample
@@ -1,4 +1,7 @@
 {
-    "emission_id": "Get from https://www.parse.com",
-    "emission_key": "Get from https://www.parse.com"
+    "emission_id_legacy": "Obsolete since parse.com has shut down. Only for backwards compatibility.",
+    "emission_key_legacy": "Obsolete since parse.com has shut down. Only for backwards compatibility",
+    "push_server": "Create while installing server from https://github.com/ParsePlatform/parse-server",
+    "emission_id": "Choose while starting push_server above",
+    "emission_key": "Choose while starting push_server above"
 }


### PR DESCRIPTION
- Convert the existing IDs to "legacy"
- Add space for new IDs and server name
- Push to both legacy and new servers

TODO:
- After the clients get updated, we need a separate change that will comment
  out the legacy code