### PR TITLE
Support separate host and intermediate cert files

### DIFF
--- a/conf/net/keys.json.sample
+++ b/conf/net/keys.json.sample
@@ -1,4 +1,5 @@
 {
-  "ssl_certificate" : "xxxxx-signed-cert.pem",
+  "host_certificate" : "xxxxx-cert.cer",
+  "chain_certificate" : "xxxxx-interm.cer",
   "private_key" : "xxxxx_privkey.key",
 }

--- a/conf/net/keys.json.sample
+++ b/conf/net/keys.json.sample
@@ -1,5 +1,5 @@
 {
   "host_certificate" : "xxxxx-cert.cer",
   "chain_certificate" : "xxxxx-interm.cer",
-  "private_key" : "xxxxx_privkey.key",
+  "private_key" : "xxxxx_privkey.key"
 }

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -469,11 +469,12 @@ if __name__ == '__main__':
       # We support SSL and want to use it
       key_file = open('conf/net/keys.json')
       key_data = json.load(key_file)
-      ssl_cert = key_data["ssl_certificate"]
+      host_cert = key_data["host_certificate"]
+      chain_cert = key_data["chain_certificate"]
       private_key = key_data["private_key"]
 
       run(host=server_host, port=server_port, server='cheroot', debug=True,
-          certfile=ssl_cert, keyfile=private_key, ssl_module='builtin')
+          certfile=host_cert, chainfile=chain_cert, keyfile=private_key)
     else:
       # Non SSL option for testing on localhost
       print("Running with HTTPS turned OFF - use a reverse proxy on production")


### PR DESCRIPTION
The previous version of cherrypy supported a single cert file, so we would need
to concatenate the host cert with the intermediate cert(s) and root cert to
generate a valid cert chain.

Apparently, the new versions support specifying host and chain certs
separately, so no concatenation necessary. The change would have saved some
users hours of setup time :)

Tested by hardcoding the cert file paths on the server. Seems to work fine.