### PR TITLE
Make it easier to test individual candidate functions

### DIFF
--- a/emission/core/wrapper/suggestion_sys.py
+++ b/emission/core/wrapper/suggestion_sys.py
@@ -175,18 +175,33 @@ Then the function will enter the Google reverse lookup and choose a business tha
 latitude and longitude given
 '''
 
+### BEGIN: Pulled out candidate functions so that we can evaluate individual accuracies
+def find_destination_business_google(lat, lon):
+    return return_address_from_google_nomfile(lat, lon)
+
+def find_destination_business_yelp(lat, lon):
+    return (None, None, None, None)
+
+def find_destination_business_nominatim(lat, lon):
+    string_address, address_dict = return_address_from_location_nominatim(lat, lon)
+    business_key = list(address_dict.keys())[0]
+    business_name = address_dict[business_key]
+    city = address_dict['city']
+    return (business_name, string_address, city,
+        (not is_service_nominatim(business_name)))
+### END: Pulled out candidate functions so that we can evaluate individual accuracies
+
+## Current combination of candidate functions;
+## First try nominatim, and if it fails, fall back to google
+## Is that the right approach?
+
 def find_destination_business(lat, lon):
+    #Off at times if the latlons are of a location that takes up a small spot, especially boba shops
+    # print(return_address_from_location_google(location))
+    # print(len(return_address_from_location_google(location)))
+    #IF RETURN_ADDRESS_FROM_LOCATION HAS A BUSINESS LOCATION ATTACHED TO THE ADDRESS
     try:
-        #Off at times if the latlons are of a location that takes up a small spot, especially boba shops
-        # print(return_address_from_location_google(location))
-        # print(len(return_address_from_location_google(location)))
-        #IF RETURN_ADDRESS_FROM_LOCATION HAS A BUSINESS LOCATION ATTACHED TO THE ADDRESS
-        string_address, address_dict = return_address_from_location_nominatim(lat, lon)   
-        business_key = list(address_dict.keys())[0]
-        business_name = address_dict[business_key]
-        city = address_dict['city']
-        return_tuple = (business_name, string_address, city,
-            (not is_service_nominatim(business_name)))
+        return_tuple = find_destination_business_nominatim(lat, lon)
         logging.debug("Nominatim found destination business %s " % str(return_tuple))
         return return_tuple
     except:
@@ -196,6 +211,49 @@ def find_destination_business(lat, lon):
             % str(return_tuple))
         return return_tuple
 
+### BEGIN: Pulled out candidate functions so that we can evaluate individual accuracies
+def category_of_business_awesome(lat, lon):
+    return []
+
+def category_from_name(business_name):
+    categories = []
+    for c in business_reviews(YELP_API_KEY, business_name.replace(' ', '-') + '-' + city)['categories']:
+        categories.append(c['alias'])
+    return categories
+
+def category_from_address(address):
+    categories = []
+    possible_bus = match_business_address(address)["businesses"][0]
+    possible_categ = possible_bus["categories"]
+    for p in possible_categ:
+        categories.append(p["alias"])
+    return categories
+### END: Pulled out candidate functions so that we can evaluate individual accuracies
+
+### BEGIN: Wrappers for the candidate functions to make them callable from the harness
+### We do not want to use them in the combination function directly because that will
+### result in two separate calls to `find_destination_business`
+def category_from_name_wrapper(lat, lon):
+    business_name, address, city, location_is_service = find_destination_business(lat, lon)
+    if not location_is_service:
+        return []
+
+    if business_name is None:
+        return []
+
+    return category_from_name(business_name)
+
+def category_from_address_wrapper(lat, lon):
+    business_name, address, city, location_is_service = find_destination_business(lat, lon)
+    if not location_is_service:
+        return []
+
+    return category_from_address(address)
+### END: Wrappers for the candidate functions to make them callable from the harness
+
+## Current combination of candidate functions;
+## First try name, and if it fails, fall back to address
+## Is that the right approach?
 def category_of_business_nominatim(lat, lon):
     try:
         business_name, address, city, location_is_service = find_destination_business(lat, lon)
@@ -204,15 +262,9 @@ def category_of_business_nominatim(lat, lon):
 
         categories = []
         if business_name is not None:
-            for c in business_reviews(YELP_API_KEY, business_name.replace(' ', '-') + '-' + city)['categories']:
-                categories.append(c['alias'])
-            return categories
+            return category_from_name(business_name)
         else:
-            possible_bus = match_business_address(address)["businesses"][0]
-            possible_categ = possible_bus["categories"]
-            for p in possible_categ:
-                categories.append(p["alias"])
-            return categories
+            return category_from_address(address)
     except:
         raise ValueError("Something went wrong")
 

--- a/emission/integrationTests/suggestionsys/algorithm_test_harness.py
+++ b/emission/integrationTests/suggestionsys/algorithm_test_harness.py
@@ -7,30 +7,30 @@ import json
 
 import emission.core.wrapper.suggestion_sys as sugg
 
-def test_find_destination_business(params):
+def test_find_destination_business(cfn, params):
     lat, lon = sugg.geojson_to_lat_lon_separated(params["loc"])
-    result = sugg.find_destination_business(lat, lon)
+    result = cfn(lat, lon)
     return list(result)
 
-def test_category_of_business_nominatim(params):
+def test_category_of_business_nominatim(cfn, params):
     lat, lon = sugg.geojson_to_lat_lon_separated(params["loc"])
-    result = sugg.category_of_business_nominatim(lat, lon)
+    result = cfn(lat, lon)
     return result
 
-def test_calculate_yelp_server_suggestion_for_locations(params):
+def test_calculate_yelp_server_suggestion_for_locations(cfn, params):
     start_loc = params["start_loc"]
     end_loc = params["end_loc"]
     distance_in_miles = sugg.distance(sugg.geojson_to_latlon(start_loc), sugg.geojson_to_latlon(end_loc))
     distance_in_meters = distance_in_miles / 0.000621371
     logging.debug("distance in meters = %s" % distance_in_meters)
     # calculation function expects distance in meters
-    result = sugg.calculate_yelp_server_suggestion_for_locations(start_loc, end_loc, distance_in_meters)
+    result = cfn(start_loc, end_loc, distance_in_meters)
     return result.get('businessid', None)
 
-def test_single_instance(test_fn, instance):
+def test_single_instance(test_fn, cfn, instance):
     logging.debug("-----" + instance["test_name"] + "------")
     param = instance["input"]
-    result = test_fn(param)
+    result = test_fn(cfn, param)
     exp_output = instance["output"]
     if exp_output == result:
         return True
@@ -49,6 +49,23 @@ TEST_WRAPPER_MAP = {
     "calculate_yelp_server_suggestion_for_locations": test_calculate_yelp_server_suggestion_for_locations
 }
 
+CANDIDATE_ALGORITHMS = {
+    "find_destination_business": [
+        sugg.find_destination_business_google,
+        sugg.find_destination_business_yelp,
+        sugg.find_destination_business_nominatim
+    ],
+    "category_of_business_nominatim": [
+        sugg.category_of_business_nominatim,
+        sugg.category_from_name_wrapper,
+        sugg.category_from_address_wrapper,
+        sugg.category_of_business_awesome
+    ],
+    "calculate_yelp_server_suggestion_for_locations": [
+        sugg.calculate_yelp_server_suggestion_for_locations
+    ]
+}
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -57,6 +74,8 @@ if __name__ == '__main__':
     parser.add_argument("algorithm",
         choices=TEST_WRAPPER_MAP.keys(),
         help="the algorithm to test")
+    parser.add_argument("--candidates", nargs="*",
+        help="the candidate implementations of the algorithm; see suggestion_sys for details")
     parser.add_argument("-f", "--infile",
         help="the file that has the inputs and expected outputs. default is emission/integrationTests/suggestionsys/{algorithm}.dataset.json")
 
@@ -73,17 +92,39 @@ if __name__ == '__main__':
     test_fn = TEST_WRAPPER_MAP[args.algorithm]
     logging.info("Mapped algorithm %s -> %s" % (args.algorithm, test_fn))
 
-    dataset = json.load(open(args.infile))
-    successfulTests = 0
-    failedTests = 0
-    for instance in dataset:
-        result = test_single_instance(test_fn, instance)
-        if result:
-            successfulTests = successfulTests + 1
-        else:
-            failedTests = failedTests + 1
-        logging.debug("After instance %s, successfulTests = %d, failedTests = %d"
-            % (instance["test_name"], successfulTests, failedTests))
+    all_candidate_fn_list = CANDIDATE_ALGORITHMS[args.algorithm]
+    all_candidate_name_list = [c.__name__ for c in CANDIDATE_ALGORITHMS[args.algorithm]]
+    if args.candidates is None:
+        args.candidates = all_candidate_name_list
 
-    logging.info("Test complete, overall accuracy = %s " % ((successfulTests * 100) / (successfulTests + failedTests)))
+    logging.info("specified candidates = %s" % args.candidates)
+    invalid_candidate_fn_names = [c for c in args.candidates
+        if c not in all_candidate_name_list]
+    if len(invalid_candidate_fn_names) > 0:
+        print("Did not find candidate algorithms %s" % invalid_candidate_fn_names)
+        exit(1)
+
+    candidate_fns = [fn for fn in all_candidate_fn_list if fn.__name__ in args.candidates]
+    logging.info("Comparing candidate functions %s" % candidate_fns)
+
+    dataset = json.load(open(args.infile))
+    cfn2resultlist= []
+    for cfn in candidate_fns:
+        successfulTests = 0
+        failedTests = 0
+        for instance in dataset:
+            result = test_single_instance(test_fn, cfn, instance)
+            if result:
+                successfulTests = successfulTests + 1
+            else:
+                failedTests = failedTests + 1
+            logging.debug("For candidate %s, after instance %s, successfulTests = %d, failedTests = %d"
+                % (cfn.__name__, instance["test_name"], successfulTests, failedTests))
+        cfn2resultlist.append((cfn.__name__, successfulTests, failedTests))
+        logging.info("Testing candidate %s complete, overall accuracy = %s " %
+            (cfn.__name__, (successfulTests * 100) / (successfulTests + failedTests)))
+
+    logging.info("Test complete, comparison results = ")
+    for cfn_name, successfulTests, failedTests in cfn2resultlist:
+        logging.info("candidate: %s, accuracy = %s" % (cfn_name, (successfulTests * 100) / (successfulTests + failedTests)))
 


### PR DESCRIPTION
Enhance the test harness to compare the performance of various implementations
of the same algorithm. In particular:
- add a list of candidate implementations for each step in the pipeline
- allow users to choose which candidates they want to test
- default to testing all candidates if the user does not specify anything

We also keep track of the results for each step and print out a comparison at the end

Also, refactor the existing suggestion system to allow us to compare the
various choices (e.g. nominatim v/s google v/s yelp?) for reverse geocoding and
search by name v/s search by address for category lookup v/s something even
more awesome?

Testing done:

With no categories specified (which also ensures that the refactoring of the
suggestion system did not did not have a regression by testing
`category_of_business_nominatim`, which returned the same result as last night)

```
./e-mission-py.bash emission/integrationTests/suggestionsys/algorithm_test_harness.py category_of_business_nominatim
INFO:root:candidate: category_of_business_nominatim, accuracy = 4.0
INFO:root:candidate: category_from_name_wrapper, accuracy = 6.0
INFO:root:candidate: category_from_address_wrapper, accuracy = 4.0
INFO:root:candidate: category_of_business_awesome, accuracy = 6.0
```

With categories specified

```
./e-mission-py.bash emission/integrationTests/suggestionsys/algorithm_test_harness.py category_of_business_nominatim --candidates category_of_business_awesome
INFO:root:candidate: category_of_business_awesome, accuracy = 6.0
```