### PR TITLE
Fix errors in loading and purging the multi-timeline

### DIFF
--- a/bin/debug/load_multi_timeline_for_range.py
+++ b/bin/debug/load_multi_timeline_for_range.py
@@ -51,8 +51,10 @@ def load_pipeline_states(file_prefix, all_uuid_list):
         pipeline_filename = "%s_pipelinestate_%s.gz" % (file_prefix, curr_uuid)
         print("Loading pipeline state for %s from %s" % 
             (curr_uuid, pipeline_filename))
-        with gzip.open(filename) as gfd:
+        with gzip.open(pipeline_filename) as gfd:
             states = json.load(gfd, object_hook = bju.object_hook)
+            if args.verbose:
+                logging.debug("Loading states of length %s" % len(states))
             edb.get_pipeline_state_db().insert_many(states)
 
 def post_check(unique_user_list, all_rerun_list):

--- a/bin/debug/purge_multi_timeline_for_range.py
+++ b/bin/debug/purge_multi_timeline_for_range.py
@@ -43,6 +43,9 @@ if __name__ == '__main__':
     psdb = edb.get_pipeline_state_db()
 
     for i, filename in enumerate(sel_file_list):
+        if "pipelinestate" in filename:
+            continue
+
         logging.info("=" * 50)
         logging.info("Deleting data from file %s" % filename)
 


### PR DESCRIPTION
- Fix purge to ignore pipeline state files (similar to load)
- Fix load to actually load from the pipeline state filename and not the last
  regular data filename (doh!)

Thanks to @omrachel for reporting the issue