### PR TITLE
Turn off the config copying to the usercache

### DIFF
--- a/emission/net/usercache/builtin_usercache_handler.py
+++ b/emission/net/usercache/builtin_usercache_handler.py
@@ -107,9 +107,9 @@ class BuiltinUserCacheHandler(enuah.UserCacheHandler):
         time_query = esp.get_time_range_for_output_gen(self.user_id)
         try:
             self.storeTimelineToCache(time_query)
-            self.storeCommonTripsToCache(time_query)
-            last_processed_ts = self.storeConfigsToCache(time_query)
-            esp.mark_output_gen_done(self.user_id, last_processed_ts)
+            # self.storeCommonTripsToCache(time_query)
+            # last_processed_ts = self.storeConfigsToCache(time_query)
+            # esp.mark_output_gen_done(self.user_id, last_processed_ts)
         except:
             logging.exception("Storing views to cache failed for user %s" % self.user_id)
             esp.mark_output_gen_failed(self.user_id)


### PR DESCRIPTION
The code to copy the config to the usercache was intended to make it easier to
change configurations from the server in order to potentially tweak the data
collection based on data collected so far, or to set up structured experiments
on the server.

But the code has been plagued with errors, notably deleting the consent after
install during the pilot last Fall, which led to the workaround(s) in
https://github.com/e-mission/cordova-usercache/commit/f35f39a1766ee660519a7481eb05c8ac7d8be43b
https://github.com/e-mission/cordova-usercache/commit/beed602252e80d4ab6194a0d794edeae82568c04

A quick look at the configs in the current usercache shows that there is a problem.

There are 561 entries in the usercache for the sensor_config.

```
In [862]: edb.get_usercache_db().find({"metadata.key": "config/sensor_config"}).count()
Out[862]: 561
```

But from only 83 users. So there must be:
- multiple entries for each user
- some missing entries, since we have closer to 500 overall users.

```
In [868]: unique_sensor_config = edb.get_usercache_db().find({"metadata.key": "config/sensor_config"}).distinct("user_id")

In [869]: len(unique_sensor_config)
Out[869]: 83

In [872]: edb.get_uuid_db().find().count()
Out[872]: 515
```

And indeed, we have 26 sensor configs for the first user.

```
In [871]: edb.get_usercache_db().find({"metadata.key": "config/sensor_config", "user_id": unique_sensor_config[0]}).count()
Out[871]: 26
```

This is even more true for consent.

```
In [865]: edb.get_usercache_db().find({"metadata.key": "config/consent"}).count()
Out[865]: 901

In [875]: unique_consent = edb.get_usercache_db().find({"metadata.key": "config/consent"}).distinct("user_id")

In [876]: len(unique_consent)
Out[876]: 252
```

And we have not yet used the feature to modify the configuration on the server,
and it is unclear that we ever will. Let's turn this code off for now and
potentially remove it forever in a bit.