### PR TITLE
More fixes to push notification code

### DIFF
--- a/bin/push/push_to_users.py
+++ b/bin/push/push_to_users.py
@@ -40,9 +40,13 @@ if __name__ == '__main__':
     if (args.silent):
         response = pnu.send_silent_notification_to_users(uuid_list, {}, dev=args.dev)
     else:
+        json_data = {
+            "title": args.title_message[0],
+            "message": args.title_message[1]
+        }
         response = pnu.send_visible_notification_to_users(uuid_list,
-                                                            args.title_message[0],
-                                                            args.title_message[1],
-                                                            {},
+                                                            json_data["title"],
+                                                            json_data["message"],
+                                                            json_data,
                                                             dev = args.dev)
     pnu.display_response(response)

--- a/emission/net/ext_service/push/notify_interface.py
+++ b/emission/net/ext_service/push/notify_interface.py
@@ -43,10 +43,10 @@ class NotifyInterface(object):
     def get_and_invalidate_entries(self):
         pass
 
-    def send_visible_notification(self, token_list, title, message, json_data, dev=False):
+    def send_visible_notification(self, token_map, title, message, json_data, dev=False):
         pass
 
-    def send_silent_notification(self, token_list, title, message, json_data, dev=False):
+    def send_silent_notification(self, token_map, title, message, json_data, dev=False):
         pass
 
     def display_response(self, response):

--- a/emission/net/ext_service/push/notify_queries.py
+++ b/emission/net/ext_service/push/notify_queries.py
@@ -31,10 +31,19 @@ def combine_queries(query_list):
 
 def get_matching_tokens(query):
     logging.debug("Getting tokens matching query %s" % query)
-    ret_cursor = edb.get_profile_db().find(query, {"_id": False, "device_token": True})
-    mapped_list = [e.get("device_token") for e in ret_cursor]
-    non_null_list = [item for item in mapped_list if item is not None]
-    return non_null_list
+    ret_map = {"ios": [],
+               "android": []}
+    ret_cursor = edb.get_profile_db().find(query, {"_id": False, "device_token": True, "curr_platform": True})
+    for i, entry in enumerate(ret_cursor):
+        curr_platform = entry["curr_platform"]
+        device_token = entry["device_token"]
+        if curr_platform is None or device_token is None:
+            logging.warning("ignoring entry %s due to None values" % entry)
+        else:
+            logging.debug("adding token %s to list for platform %s" % (device_token, curr_platform))
+            ret_map[curr_platform].append(device_token)
+
+    return ret_map
 
 def get_matching_user_ids(query):
     logging.debug("Getting tokens matching query %s" % query)

--- a/emission/net/ext_service/push/notify_usage.py
+++ b/emission/net/ext_service/push/notify_usage.py
@@ -22,23 +22,23 @@ def __get_default_interface__():
     return interface_obj
 
 def send_visible_notification_to_users(user_id_list, title, message, json_data, dev=False):
-    token_list = pnq.get_matching_tokens(pnq.get_user_query(user_id_list))
+    token_map = pnq.get_matching_tokens(pnq.get_user_query(user_id_list))
     logging.debug("user_id_list of length %d -> token list of length %d" % 
-        (len(user_id_list), len(token_list)))
-    return __get_default_interface__().send_visible_notification(token_list, title, message, json_data, dev)
+        (len(user_id_list), len(token_map["ios"]) + len(token_map["android"])))
+    return __get_default_interface__().send_visible_notification(token_map, title, message, json_data, dev)
 
 def send_silent_notification_to_users(user_id_list, json_data, dev=False):
-    token_list = pnq.get_matching_tokens(pnq.get_user_query(user_id_list))
+    token_map = pnq.get_matching_tokens(pnq.get_user_query(user_id_list))
     logging.debug("user_id_list of length %d -> token list of length %d" % 
-        (len(user_id_list), len(token_list)))
-    return __get_default_interface__().send_silent_notification(token_list, json_data, dev)
+        (len(user_id_list), len(token_map)))
+    return __get_default_interface__().send_silent_notification(token_map, json_data, dev)
 
 def send_silent_notification_to_ios_with_interval(interval, dev=False):
     query = pnq.combine_queries([pnq.get_platform_query("ios"),
                                  pnq.get_sync_interval_query(interval)])
-    token_list = pnq.get_matching_tokens(query)
-    logging.debug("found %d tokens for ios with interval %d" % (len(token_list), interval))
-    return __get_default_interface__().send_silent_notification(token_list, {}, dev)
+    token_map = pnq.get_matching_tokens(query)
+    logging.debug("found %d tokens for ios with interval %d" % (len(token_map), interval))
+    return __get_default_interface__().send_silent_notification(token_map, {}, dev)
 
 def display_response(response):
     if response is None:


### PR DESCRIPTION
It turns out that firebase, which used to not return mappings for android
tokens, now returns mappings for all tokens. And the tokens returned in the
android case are actually invalid, which breaks push on android.

So we can no longer use the return value from firebase to determine whether a
particular token is android or iOS - instead we need to start by
pre-categorizing tokens, and only mapping iOS tokens.

Fortunately, at the time that we started storing our own tokens, we also started storing the current platform, so we have this data.

This means that the change is largely mechanical. We need to start with
retrieving a map of device tokens, separated into iOS and android, instead of a
merged list. And then we need to propogate that change through out the
downstream code.

We can remove the part which assumes that if there is no mapping, it is
android since we will only ever map iOS tokens.

Also, recall that firebase android push notifications are not displayed unless
they have associated json data (e.g. 8e306fb9be532d995cabc4c28e6907fd95dcacb4),
so we change the `push_to_users.py` code to pass in the title and message as
part of the json data.

With this, manually created push notifications work on both android and iOS.

Testing done:
- imported profiles containing tokens from production systems
- generated manual pushes for android and iOS using `bin/push/push_to_users.py`