### PR TITLE
Add new scripts to load and delete multi-user timelines

### DIFF
--- a/bin/debug/extract_timeline_for_day_range_and_user.py
+++ b/bin/debug/extract_timeline_for_day_range_and_user.py
@@ -24,7 +24,10 @@ def export_timeline(user_id_str, start_day_str, end_day_str, file_name):
         (start_day_ts, arrow.get(start_day_ts),
          end_day_ts, arrow.get(end_day_ts)))
 
-    ts = esta.TimeSeries.get_time_series(uuid.UUID(user_id_str))
+    if user_id_str == "all":
+        ts = esta.TimeSeries.get_aggregate_time_series(uuid.UUID(user_id_str))
+    else:
+        ts = esta.TimeSeries.get_time_series(uuid.UUID(user_id_str))
     loc_time_query = estt.TimeQuery("data.ts", start_day_ts, end_day_ts)
     loc_entry_list = list(ts.find_entries(key_list=None, time_query=loc_time_query))
     trip_time_query = estt.TimeQuery("data.start_ts", start_day_ts, end_day_ts)

--- a/bin/debug/load_multi_timeline_for_range.py
+++ b/bin/debug/load_multi_timeline_for_range.py
@@ -1,0 +1,80 @@
+import logging
+
+import json
+import bson.json_util as bju
+import emission.storage.timeseries.abstract_timeseries as esta
+
+import argparse
+
+import common
+import emission.core.wrapper.user as ecwu
+import emission.core.wrapper.entry as ecwe
+
+args = None
+
+def register_fake_users(prefix, unique_user_list):
+    logging.info("Creating user entries for %d users" % len(unique_user_list))
+
+    format_string = "{0}-%0{1}d".format(prefix, len(str(len(unique_user_list))))
+    logging.debug("pattern = %s" % format_string)
+
+    for i, uuid in enumerate(unique_user_list):
+        username = (format_string % i)
+        if args.verbose is not None and i % args.verbose == 0:
+            logging.info("About to insert mapping %s -> %s" % (username, uuid))
+        # Let's register and then update instead of manipulating the database directly
+        # Alternatively, we can refactor register to pass in the uuid as well
+        user = ecwu.User.registerWithUUID(username, uuid)
+
+def get_load_ranges(entries):
+    start_indices = range(0, len(entries), args.batch_size)
+    ranges = zip(start_indices, start_indices[1:])
+    ranges.append((start_indices[-1], len(entries)))
+    return ranges
+
+def post_check(unique_user_list):
+    import emission.core.get_database as edb
+
+    logging.info("For %s users, loaded %s raw entries and %s processed entries" %
+        (len(unique_user_list),
+         edb.get_timeseries_db().find({"user_id": {"$in": list(unique_user_list)}}).count(),
+         edb.get_analysis_timeseries_db().find({"user_id": {"$in": list(unique_user_list)}}).count()))
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("timeline_filename",
+        help="the name of the file that contains the json representation of the timeline")
+    parser.add_argument("-v", "--verbose", type=int,
+        help="after how many lines we should print a status message.")
+
+    parser.add_argument("-i", "--info-only", default=False, action='store_true',
+        help="only print entry analysis")
+
+    parser.add_argument("-s", "--batch-size", default=10000,
+        help="batch size to use for the entries")
+
+    parser.add_argument("-p", "--prefix", default="user",
+        help="prefix for the automatically generated usernames. usernames will be <prefix>-001, <prefix>-002...")
+
+    args = parser.parse_args()
+
+    fn = args.timeline_filename
+    logging.info("Loading file %s" % fn)
+    ts = esta.TimeSeries.get_aggregate_time_series()
+
+    entries = json.load(open(fn), object_hook = bju.object_hook)
+
+    unique_user_list = common.analyse_timeline(entries)
+    if not args.info_only:
+        register_fake_users(args.prefix, unique_user_list)
+        load_ranges = get_load_ranges(entries)
+
+        for i, curr_range in enumerate(load_ranges):
+            if args.verbose is not None and i % args.verbose == 0:
+                logging.info("About to load range %s -> %s" % (curr_range[0], curr_range[1]))
+            wrapped_entries = [ecwe.Entry(e) for e in entries[curr_range[0]:curr_range[1]]]
+            for entry in wrapped_entries:
+                insert_result = ts.insert(entry)
+       
+        post_check(unique_user_list) 

--- a/bin/debug/load_timeline_for_day_and_user.py
+++ b/bin/debug/load_timeline_for_day_and_user.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     parser.add_argument("-r", "--retain", action="store_true",
         help="specify whether the entries should overwrite existing ones (default) or create new ones")
 
-    parser.add_argument("-v", "--verbose",
+    parser.add_argument("-v", "--verbose", type=int,
         help="after how many lines we should print a status message.")
 
     args = parser.parse_args()

--- a/bin/debug/purge_multi_timeline_for_range.py
+++ b/bin/debug/purge_multi_timeline_for_range.py
@@ -1,0 +1,54 @@
+import logging
+import argparse
+import json
+import bson.json_util as bju
+
+# Our imports
+import common
+import emission.core.get_database as edb
+
+# This is shamelessly going to use edb because we have immutable data, so no
+# way to nicely delete entries through the timeseries options
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("timeline_filename",
+        help="the name of the file that contains the json representation of the timeline")
+    parser.add_argument("-v", "--verbose", type=int,
+        help="after how many lines we should print a status message.")
+
+    parser.add_argument("-i", "--info-only", default=False, action='store_true',
+        help="only print entry analysis")
+
+    parser.add_argument("-s", "--batch-size", default=10000,
+        help="batch size to use for the entries")
+
+    parser.add_argument("-p", "--prefix", default="user",
+        help="prefix for the automatically generated usernames. usernames will be <prefix>-001, <prefix>-002...")
+
+    args = parser.parse_args()
+    fn = args.timeline_filename
+    logging.info("Loading file %s" % fn)
+
+    entries = json.load(open(fn), object_hook = bju.object_hook)
+
+    unique_user_list = common.analyse_timeline(entries)
+    if not args.info_only:
+        ts_db = edb.get_timeseries_db()
+        ats_db = edb.get_analysis_timeseries_db()
+        udb = edb.get_uuid_db()
+
+        for i, uuid in enumerate(unique_user_list):
+            
+            logging.info("For uuid = %s, deleting entries from the timeseries" % uuid)
+            timeseries_del_result = ts_db.remove({"user_id": uuid})
+            logging.info("result = %s" % timeseries_del_result)
+
+            logging.info("For uuid = %s, deleting entries from the analysis_timeseries" % uuid)
+            analysis_timeseries_del_result = ats_db.remove({"user_id": uuid})
+            logging.info("result = %s" % analysis_timeseries_del_result)
+
+            logging.info("For uuid %s, deleting entries from the user_db" % uuid)
+            user_db_del_result = udb.remove({"uuid": uuid})
+            logging.info("result = %s" % user_db_del_result)

--- a/emission/storage/pipeline_queries.py
+++ b/emission/storage/pipeline_queries.py
@@ -88,7 +88,7 @@ def mark_smoothing_failed(user_id):
     mark_stage_failed(user_id, ps.PipelineStages.JUMP_SMOOTHING)
 
 def get_complete_ts(user_id):
-    return get_current_state(user_id, ps.PipelineStages.JUMP_SMOOTHING).last_ts_run
+    return get_current_state(user_id, ps.PipelineStages.CLEAN_RESAMPLING).last_processed_ts
 
 def get_time_range_for_clean_resampling(user_id):
     # type: (uuid.UUID) -> emission.storage.timeseries.timequery.TimeQuery

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -292,7 +292,9 @@ class BuiltinTimeSeries(esta.TimeSeries):
             keyfunc = lambda e: e.metadata.key
             sorted_data = sorted(entries, key=keyfunc)
             for k, g in itertools.groupby(sorted_data, keyfunc):
-                return self.get_timeseries_db(k).insert(g, continue_on_error=True)
+                glist = list(g)
+                logging.debug("Inserting %s entries for key %s" % (len(glist), k))
+                self.get_timeseries_db(k).insert(glist, continue_on_error=False)
         else:
             return ts_enum_map[data_type].insert(entries, continue_on_error=True)
 
@@ -305,7 +307,7 @@ class BuiltinTimeSeries(esta.TimeSeries):
             entry = ecwe.Entry(entry)
         if "user_id" not in entry or entry["user_id"] is None:
             entry["user_id"] = self.user_id
-        if entry["user_id"] != self.user_id:
+        if self.user_id is not None and entry["user_id"] != self.user_id:
             raise AttributeError("Saving entry %s for %s in timeseries for %s" % 
 		(entry, entry["user_id"], self.user_id))
         else:


### PR DESCRIPTION
These timelines are aggregated at the source (e.g. all data from Sept to Dec), so we want to load them together and retain UUIDs so that they can be correlated with other information - e.g. surveys

Change is pretty straightforward, just took a long time to test.
