### PR TITLE
Switch to a parse compatible push notification server

### DIFF
--- a/bin/remotePush.py
+++ b/bin/remotePush.py
@@ -38,13 +38,14 @@ print "parse.com %s" % result
 parse_headers = {
    "X-Parse-Application-Id": config_data["emission_id"],
    "X-Parse-REST-API-Key": config_data["emission_key"],
+   "X-Parse-Master-Key": config_data["emission_master_key"],
    "Content-Type": "application/json"
 }
 
-connection = httplib.HTTPConnection('aws-parse-push-server', 1337)
+connection = httplib.HTTPSConnection('parseapi.back4app.com', 443)
 connection.connect()
 
-connection.request('POST', '/parse/push', json.dumps(silent_push_msg), parse_headers)
+connection.request('POST', '/push', json.dumps(silent_push_msg), parse_headers)
 
 result = json.loads(connection.getresponse().read())
 print "open parse server %s" % result

--- a/conf/net/ext_service/parse.json.sample
+++ b/conf/net/ext_service/parse.json.sample
@@ -1,7 +1,8 @@
 {
     "emission_id_legacy": "Obsolete since parse.com has shut down. Only for backwards compatibility.",
     "emission_key_legacy": "Obsolete since parse.com has shut down. Only for backwards compatibility",
-    "push_server": "Create while installing server from https://github.com/ParsePlatform/parse-server",
+    "push_server": "Choose a parse-compatible push notification provider",
     "emission_id": "Choose while starting push_server above",
-    "emission_key": "Choose while starting push_server above"
+    "emission_key": "Choose while starting push_server above",
+    "emission_master_key": "Choose while starting push_server above"
 }


### PR DESCRIPTION
When using our own server, I was able to connect to it from another AWS server
and from my laptop, but wasn't able to connect from the phone. Not even from
Safari, so this is not some weird app permission issue. Need to play around
with it a bit more, but for now, let's use a parse-compatible hosted provider instead.

This has been tested by making changes directly in production and it works.