### PR TITLE
fix six.py version in environment36.yml

### DIFF
--- a/setup/environment36.yml
+++ b/setup/environment36.yml
@@ -153,7 +153,7 @@ dependencies:
 - simplegeneric=0.8.1=py36_1
 - singledispatch=3.4.0.3=py36_0
 - sip=4.18=py36_0
-- six=1.10.0=py36_0
+- six=1.11.0=py36_0
 - snowballstemmer=1.2.1=py36_0
 - sortedcollections=0.5.3=py36_0
 - sortedcontainers=1.5.7=py36_0


### PR DESCRIPTION
cheroot's server.py file (found in ~/anaconda3/envs/emission/lib/python3.6/site-packages/cheroot) uses 'unquote_to_bytes' function, which was not added to six.py until version 1.11.0 (https://github.com/benjaminp/six/blob/master/six.py). 

conda environment file used version 1.10.0, which does not have that function. https://github.com/benjaminp/six/blob/c3ec058bf8c4d6329224eac53366c8e9ce511417/six.py

without this, server is inaccessible from browser