### PR TITLE
Ensure no logging as part of a standard import

### DIFF
--- a/bin/debug/load_multi_timeline_for_range.py
+++ b/bin/debug/load_multi_timeline_for_range.py
@@ -80,7 +80,7 @@ if __name__ == '__main__':
     parser.add_argument("-i", "--info-only", default=False, action='store_true',
         help="only print entry analysis")
 
-    parser.add_argument("-s", "--batch-size", default=10000,
+    parser.add_argument("-s", "--batch-size", default=10000, type=int,
         help="batch size to use for the entries")
 
     parser.add_argument("-p", "--prefix", default="user",

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -9,18 +9,17 @@ from pymongo import MongoClient
 import pymongo
 import os
 import json
-import logging
 
 try:
     config_file = open('conf/storage/db.conf')
 except:
-    logging.warning("storage not configured, falling back to sample, default configuration")
+    print("storage not configured, falling back to sample, default configuration")
     config_file = open('conf/storage/db.conf.sample')
 
 config_data = json.load(config_file)
 url = config_data["timeseries"]["url"]
 
-logging.debug("Connecting to database URL "+url)
+print("Connecting to database URL "+url)
 _current_db = MongoClient(url).Stage_database
 
 def _get_current_db():


### PR DESCRIPTION
Ensure that the database code does not do any logging during module load.  This
is because it is frequently imported by other scripts, and those imports run
before any configuration (in `__main__`) for example is executed. This means
that the logging is configured to the default values, which, given the first
log message, is WARNING.

This change replaces the log with print.
BEFORE: logs only WARNINGS
AFTER: logs everything

+ bonus fix: mark the `-s` parameter as `type=int`. Otherwise it remains a
string and the batching fails later.