### PR TITLE
Add a new ios key to the config file

### DIFF
--- a/conf/net/keys.json
+++ b/conf/net/keys.json
@@ -5,6 +5,7 @@
   "client_key" : "Get from https://console.developers.google.com",
   "__comment": "iOS client key to handle the fact that the google iOS API does not work. The open source API does not take the webclient app, so we have the iOS client ID here.",
   "ios_client_key" : "Get from https://console.developers.google.com",
+  "ios_client_key_new" : "Get from https://console.developers.google.com",
   "moves" : {
     "client_id": "Get from https://dev.moves-app.com",
     "client_secret": "Get from https://dev.moves-app.com",

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -63,6 +63,7 @@ private_key = key_data["private_key"]
 client_key = key_data["client_key"]
 client_key_old = key_data["client_key_old"]
 ios_client_key = key_data["ios_client_key"]
+ios_client_key_new = key_data["ios_client_key_new"]
 
 BaseRequest.MEMFILE_MAX = 1024 * 1024 * 1024 # Allow the request size to be 1G
 # to accomodate large section sizes
@@ -716,16 +717,22 @@ def verifyUserToken(token):
                 tokenFields = oauth2client.client.verify_id_token(token, ios_client_key)
                 logging.debug(tokenFields)
             except AppIdentityError as iOSExp:
-                traceback.print_exc()
-                logging.debug("OAuth failed to verify id token, falling back to constructedURL")
-                #fallback to verifying using Google API
-                constructedURL = ("https://www.googleapis.com/oauth2/v1/tokeninfo?id_token=%s" % token)
-                r = requests.get(constructedURL)
-                tokenFields = json.loads(r.content)
-                in_client_key = tokenFields['audience']
-                if (in_client_key != client_key):
-                    if (in_client_key != ios_client_key):
-                        abort(401, "Invalid client key %s" % in_client_key)
+                try:
+                    logging.debug("Using OAuth2Client to verify id token from newer iOS phones")
+                    tokenFields = oauth2client.client.verify_id_token(token, ios_client_key_new)
+                    logging.debug(tokenFields)
+                except AppIdentityError as iOSExp:
+                    traceback.print_exc()
+                    logging.debug("OAuth failed to verify id token, falling back to constructedURL")
+                    #fallback to verifying using Google API
+                    constructedURL = ("https://www.googleapis.com/oauth2/v1/tokeninfo?id_token=%s" % token)
+                    r = requests.get(constructedURL)
+                    tokenFields = json.loads(r.content)
+                    in_client_key = tokenFields['audience']
+                    if (in_client_key != client_key):
+                        if (in_client_key != ios_client_key and 
+                            in_client_key != ios_client_key_new):
+                            abort(401, "Invalid client key %s" % in_client_key)
     logging.debug("Found user email %s" % tokenFields['email'])
     return tokenFields['email']
 


### PR DESCRIPTION
So that we can auth both old and new entries.
This is the transition plan for the google auth change.
https://github.com/e-mission/cordova-jwt-auth/pull/13