### PR TITLE
Some minor fixes to the mode inference pipeline

### DIFF
--- a/bin/analysis/remove_inferred_modes.py
+++ b/bin/analysis/remove_inferred_modes.py
@@ -1,0 +1,70 @@
+"""
+Reset only the mode inference objects
+This helps us experiment with different mode inference methods without
+resetting the entire pipeline.
+Useful while mode inference is the most recent data object, and we need to
+experiment with it to make it better.
+"""
+
+"""
+This is similar to `bin/reset_pipeline.py` but *much* easier, since the mode
+inference results are not linked to anything else. And the start_ts of the
+inference result = start_ts of the section it maps to. We just need to delete
+everything after the reset point and set the pipeline state accordingly.
+"""
+import logging
+import argparse
+import uuid
+import arrow
+
+import emission.analysis.classification.inference.mode.pipeline as eacimp
+import emission.core.get_database as edb
+import emission.storage.decorations.user_queries as esdu
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
+    parser = argparse.ArgumentParser()
+    # Options corresponding to
+    # https://github.com/e-mission/e-mission-server/issues/333#issuecomment-312464984
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-a", "--all", action="store_true", default=False,
+        help="reset the pipeline for all users")
+    group.add_argument("-p", "--platform", choices = ['android', 'ios'],
+                        help="reset the pipeline for all on the specified platform")
+    group.add_argument("-u", "--user_list", nargs='+',
+        help="user ids to reset the pipeline for")
+    group.add_argument("-e", "--email_list", nargs='+',
+        help="email addresses to reset the pipeline for")
+    parser.add_argument("-d", "--date",
+        help="date to reset the pipeline to. Format 'YYYY-mm-dd' e.g. 2016-02-17. Interpreted in UTC, so 2016-02-17 will reset the pipeline to 2016-02-16T16:00:00-08:00 in the pacific time zone")
+    parser.add_argument("-n", "--dry_run", action="store_true", default=False,
+                        help="do everything except actually perform the operations")
+
+    args = parser.parse_args()
+    print(args)
+
+    # Handle the first row in the table
+    if args.date is None:
+        if args.all:
+            eacimp.del_all_objects(args.dry_run)
+        else:
+            user_list = _get_user_list(args)
+            logging.info("received list with %s users" % user_list)
+            logging.info("first few entries are %s" % user_list[0:5])
+            for user_id in user_list:
+                logging.info("resetting user %s to start" % user_id)
+                eacimp.del_objects_after(user_id, 0, args.dry_run)
+    else:
+    # Handle the second row in the table
+        day_dt = arrow.get(args.date, "YYYY-MM-DD")
+        logging.debug("day_dt is %s" % day_dt)
+        day_ts = day_dt.timestamp
+        logging.debug("day_ts is %s" % day_ts)
+        user_list = _get_user_list(args)
+        logging.info("received list with %s users" % user_list)
+        logging.info("first few entries are %s" % user_list[0:5])
+        for user_id in user_list:
+            logging.info("resetting user %s to ts %s" % (user_id, day_ts))
+            eacimp.del_objects_after(user_id, day_ts, args.dry_run)
+

--- a/conf/analysis/debug.conf.json.sample
+++ b/conf/analysis/debug.conf.json.sample
@@ -2,5 +2,6 @@
     "intake.cleaning.clean_and_resample.speedDistanceAssertions": true,
     "intake.cleaning.filter_accuracy.enable": false,
     "classification.inference.mode.useAdvancedFeatureIndices": true,
+    "classification.inference.mode.useBusTrainFeatureIndices": true,
     "analysis.result.section.key": "analysis/inferred_section"
 }

--- a/emission/analysis/classification/inference/mode/pipeline.py
+++ b/emission/analysis/classification/inference/mode/pipeline.py
@@ -82,6 +82,9 @@ def del_objects_after(user_id, reset_ts, is_dry_run):
     logging.debug("After all updates, del_query = %s" % del_query)
 
     reset_pipeline_query = {"pipeline_stage": ecwp.PipelineStages.MODE_INFERENCE.value}
+    # Fuzz the TRIP_SEGMENTATION stage 5 mins because of
+    # https://github.com/e-mission/e-mission-server/issues/333#issuecomment-312730217
+    FUZZ_FACTOR = 5 * 60
     reset_pipeline_update = {'$set': {'last_processed_ts': reset_ts + FUZZ_FACTOR}}
     logging.info("About to reset stage %s to %s" 
         % (ecwp.PipelineStages.MODE_INFERENCE, reset_ts))

--- a/emission/analysis/classification/inference/mode/pipeline.py
+++ b/emission/analysis/classification/inference/mode/pipeline.py
@@ -241,10 +241,12 @@ class ModeInferencePipeline:
     logging.debug("location features = %s" % LocationFeatureIndices)
     logging.debug("time features = %s" % TimeFeatureIndices)
     logging.debug("bus train features = %s" % BusTrainFeatureIndices)
+    retIndices = genericFeatureIndices
     if eac.get_config()["classification.inference.mode.useAdvancedFeatureIndices"]:
-        return genericFeatureIndices + AdvancedFeatureIndices + BusTrainFeatureIndices
-    else:
-        return genericFeatureIndices + BusTrainFeatureIndices
+        retIndices = retIndices + AdvancedFeatureIndices
+    if eac.get_config()["classification.inference.mode.useBusTrainFeatureIndices"]:
+        retIndices = retIndices + BusTrainFeatureIndices
+    return retIndices
 
   def generateFeatureMatrixAndIDsStep(self, toPredictSections):
     toPredictSections = toPredictSections

--- a/emission/analysis/classification/inference/mode/pipeline.py
+++ b/emission/analysis/classification/inference/mode/pipeline.py
@@ -23,6 +23,7 @@ import emission.core.get_database as edb
 import emission.core.wrapper.entry as ecwe
 import emission.core.wrapper.modeprediction as ecwm
 import emission.core.wrapper.motionactivity as ecwma
+import emission.core.wrapper.pipelinestate as ecwp
 
 from uuid import UUID
 
@@ -48,7 +49,28 @@ def predict_mode(user_id):
         logging.exception("Error while inferring modes, timestamp is unchanged")
         epq.mark_mode_inference_failed(user_id)
 
-# Delete the objects created by this pipeline step
+# Delete the objects created by this pipeline step (across users)
+def del_all_objects(is_dry_run):
+    del_query = {}
+    del_query.update({"metadata.key": {"$in": ["inference/prediction", "analysis/inferred_section"]}})
+    logging.info("About to delete %d entries" 
+        % edb.get_analysis_timeseries_db().find(del_query).count())
+    logging.info("About to delete entries with keys %s" 
+        % edb.get_analysis_timeseries_db().find(del_query).distinct("metadata.key"))
+
+    del_pipeline_query = {"pipeline_stage": ecwp.PipelineStages.MODE_INFERENCE.value}
+    logging.info("About to delete pipeline entries for stage %s" %
+        ecwp.PipelineStages.MODE_INFERENCE)
+
+    if is_dry_run:
+        logging.info("this is a dry-run, returning from del_objects_after without modifying anything")
+    else:
+        result = edb.get_analysis_timeseries_db().delete_many(del_query)
+        logging.info("this is not a dry-run, result of deleting analysis entries is %s" % result.raw_result)
+        result = edb.get_pipeline_state_db().delete_many(del_pipeline_query)
+        logging.info("this is not a dry-run, result of deleting pipeline state is %s" % result.raw_result)
+
+# Delete the objects created by this pipeline step (for a particular user)
 def del_objects_after(user_id, reset_ts, is_dry_run):
     del_query = {}
     # handle the user
@@ -58,6 +80,12 @@ def del_objects_after(user_id, reset_ts, is_dry_run):
     # all objects inserted here have start_ts and end_ts and are trip-like
     del_query.update({"data.start_ts": {"$gt": reset_ts}})
     logging.debug("After all updates, del_query = %s" % del_query)
+
+    reset_pipeline_query = {"pipeline_stage": ecwp.PipelineStages.MODE_INFERENCE.value}
+    reset_pipeline_update = {'$set': {'last_processed_ts': reset_ts + FUZZ_FACTOR}}
+    logging.info("About to reset stage %s to %s" 
+        % (ecwp.PipelineStages.MODE_INFERENCE, reset_ts))
+    
 
     logging.info("About to delete %d entries" 
         % edb.get_analysis_timeseries_db().find(del_query).count())

--- a/emission/analysis/plotting/geojson/geojson_feature_converter.py
+++ b/emission/analysis/plotting/geojson/geojson_feature_converter.py
@@ -153,11 +153,14 @@ def section_to_geojson(section, tl):
 
     if eac.get_section_key_for_analysis_results() == esda.INFERRED_SECTION_KEY:
         ise = esds.cleaned2inferred_section(section.user_id, section.get_id())
-        logging.debug("mapped cleaned section %s -> inferred section %s" % 
-            (section.get_id(), ise.get_id()))
-        logging.debug("changing mode from %s -> %s" % 
-            (points_line_feature.properties.sensed_mode, ise.data.sensed_mode))
-        points_line_feature.properties["sensed_mode"] = str(ise.data.sensed_mode)
+        if ise is not None:
+            logging.debug("mapped cleaned section %s -> inferred section %s" % 
+                (section.get_id(), ise.get_id()))
+            logging.debug("changing mode from %s -> %s" % 
+                (points_line_feature.properties.sensed_mode, ise.data.sensed_mode))
+            points_line_feature.properties["sensed_mode"] = str(ise.data.sensed_mode)
+        else:
+            points_line_feature.properties["sensed_mode"] = str(points_line_feature.properties.sensed_mode)
     else:
         points_line_feature.properties["sensed_mode"] = str(points_line_feature.properties.sensed_mode)
     

--- a/emission/storage/pipeline_queries.py
+++ b/emission/storage/pipeline_queries.py
@@ -109,7 +109,15 @@ def mark_mode_inference_failed(user_id):
     mark_stage_failed(user_id, ps.PipelineStages.MODE_INFERENCE)
 
 def get_complete_ts(user_id):
-    return get_current_state(user_id, ps.PipelineStages.MODE_INFERENCE).last_processed_ts
+    mode_infer_state = get_current_state(user_id, ps.PipelineStages.MODE_INFERENCE)
+    if mode_infer_state is not None:
+        return mode_infer_state.last_processed_ts
+    else:
+        cleaned_state = get_current_state(user_id, ps.PipelineStages.CLEAN_RESAMPLING)
+        if cleaned_state is not None:
+            return cleaned_state.last_processed_ts
+        else:
+            return None
 
 def get_time_range_for_clean_resampling(user_id):
     # type: (uuid.UUID) -> emission.storage.timeseries.timequery.TimeQuery


### PR DESCRIPTION
- allow us to clean up only the inferred data so that we can experiment with mode inference methods
- Better handling of the case in which we have cleaned results but not inferred results
- Support to independently toggle bus/train features in the hope that it will improve detection of caltrain