### PR TITLE
Support a new platform query + notification push type

### DIFF
--- a/bin/push/send_survey.py
+++ b/bin/push/send_survey.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     survey_spec = json.load(open(args.survey_spec))
-    assert survey_spec["alert_type"] == "survey", "alert_type = %s, expected 'survey'" % survey_spec["alert_type"]
+    assert (survey_spec["alert_type"] == "survey" or survey_spec["alert_type"] == "notify"), "alert_type = %s, expected 'survey' or 'notify'" % survey_spec["alert_type"]
 
     if args.user_uuid:
         uuid_list = map(lambda uuid_str: uuid.UUID(uuid_str), args.user_uuid)

--- a/emission/net/ext_service/push/notify_queries.py
+++ b/emission/net/ext_service/push/notify_queries.py
@@ -28,3 +28,9 @@ def get_matching_tokens(query):
     ret_list = [item for item in mapped_list if item is not None]
     return ret_list
 
+def get_matching_user_ids(query):
+    logging.debug("Getting tokens matching query %s" % query)
+    ret_cursor = edb.get_profile_db().find(query, {"_id": False, "user_id": True})
+    mapped_list = map(lambda e: e.get("user_id"), ret_cursor)
+    ret_list = [item for item in mapped_list if item is not None]
+    return ret_list

--- a/emission/net/ext_service/push/query/platform.py
+++ b/emission/net/ext_service/push/query/platform.py
@@ -1,0 +1,15 @@
+# Input spec sample at
+# emission/net/ext_service/push/sample.specs/platform.query.sample
+
+# Input: query spec
+# Output: list of uuids
+# 
+
+import logging
+
+import emission.net.ext_service.push.notify_queries as pnq
+
+def query(spec):
+  platform = spec['platform']
+  userid_list = pnq.get_matching_user_ids(pnq.get_platform_query(platform))
+  return userid_list

--- a/emission/net/ext_service/push/sample.specs/push/one_time_ios_login.example
+++ b/emission/net/ext_service/push/sample.specs/push/one_time_ios_login.example
@@ -1,0 +1,8 @@
+{
+    "alert_type": "notify",
+    "title": "One-time re-login necessary",
+    "message": "The most recent update (v2.1.0) will prompt to re-login. Don't worry, this is a one-time requirement because google is shifting from UIWebView to SFSafariViewController for greater security.",
+    "image": "icon",
+    "spec": {
+    }
+}

--- a/emission/net/ext_service/push/sample.specs/query/platform.query.sample
+++ b/emission/net/ext_service/push/sample.specs/query/platform.query.sample
@@ -1,0 +1,6 @@
+{
+    "query_type": "platform",
+    "spec": {
+        "platform": "ios"
+    }
+}


### PR DESCRIPTION
And use them to set up a sample query + push spec to inform all ios users about the new login requirement.
https://github.com/e-mission/cordova-jwt-auth/pull/13