### PR TITLE
Return a valid value from profile/update

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -272,7 +272,9 @@ def updateUserProfile():
   user_uuid = getUUID(request)
   user = User.fromUUID(user_uuid)
   new_fields = request.json['update_doc']
-  return user.update(new_fields)
+  to_return = user.update(new_fields)
+  logging.debug("Successfully updated profile for user %s" % user_uuid)
+  return {"update": True}
 
 @post('/profile/get')
 def getUserProfile():


### PR DESCRIPTION
If we don't do this, then we get `null` data, which errors out when we try to parse the result

```
            NSDictionary *parsedResult = [NSJSONSerialization JSONObjectWithData:data
                                                                options:kNilOptions
                                                                  error: &parseError];

```

https://github.com/e-mission/cordova-server-communication/blob/v1.2.0/src/ios/BEMCommunicationHelperPlugin.m#L20