### PR TITLE
Add support for exporting non-anonymized data for studies

### DIFF
--- a/bin/debug/extract_timeline_for_day_range_and_user.py
+++ b/bin/debug/extract_timeline_for_day_range_and_user.py
@@ -120,6 +120,6 @@ if __name__ == '__main__':
         uuid_list = esdu.get_all_uuids()
     elif args.file:
         with open(args.file) as fd:
-            uuid_strs = json.load(fd)
-            uuid_list = [uuid.UUID(ustr) for ustr in uuid_strs]
+            uuid_entries = json.load(fd, object_hook=bju.object_hook)
+            uuid_list = [ue["uuid"] for ue in uuid_entries]
     export_timeline_for_users(uuid_list, args)

--- a/bin/debug/get_users_for_channel.py
+++ b/bin/debug/get_users_for_channel.py
@@ -1,0 +1,33 @@
+# Extracts email -> UUID mappings for a particular channel
+# The UUIDs can be used to dump data for that channel to the student who
+# conducted the experiment. Typically used as the file input to the
+# extract_timeline_for_day_range_and_user.py script
+# The channel is stored in the "client" field of the profile
+
+import emission.core.wrapper.user as ecwu
+
+import sys
+import argparse
+import logging
+import json
+import bson.json_util as bju
+
+import emission.core.get_database as edb
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    parser = argparse.ArgumentParser(prog="get_users_for_channel")
+
+    parser.add_argument("channel", help="the channel that the users signed in to")
+    parser.add_argument("-o", "--outfile", help="the output filename (default: stdout)")
+
+    args = parser.parse_args()
+
+    matched_profiles_it = edb.get_profile_db().find({"client": args.channel})
+    matched_uuids_it = [p["user_id"] for p in matched_profiles_it]
+    matched_email2uuid_it = [edb.get_uuid_db().find_one({"uuid": u}) for u in matched_uuids_it]
+
+    logging.debug("Mapped %d entries for channel %s" % (len(matched_email2uuid_it), args.channel)) 
+
+    out_fd = sys.stdout if args.outfile is None else open(args.outfile, "w")
+    json.dump(matched_email2uuid_it, out_fd, default=bju.default)

--- a/bin/debug/load_multi_timeline_for_range.py
+++ b/bin/debug/load_multi_timeline_for_range.py
@@ -35,8 +35,22 @@ def register_fake_users(prefix, unique_user_list):
         username = (format_string % i)
         if args.verbose is not None and i % args.verbose == 0:
             logging.info("About to insert mapping %s -> %s" % (username, uuid))
-        # Let's register and then update instead of manipulating the database directly
-        # Alternatively, we can refactor register to pass in the uuid as well
+        user = ecwu.User.registerWithUUID(username, uuid)
+
+def register_mapped_users(mapfile, unique_user_list):
+    uuid_entries = json.load(open(mapfile), object_hook=bju.object_hook)
+    logging.info("Creating user entries for %d users from map of length %d" % (len(unique_user_list), len(mapfile)))
+
+    lookup_map = dict([(eu["uuid"], eu) for eu in uuid_entries])
+
+    for i, uuid in enumerate(unique_user_list):
+        username = lookup_map[uuid]["user_email"]
+        # TODO: Figure out whether we should insert the entry directly or
+        # register this way
+        # Pro: will do everything that register does, including creating the profile
+        # Con: will insert only username and uuid - id and update_ts will be different
+        if args.verbose is not None and i % args.verbose == 0:
+            logging.info("About to insert mapping %s -> %s" % (username, uuid))
         user = ecwu.User.registerWithUUID(username, uuid)
 
 def get_load_ranges(entries):
@@ -55,7 +69,10 @@ def load_pipeline_states(file_prefix, all_uuid_list):
             states = json.load(gfd, object_hook = bju.object_hook)
             if args.verbose:
                 logging.debug("Loading states of length %s" % len(states))
-            edb.get_pipeline_state_db().insert_many(states)
+            if len(states) > 0:
+                edb.get_pipeline_state_db().insert_many(states)
+            else:
+                logging.info("No pipeline states found, skipping load")
 
 def post_check(unique_user_list, all_rerun_list):
     import emission.core.get_database as edb
@@ -96,8 +113,11 @@ if __name__ == '__main__':
     parser.add_argument("-s", "--batch-size", default=10000, type=int,
         help="batch size to use for the entries")
 
-    parser.add_argument("-p", "--prefix", default="user",
+    group = parser.add_mutually_exclusive_group(required=False)
+    group.add_argument("-p", "--prefix", default="user",
         help="prefix for the automatically generated usernames. usernames will be <prefix>-001, <prefix>-002...")
+    group.add_argument("-m", "--mapfile",
+        help="file containing email <-> uuid mapping for the uuids in the dump")
 
     args = parser.parse_args()
     if args.debug:
@@ -144,6 +164,10 @@ if __name__ == '__main__':
     unique_user_list = set(all_user_list)
     if not args.info_only:
         load_pipeline_states(args.file_prefix, unique_user_list)
-        register_fake_users(args.prefix, unique_user_list)
+        print("args.prefix = %s, args.mapfile = %s" % (args.prefix, args.mapfile))
+        if args.mapfile is not None:
+            register_mapped_users(args.mapfile, unique_user_list)
+        elif args.prefix is not None:
+            register_fake_users(args.prefix, unique_user_list)
        
     post_check(unique_user_list, all_rerun_list) 

--- a/bin/debug/load_multi_timeline_for_range.py
+++ b/bin/debug/load_multi_timeline_for_range.py
@@ -164,7 +164,6 @@ if __name__ == '__main__':
     unique_user_list = set(all_user_list)
     if not args.info_only:
         load_pipeline_states(args.file_prefix, unique_user_list)
-        print("args.prefix = %s, args.mapfile = %s" % (args.prefix, args.mapfile))
         if args.mapfile is not None:
             register_mapped_users(args.mapfile, unique_user_list)
         elif args.prefix is not None:

--- a/bin/public/extract_uuids_from_email_list.py
+++ b/bin/public/extract_uuids_from_email_list.py
@@ -2,17 +2,20 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
-# Exports all data for the particular user for the particular day
-# Used for debugging issues with trip and section generation 
+# Converts user emails -> UUIDs
+# The UUIDs can be used to extract data for moving across servers
+# Typically used as the file input to the
+# extract_timeline_for_day_range_and_user.py script
 from future import standard_library
 standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import sys
 import logging
-logging.basicConfig(level=logging.DEBUG)
 import gzip
 import json
+import argparse
+import bson.json_util as bju
 
 import emission.core.wrapper.user as ecwu
 
@@ -20,22 +23,27 @@ import emission.core.wrapper.user as ecwu
 # Output data using json (easy to serialize and re-read)
 
 if __name__ == '__main__':
-    if len(sys.argv) != 3:
-        print("Usage: %s user_email_file user_id_file")
-    else:
-        user_email_filename = sys.argv[1]
-        uuid_filename = sys.argv[2]
+    logging.basicConfig(level=logging.DEBUG)
 
-        emails = open(user_email_filename).readlines()
-        uuids = []
-        for e in emails:
-            user = ecwu.User.fromEmail(e.strip())
-            if user is None:
-                logging.warning("Found no mapping for email %s" % e)
-            else:
-                uuid = user.uuid
-                logging.debug("Mapped email %s to uuid %s" % (e, uuid))
-                uuids.append(uuid)
-                
-        uuid_strs = [str(u) for u in uuids]
-        json.dump(uuid_strs, open(uuid_filename, "w"))
+    parser = argparse.ArgumentParser(prog="extract_uuids_from_email_list")
+    parser.add_argument("user_email_file")
+    parser.add_argument("-o", "--outfile", help="the output filename (default: stdout)")
+
+    args = parser.parse_args()
+
+    user_email_filename = args.user_email_file
+    out_fd = sys.stdout if args.outfile is None else open(args.outfile, "w")
+
+    emails = open(user_email_filename).readlines()
+    uuids = []
+    for e in emails:
+        user = ecwu.User.fromEmail(e.strip())
+        if user is None:
+            logging.warning("Found no mapping for email %s" % e)
+        else:
+            uuid = user.uuid
+            logging.debug("Mapped email %s to uuid %s" % (e.strip(), uuid))
+            uuids.append(uuid)
+
+    uuid_strs = [{"uuid": u} for u in uuids]
+    json.dump(uuid_strs, out_fd, default=bju.default)


### PR DESCRIPTION
Add support for exporting non-anonymized data for studies

Our consent document states that studies led by other researchers can also use
the platform, in which case, the data collected will be governed by their own
consent document, and we will send them a *non* anonymized dump, including the
email <-> uuid mapping.

Until now, we did not have a project that wanted to do this, so we did not have support for dumping the email <-> uuid mapping.

This commit adds that support.

Main changes:
1. new script to get all the email <-> uuid mappings associated with a "channel"
2. change the format expected by existing extraction script to be objects
  instead of a string list of uuids
3. change the load script to accept a `-m` option that will load the emails from
  a map file instead of creating dummy ones.

Bonus fix:
- changed the existing script that extracts uuids for creating open datasets to
  match the new format, so that uuids generated by both scripts can be handled
  by the extraction code. This only contains uuids, though, so cannot be used
  as a map file for the load. Which makes sense, since you never want to expose
  emails in a public dataset.

Testing done:

### Extracting uuid for public data works (bonus fix)

Extracting uuids from email list continues to work, although the list now
contains objects and not just strings.

New interface with arg parsing outputs to stdout by default

```
$ ./e-mission-py.bash bin/public/extract_uuids_from_email_list.py /tmp/email_list
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
DEBUG:root:Mapped email test_ucdb_load to uuid 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6
[{"uuid": {"$uuid": "74f5bc929d2e45b889bafc6f18000ab6"}}]
```

And to a file otherwise

```
$ ./e-mission-py.bash bin/public/extract_uuids_from_email_list.py /tmp/email_list -o /tmp/uuid_list
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
DEBUG:root:Mapped email test_ucdb_load to uuid 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6
```

Extracting the timeline for this list still works after changing the parsing for the `-f` option


```
$ ./e-mission-py.bash bin/debug/extract_timeline_for_day_range_and_user.py -f /tmp/uuid_list 2000-01-01 2020-01-01 /tmp/test_file
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
INFO:root:==================================================
INFO:root:Extracting timeline for user 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6 day 2000-01-01 -> 2020-01-01 and saving to file /tmp/test_file
DEBUG:root:start_day_ts = 946684800 (2000-01-01T00:00:00+00:00), end_day_ts = 1577836800 (2020-01-01T00:00:00+00:00)
...
INFO:root:Found 90 loc entries, 0 trip-like entries, 0 place-like entries = 90 total entries
INFO:root:timeline has unique keys = {'stats/server_api_time'}
INFO:root:Found 0 pipeline states []
```

### Extracting users for a channel works (step 1)

New get_users_for_channel script also works for stdout...

```
$ ./e-mission-py.bash bin/debug/get_users_for_channel.py foo
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
DEBUG:root:Mapped 1 entries for channel foo
[{"_id": {"$oid": "5b84e9df91da20c31c8ce47e"}, "user_email": "test_ucdb_load", "uuid": {"$uuid": "74f5bc929d2e45b889bafc6f18000ab6"}, "update_ts": {"$date": 1535412606366}}]
```

and to file

```
$ ./e-mission-py.bash bin/debug/get_users_for_channel.py foo -o /tmp/uuid_list_2
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
DEBUG:root:Mapped 1 entries for channel foo
```

### Changes to download user data work (step 2)

Extraction continues to work since the objects have a `uuid` field.

```
$ ./e-mission-py.bash bin/debug/extract_timeline_for_day_range_and_user.py -f /tmp/uuid_list_2 2000-01-01 2020-01-01 /tmp/test_file_2
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
INFO:root:==================================================
INFO:root:Extracting timeline for user 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6 day 2000-01-01 -> 2020-01-01 and saving to file /tmp/test_file_2
DEBUG:root:start_day_ts = 946684800 (2000-01-01T00:00:00+00:00), end_day_ts = 1577836800 (2020-01-01T00:00:00+00:00)
...
INFO:root:Found 90 loc entries, 0 trip-like entries, 0 place-like entries = 90 total entries
INFO:root:timeline has unique keys = {'stats/server_api_time'}
INFO:root:Found 0 pipeline states []
```

### Changes to load from a map file work (step 3)

Loading the extracted data with the new `-m` mapping option works.

```
$ ./e-mission-py.bash bin/debug/load_multi_timeline_for_range.py -v 1 -m /tmp/uuid_list_2 /tmp/test_file_2
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
INFO:root:Loading file or prefix /tmp/test_file_2
INFO:root:Found 2 matching files for prefix /tmp/test_file_2
INFO:root:files are ['/tmp/test_file_2_pipelinestate_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz', '/tmp/test_file_2_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz'] ... ['/tmp/test_file_2_pipelinestate_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz']
INFO:root:==================================================
INFO:root:Loading data from file /tmp/test_file_2_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz
INFO:root:Analyzing timeline...
INFO:root:timeline has 90 entries
INFO:root:timeline has data from 1 users
INFO:root:timeline has the following unique keys {'stats/server_api_time'}
INFO:root:timeline for user 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6 contains only raw data
INFO:root:About to load range 0 -> 90
Loading pipeline state for 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6 from /tmp/test_file_2_pipelinestate_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz
args.prefix = user, args.mapfile = /tmp/uuid_list_2
INFO:root:Creating user entries for 1 users from map of length 16
INFO:root:About to insert mapping test_ucdb_load -> 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6
INFO:root:For 1 users, loaded 90 raw entries, 0 processed entries and 0 pipeline states
INFO:root:all entries in the timeline contain only raw data, need to run the intake pipeline
```

And the list of users is unchanged because we loaded the user with email
`test_ucdb_load`, which was always there.

```
In [23]: list(edb.get_uuid_db().find())
Out[23]:
[{'_id': ObjectId('5b7c5cce58b6cc2f0e261660'),
  'update_ts': datetime.datetime(2018, 8, 21, 11, 41, 18, 297000),
  'user_email': 'indy_day',
  'uuid': UUID('c3613fb1-8975-439f-9a11-06a9d18ba01f')},
 {'_id': ObjectId('5b7c5cf258b6cc2f0e261e5e'),
  'update_ts': datetime.datetime(2018, 8, 21, 11, 42, 1, 792000),
  'user_email': 'iphone_2016',
  'uuid': UUID('31252f6e-47b1-43ce-9d76-76972d0f2f33')},
 {'_id': ObjectId('5b84e95191da20c31c8ce16d'),
  'update_ts': datetime.datetime(2018, 8, 27, 23, 18, 57, 800000),
  'user_email': 'test_tsdb_load',
  'uuid': UUID('b1e80dcd-eb4e-4926-bace-d046a284b5aa')},
 {'_id': ObjectId('5b84e9df91da20c31c8ce47e'),
  'update_ts': datetime.datetime(2018, 8, 28, 13, 38, 16, 323000),
  'user_email': 'test_ucdb_load',
  'uuid': UUID('74f5bc92-9d2e-45b8-89ba-fc6f18000ab6')}]
```

After resetting...

```
In [24]: edb.get_timeseries_db().delete_many({"user_id": UUID('74f5bc92-9d2e-45b8-89ba-f
    ...: c6f18000ab6')})
Out[24]: <pymongo.results.DeleteResult at 0x105c050c8>
```

reload without the `-m` option which creates dummy email addresses for additional privacy protection.

```
$ ./e-mission-py.bash bin/debug/load_multi_timeline_for_range.py -v 1 /tmp/test_file_2
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
INFO:root:Loading file or prefix /tmp/test_file_2
INFO:root:Found 2 matching files for prefix /tmp/test_file_2
INFO:root:files are ['/tmp/test_file_2_pipelinestate_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz', '/tmp/test_file_2_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz'] ... ['/tmp/test_file_2_pipelinestate_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz']
INFO:root:==================================================
INFO:root:Loading data from file /tmp/test_file_2_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz
INFO:root:Analyzing timeline...
INFO:root:timeline has 90 entries
INFO:root:timeline has data from 1 users
INFO:root:timeline has the following unique keys {'stats/server_api_time'}
INFO:root:timeline for user 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6 contains only raw data
INFO:root:About to load range 0 -> 90
Loading pipeline state for 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6 from /tmp/test_file_2_pipelinestate_74f5bc92-9d2e-45b8-89ba-fc6f18000ab6.gz
INFO:root:No pipeline states found, skipping load
args.prefix = user, args.mapfile = None
INFO:root:Creating user entries for 1 users
INFO:root:pattern = user-%01d
INFO:root:About to insert mapping user-0 -> 74f5bc92-9d2e-45b8-89ba-fc6f18000ab6
INFO:root:For 1 users, loaded 90 raw entries, 0 processed entries and 0 pipeline states
INFO:root:all entries in the timeline contain only raw data, need to run the intake pipeline
```

And we see another entry with the same uuid

```
In [25]: list(edb.get_uuid_db().find())
Out[25]:
[{'_id': ObjectId('5b7c5cce58b6cc2f0e261660'),
  'update_ts': datetime.datetime(2018, 8, 21, 11, 41, 18, 297000),
  'user_email': 'indy_day',
  'uuid': UUID('c3613fb1-8975-439f-9a11-06a9d18ba01f')},
 {'_id': ObjectId('5b7c5cf258b6cc2f0e261e5e'),
  'update_ts': datetime.datetime(2018, 8, 21, 11, 42, 1, 792000),
  'user_email': 'iphone_2016',
  'uuid': UUID('31252f6e-47b1-43ce-9d76-76972d0f2f33')},
 {'_id': ObjectId('5b84e95191da20c31c8ce16d'),
  'update_ts': datetime.datetime(2018, 8, 27, 23, 18, 57, 800000),
  'user_email': 'test_tsdb_load',
  'uuid': UUID('b1e80dcd-eb4e-4926-bace-d046a284b5aa')},
 {'_id': ObjectId('5b84e9df91da20c31c8ce47e'),
  'update_ts': datetime.datetime(2018, 8, 28, 13, 38, 16, 323000),
  'user_email': 'test_ucdb_load',
  'uuid': UUID('74f5bc92-9d2e-45b8-89ba-fc6f18000ab6')},
 {'_id': ObjectId('5b85b39c91da20c31c8cf796'),
  'update_ts': datetime.datetime(2018, 8, 28, 13, 42, 4, 615000),
  'user_email': 'user-0',
  'uuid': UUID('74f5bc92-9d2e-45b8-89ba-fc6f18000ab6')}]
```