### PR TITLE
Stop updating the read_ts when we read messages from the usercache

### DIFF
--- a/emission/net/usercache/builtin_usercache.py
+++ b/emission/net/usercache/builtin_usercache.py
@@ -128,16 +128,6 @@ class BuiltinUserCache(ucauc.UserCache):
         read_ts = time.time()
         combo_query = self._get_msg_query(key_list, timeQuery)
         
-        # We first update the read timestamp and then actually read the messages
-        # This ensures that the values that we return have the read_ts set
-        # Is this important/useful? Dunno
-        update_read = {
-            '$set': {
-                'metadata.read_ts': read_ts
-            }
-        }
-        update_result = self.db.update(combo_query, update_read)
-        logging.debug("result = %s after updating read timestamp", update_result)
         # In the handler, we assume that the messages are processed in order of
         # the write timestamp, because we use the last_ts_processed to mark the
         # beginning of the entry for the next query. So let's sort by the


### PR DESCRIPTION
- We didn't have a clear use case for it
- In the event, we didn't end up using it
- Writing while reading messes up our attempts to have read-only guarantees and
  read-only connections to the database