### PR TITLE
Extend usercache load/store to the multi-user timelines as well

### DIFF
--- a/bin/debug/load_multi_timeline_for_range.py
+++ b/bin/debug/load_multi_timeline_for_range.py
@@ -22,6 +22,7 @@ import gzip
 import emission.storage.timeseries.abstract_timeseries as esta
 import emission.core.wrapper.user as ecwu
 import emission.core.wrapper.entry as ecwe
+import emission.storage.timeseries.cache_series as estcs
 
 args = None
 
@@ -153,13 +154,12 @@ if __name__ == '__main__':
 
         load_ranges = get_load_ranges(entries)
         if not args.info_only:
-            ts = esta.TimeSeries.get_time_series(curr_uuid)
             for j, curr_range in enumerate(load_ranges):
                 if args.verbose is not None and j % args.verbose == 0:
                     logging.info("About to load range %s -> %s" % (curr_range[0], curr_range[1]))
                 wrapped_entries = [ecwe.Entry(e) for e in entries[curr_range[0]:curr_range[1]]]
-                for entry in wrapped_entries:
-                    insert_result = ts.insert(entry)
+                (tsdb_count, ucdb_count) = estcs.insert_entries(curr_uuid, wrapped_entries)
+        print("For uuid %s, finished loading %d entries into the usercache and %d entries into the timeseries" % (curr_uuid, ucdb_count, tsdb_count))
 
     unique_user_list = set(all_user_list)
     if not args.info_only:

--- a/bin/debug/load_timeline_for_day_and_user.py
+++ b/bin/debug/load_timeline_for_day_and_user.py
@@ -7,7 +7,7 @@ standard_library.install_aliases()
 from builtins import *
 import json
 import bson.json_util as bju
-import emission.core.get_database as edb
+import emission.storage.timeseries.cache_series as estcs
 import argparse
 import emission.core.wrapper.user as ecwu
 
@@ -28,28 +28,19 @@ if __name__ == '__main__':
     fn = args.timeline_filename
     print(fn)
     print("Loading file " + fn)
-    tsdb = edb.get_timeseries_db()
-    ucdb = edb.get_usercache_db()
     user = ecwu.User.register(args.user_email)
     override_uuid = user.uuid
     print("After registration, %s -> %s" % (args.user_email, override_uuid))
     entries = json.load(open(fn), object_hook = bju.object_hook)
-    tsdb_count = 0
-    ucdb_count = 0
+    munged_entries = []
     for i, entry in enumerate(entries):
         entry["user_id"] = override_uuid
         if not args.retain:
             del entry["_id"]
         if args.verbose is not None and i % args.verbose == 0:
             print("About to save %s" % entry)
-        if "write_fmt_time" in entry["metadata"]:
-            # write_fmt_time is filled in only during the formatting process
-            # so if write_fmt_time exists, it must be in the timeseries already
-            tsdb.save(entry)
-            tsdb_count = tsdb_count + 1
-        else:
-            ucdb.save(entry)
-            ucdb_count = ucdb_count + 1
+        munged_entries.append(entry)
 
+    (tsdb_count, ucdb_count) = estcs.insert_entries(munged_entries)
     print("Finished loading %d entries into the usercache and %d entries into the timeseries" %
         (ucdb_count, tsdb_count))

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -20,6 +20,8 @@ ts_enum_map = {
     esta.EntryType.ANALYSIS_TYPE: edb.get_analysis_timeseries_db()
 }
 
+INVALID_QUERY = {'1': '2'}
+
 class BuiltinTimeSeries(esta.TimeSeries):
     def __init__(self, user_id):
         super(BuiltinTimeSeries, self).__init__(user_id)
@@ -198,6 +200,8 @@ class BuiltinTimeSeries(esta.TimeSeries):
                                                                  geo_query,
                                                                  extra_query_list,
                                                                  sort_key)
+        logging.debug("orig_ts_db_matches = %s, analysis_ts_db_matches = %s" %
+            (orig_ts_db_result.count(), analysis_ts_db_result.count()))
         return itertools.chain(orig_ts_db_result, analysis_ts_db_result)
 
     def _get_entries_for_timeseries(self, tsdb, key_list, time_query, geo_query,
@@ -223,9 +227,9 @@ class BuiltinTimeSeries(esta.TimeSeries):
             # Out[593]: 449869
             ts_db_result.limit(25 * 10000)
         else:
-            ts_db_result = [].__iter__()
+            ts_db_result = tsdb.find(INVALID_QUERY)
 
-        logging.debug("finished querying values for %s" % key_list)
+        logging.debug("finished querying values for %s, count = %d" % (key_list, ts_db_result.count()))
         return ts_db_result
 
     def get_entry_at_ts(self, key, ts_key, ts):


### PR DESCRIPTION
- refactor previous insertion code to automatically insert into usercache or timeseries depending on entry format
- change old code to use newly refactored function
- change multi-user load to use newly refactored function
- change multi-user store to use `cacheseries.find_entries` instead of `timeseries.find_entries`
- change multi-user store to query separately for `background/motion_activity` since it does not have `data.ts` before formatting and will not be returned from the usercache

Bonus fix:
- return an empty cursor instead of an iterator from the query function so that the return value is consistent in the zero and non-zero cases. We can then call cursor methods such as `count()` on the return value without failing. Can revert if it turns out that there was some advantage to not using an empty cursor, or the method to generate an empty cursor (using an invalid query) fails.