### PR TITLE
Save the timeline into a set of user files

### DIFF
--- a/bin/debug/common.py
+++ b/bin/debug/common.py
@@ -1,5 +1,7 @@
 import logging
 
+import glob
+
 def analyse_timeline(entries):
     logging.info("Analyzing timeline...")
     logging.info("timeline has %d entries" % len(entries))
@@ -7,14 +9,27 @@ def analyse_timeline(entries):
     unique_user_list = set(map(lambda e: e["user_id"], entries))
     logging.info("timeline has data from %d users" % len(unique_user_list))
     unique_user_list_list = list(unique_user_list)
-    logging.info("Found %d entries with blank uuid, loading them anyway" % 
-        (len([entry for entry in entries if entry["user_id"] == ''])))
+    blank_uuid_list = [entry for entry in entries if entry["user_id"] == '']
+    if len(blank_uuid_list) > 0:
+        logging.info("Found %d entries with blank uuid, loading them anyway" % 
+            (len(blank_uuid_list)))
 
     unique_key_list = set(map(lambda e: e["metadata"]["key"], entries))
     logging.info("timeline has the following unique keys %s" % unique_key_list)
 
     if "analysis/cleaned_trip" in unique_key_list and "analysis/cleaned_place" in unique_key_list:
-        logging.info("timeline contains analysis results, no need to run the intake pipeline")
+        logging.info("timeline for user %s contains analysis results" % unique_user_list_list[0])
+        needs_rerun = False
     else:
-        logging.info("timeline contains only raw data, need to run the intake pipeline")
-    return unique_user_list
+        logging.info("timeline for user %s contains only raw data" % unique_user_list_list[0])
+        needs_rerun = True
+
+    return unique_user_list_list, needs_rerun
+
+split_user_id = lambda(fn): fn.split("_")[-1]
+
+def read_files_with_prefix(prefix):
+    matching_files = glob.glob(prefix+"*")
+    logging.info("Found %d matching files for prefix %s" % (len(matching_files), prefix))
+    logging.info("files are %s ... %s" % (matching_files[0:5], matching_files[-5:-1]))
+    return matching_files

--- a/bin/debug/extract_timeline_for_day_range_and_user.py
+++ b/bin/debug/extract_timeline_for_day_range_and_user.py
@@ -12,10 +12,11 @@ import arrow
 
 import emission.storage.timeseries.abstract_timeseries as esta
 import emission.storage.timeseries.timequery as estt
+import emission.storage.decorations.user_queries as esdu
 
-def export_timeline(user_id_str, start_day_str, end_day_str, file_name):
+def export_timeline(user_id, start_day_str, end_day_str, file_name):
     logging.info("Extracting timeline for user %s day %s -> %s and saving to file %s" %
-                 (user_id_str, start_day_str, end_day_str, file_name))
+                 (user_id, start_day_str, end_day_str, file_name))
 
     # day_dt = pydt.datetime.strptime(day_str, "%Y-%m-%d").date()
     start_day_ts = arrow.get(start_day_str).timestamp
@@ -24,10 +25,7 @@ def export_timeline(user_id_str, start_day_str, end_day_str, file_name):
         (start_day_ts, arrow.get(start_day_ts),
          end_day_ts, arrow.get(end_day_ts)))
 
-    if user_id_str == "all":
-        ts = esta.TimeSeries.get_aggregate_time_series()
-    else:
-        ts = esta.TimeSeries.get_time_series(uuid.UUID(user_id_str))
+    ts = esta.TimeSeries.get_time_series(user_id)
     loc_time_query = estt.TimeQuery("data.ts", start_day_ts, end_day_ts)
     loc_entry_list = list(ts.find_entries(key_list=None, time_query=loc_time_query))
     trip_time_query = estt.TimeQuery("data.start_ts", start_day_ts, end_day_ts)
@@ -35,13 +33,41 @@ def export_timeline(user_id_str, start_day_str, end_day_str, file_name):
     place_time_query = estt.TimeQuery("data.enter_ts", start_day_ts, end_day_ts)
     place_entry_list = list(ts.find_entries(key_list=None, time_query=place_time_query))
 
-    logging.info("Found %d loc entries, %d trip-like entries, %d place-like entries" % 
-        (len(loc_entry_list), len(trip_entry_list), len(place_entry_list)))
-    json.dump(loc_entry_list + trip_entry_list + place_entry_list,
-        open(file_name, "w"), default=bju.default, allow_nan=False, indent=4)
+    combined_list = loc_entry_list + trip_entry_list + place_entry_list
+    logging.info("Found %d loc entries, %d trip-like entries, %d place-like entries = %d total entries" % 
+        (len(loc_entry_list), len(trip_entry_list), len(place_entry_list), len(combined_list)))
+
+    validate_truncation(loc_entry_list, trip_entry_list, place_entry_list)
+
+    unique_key_list = set(map(lambda e: e["metadata"]["key"], combined_list))
+    logging.info("timeline has unique keys = %s" % unique_key_list)
+    if len(combined_list) == 0 or unique_key_list == set(['stats/pipeline_time']):
+        logging.info("No entries found in range for user %s, skipping save" % user_id)
+    else:
+        combined_filename = "%s_%s" % (file_name, user_id)
+        json.dump(combined_list,
+            open(combined_filename, "w"), default=bju.default, allow_nan=False, indent=4)
+
+def validate_truncation(loc_entry_list, trip_entry_list, place_entry_list):
+    MAX_LIMIT = 25 * 10000
+    if len(loc_entry_list) == MAX_LIMIT:
+        logging.warning("loc_entry_list length = %d, probably truncated" % len(loc_entry_list))
+    if len(trip_entry_list) == MAX_LIMIT:
+        logging.warning("trip_entry_list length = %d, probably truncated" % len(trip_entry_list))
+    if len(place_entry_list) == MAX_LIMIT:
+        logging.warning("place_entry_list length = %d, probably truncated" % len(place_entry_list))
+
 
 if __name__ == '__main__':
     if len(sys.argv) != 5:
-        print "Usage: %s <user> <start_day> <end_day> <file>" % (sys.argv[0])
+        print "Usage: %s <user> <start_day> <end_day> <file_prefix>" % (sys.argv[0])
     else:
-        export_timeline(user_id_str=sys.argv[1], start_day_str=sys.argv[2], end_day_str=sys.argv[3], file_name=sys.argv[4])
+        user_id_str = sys.argv[1]
+        if user_id_str == "all":
+            all_uuids = esdu.get_all_uuids()
+            for curr_uuid in all_uuids:
+                if curr_uuid != '':
+                    logging.info("=" * 50)
+                    export_timeline(user_id=curr_uuid, start_day_str=sys.argv[2], end_day_str=sys.argv[3], file_name=sys.argv[4])
+        else:
+            export_timeline(user_id=uuid.UUID(sys.argv[1]), start_day_str=sys.argv[2], end_day_str=sys.argv[3], file_name=sys.argv[4])

--- a/bin/debug/load_multi_timeline_for_range.py
+++ b/bin/debug/load_multi_timeline_for_range.py
@@ -2,11 +2,12 @@ import logging
 
 import json
 import bson.json_util as bju
-import emission.storage.timeseries.abstract_timeseries as esta
-
 import argparse
 
 import common
+import os
+
+import emission.storage.timeseries.abstract_timeseries as esta
 import emission.core.wrapper.user as ecwu
 import emission.core.wrapper.entry as ecwe
 
@@ -16,7 +17,7 @@ def register_fake_users(prefix, unique_user_list):
     logging.info("Creating user entries for %d users" % len(unique_user_list))
 
     format_string = "{0}-%0{1}d".format(prefix, len(str(len(unique_user_list))))
-    logging.debug("pattern = %s" % format_string)
+    logging.info("pattern = %s" % format_string)
 
     for i, uuid in enumerate(unique_user_list):
         username = (format_string % i)
@@ -32,19 +33,35 @@ def get_load_ranges(entries):
     ranges.append((start_indices[-1], len(entries)))
     return ranges
 
-def post_check(unique_user_list):
+def post_check(unique_user_list, all_rerun_list):
     import emission.core.get_database as edb
+    import numpy as np
 
     logging.info("For %s users, loaded %s raw entries and %s processed entries" %
         (len(unique_user_list),
          edb.get_timeseries_db().find({"user_id": {"$in": list(unique_user_list)}}).count(),
          edb.get_analysis_timeseries_db().find({"user_id": {"$in": list(unique_user_list)}}).count()))
 
+    all_rerun_arr = np.array(all_rerun_list)
+   
+    # want to check if no entry needs a rerun? In this case we are done
+    # no entry needs a rerun = all entries are false, not(all entries) are true
+    if np.all(np.logical_not(all_rerun_list)):
+        logging.info("all entries in the timeline contain analysis results, no need to run the intake pipeline")
+    # if all entries need to be re-run, we must have had raw data throughout
+    elif np.all(all_rerun_list):
+        logging.info("all entries in the timeline contain only raw data, need to run the intake pipeline")
+    else:
+        logging.info("timeline contains a mixture of analysis results and raw data - complain to shankari!")
+
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
     parser = argparse.ArgumentParser()
     parser.add_argument("timeline_filename",
-        help="the name of the file that contains the json representation of the timeline")
+        help="the name of the file or file prefix that contains the json representation of the timeline")
+
+    parser.add_argument("-d", "--debug", type=int,
+        help="set log level to DEBUG")
+
     parser.add_argument("-v", "--verbose", type=int,
         help="after how many lines we should print a status message.")
 
@@ -58,23 +75,47 @@ if __name__ == '__main__':
         help="prefix for the automatically generated usernames. usernames will be <prefix>-001, <prefix>-002...")
 
     args = parser.parse_args()
+    if args.debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
 
     fn = args.timeline_filename
-    logging.info("Loading file %s" % fn)
-    ts = esta.TimeSeries.get_aggregate_time_series()
+    logging.info("Loading file or prefix %s" % fn)
+    sel_file_list = common.read_files_with_prefix(fn)
 
-    entries = json.load(open(fn), object_hook = bju.object_hook)
+    all_user_list = []
+    all_rerun_list = []
 
-    unique_user_list = common.analyse_timeline(entries)
+    for i, filename in enumerate(sel_file_list):
+        logging.info("=" * 50)
+        logging.info("Loading data from file %s" % filename)
+        
+        entries = json.load(open(filename), object_hook = bju.object_hook)
+
+# Obtain uuid and rerun information from entries
+        curr_uuid_list, needs_rerun = common.analyse_timeline(entries)
+        if len(curr_uuid_list) > 1:
+            logging.warning("Found %d users, %s in filename, aborting! " % 
+                (len(curr_uuid_list), curr_uuid_list))
+            raise RuntimeException("Found %d users, %s in filename, expecting 1, %s" %
+                (len(curr_uuid_list), curr_uuid_list, common.split_user_id(filename)))
+        curr_uuid = curr_uuid_list[0]
+        all_user_list.append(curr_uuid)
+        all_rerun_list.append(needs_rerun)
+
+        load_ranges = get_load_ranges(entries)
+        if not args.info_only:
+            ts = esta.TimeSeries.get_time_series(curr_uuid)
+            for j, curr_range in enumerate(load_ranges):
+                if args.verbose is not None and j % args.verbose == 0:
+                    logging.info("About to load range %s -> %s" % (curr_range[0], curr_range[1]))
+                wrapped_entries = [ecwe.Entry(e) for e in entries[curr_range[0]:curr_range[1]]]
+                for entry in wrapped_entries:
+                    insert_result = ts.insert(entry)
+
+    unique_user_list = set(all_user_list)
     if not args.info_only:
         register_fake_users(args.prefix, unique_user_list)
-        load_ranges = get_load_ranges(entries)
-
-        for i, curr_range in enumerate(load_ranges):
-            if args.verbose is not None and i % args.verbose == 0:
-                logging.info("About to load range %s -> %s" % (curr_range[0], curr_range[1]))
-            wrapped_entries = [ecwe.Entry(e) for e in entries[curr_range[0]:curr_range[1]]]
-            for entry in wrapped_entries:
-                insert_result = ts.insert(entry)
        
-        post_check(unique_user_list) 
+    post_check(unique_user_list, all_rerun_list) 


### PR DESCRIPTION
For defensive reasons (to ensure that sending in a very broad query does not
crash the server/take too much time), I limit the number of results returned by
find_entries
https://github.com/e-mission/e-mission-server/blob/master/emission/storage/timeseries/builtin_timeseries.py#L213

That limit is fine for a single user, but when I pull data for multiple users
at a time, we hit the limit and so some data is not dumped.  This is also why I
didn't run into it when I tested against a smaller range earlier.

Fix it by querying for each user separately. Then we can also save the data for
each user into a separate file. This is much more memory-safe and performant
since we don't have to have all the data in memory at the same time, and
ensures that we don't run out of memory while loading a large dataset.

We then need to fix the load and purge scripts to work off multiple files as well.