### PR TITLE
Introduce a random seed to improve reproducibility

### DIFF
--- a/emission/pipeline/intake_stage.py
+++ b/emission/pipeline/intake_stage.py
@@ -55,7 +55,7 @@ def run_intake_pipeline(process_number, uuid_list):
         intake_log_config["handlers"]["errors"]["filename"].replace("intake", "intake_%s" % process_number)
 
     logging.config.dictConfig(intake_log_config)
-    # np.random.seed(61297777)
+    np.random.seed(61297777)
 
     logging.info("processing UUID list = %s" % uuid_list)
 


### PR DESCRIPTION
There is some randomness in the pipeline due to
a56adddc5dc8c94cbe98964aafb17df3bc3f724c. This has not significantly affected
reproducibility, but just to be on the safe side, we set a random seed while
running the regular pipeline as well.

This is the same seed that is set while running the single intake pipeline ( in
`bin/debug/intake_single_user.py`) or the tests (in
`emission/tests/analysisTests/intakeTests/TestPipelineRealData.py`)

Since we only use the randomness to get a large number of points quickly and
don't rely on randomness to avoid getting stuck or for convergence, this should
be safe.