### PR TITLE
Update the motion activity inputs to support version 11.0.1 of google…

### DIFF
--- a/emission/net/usercache/formatters/android/motion_activity.py
+++ b/emission/net/usercache/formatters/android/motion_activity.py
@@ -31,8 +31,10 @@ def format(entry):
         data.type = ecwa.MotionTypes(entry.data.zzbjA).value
     elif 'ajO' in entry.data:
         data.type = ecwa.MotionTypes(entry.data.ajO).value
-    else:
+    elif 'zzaKM' in entry.data:
         data.type = ecwa.MotionTypes(entry.data.zzaKM).value
+    else:
+        data.type = ecwa.MotionTypes(entry.data.zzbhB).value
 
 
     if 'agc' in entry.data:
@@ -43,8 +45,10 @@ def format(entry):
         data.confidence = entry.data.zzbjB
     elif 'ajP' in entry.data:
         data.confidence = entry.data.ajP
-    else:
+    elif 'zzaKN' in entry.data:
         data.confidence = entry.data.zzaKN
+    else:
+        data.confidence = entry.data.zzbhC
 
     data.ts = formatted_entry.metadata.write_ts
     data.local_dt = formatted_entry.metadata.write_local_dt


### PR DESCRIPTION
… play services

As part of the last android update (https://github.com/e-mission/e-mission-docs/issues/325#issuecomment-469554290), we updated the phonegap-push-plugin from
1.9.2 to 2.2.3. This also added a dependency on the firebase 11.0.1 libraries,
so we had to update our google-play-services library to 11.0.1 across the
board.

As always, this changes the field names corresponding to the type and the confidence,
so we need to upgrade the formatter, similar to https://github.com/e-mission/e-mission-server/commit/3dc3e6097a9b425d5da6a81d2670e73f0fe93170#diff-9ac627c6813517845b71887afb3cbb11, https://github.com/e-mission/e-mission-server/commit/903274d3bf87e642430e5b603c924601baa3955a#diff-9ac627c6813517845b71887afb3cbb11, ....