### PR TITLE
Debugged the nominatim function, so it runs

### DIFF
--- a/emission/core/wrapper/suggestion_sys.py
+++ b/emission/core/wrapper/suggestion_sys.py
@@ -211,16 +211,16 @@ def find_destination_business(lat, lon):
     # print(return_address_from_location_google(location))
     # print(len(return_address_from_location_google(location)))
     #IF RETURN_ADDRESS_FROM_LOCATION HAS A BUSINESS LOCATION ATTACHED TO THE ADDRESS
-    # try:
+    try:
         return_tuple = find_destination_business_nominatim(lat, lon)
         logging.debug("Nominatim found destination business %s " % str(return_tuple))
         return return_tuple
-    # except:
-    #     #USE GOOGLE API JUST IN CASE if nominatim doesn't work
-    #     return_tuple = return_address_from_google_nomfile(lat, lon)
-    #     logging.debug("Nominatim failed, Google found destination business %s "
-    #         % str(return_tuple))
-    #     return return_tuple
+    except:
+        #USE GOOGLE API JUST IN CASE if nominatim doesn't work
+        return_tuple = return_address_from_google_nomfile(lat, lon)
+        logging.debug("Nominatim failed, Google found destination business %s "
+            % str(return_tuple))
+        return return_tuple
 
 ### BEGIN: Pulled out candidate functions so that we can evaluate individual accuracies
 def category_of_business_awesome(lat, lon):

--- a/emission/core/wrapper/suggestion_sys.py
+++ b/emission/core/wrapper/suggestion_sys.py
@@ -186,7 +186,15 @@ def find_destination_business_nominatim(lat, lon):
     string_address, address_dict = return_address_from_location_nominatim(lat, lon)
     business_key = list(address_dict.keys())[0]
     business_name = address_dict[business_key]
-    city = address_dict['city']
+    try:
+        city = address_dict['city']
+    except: 
+        try:
+            city = address_dict["town"]
+        except:
+            zipcode = address_dict["postcode"]
+            city = zipcode_to_city(zipcode)  
+
     return (business_name, string_address, city,
         (not is_service_nominatim(business_name)))
 ### END: Pulled out candidate functions so that we can evaluate individual accuracies
@@ -200,16 +208,16 @@ def find_destination_business(lat, lon):
     # print(return_address_from_location_google(location))
     # print(len(return_address_from_location_google(location)))
     #IF RETURN_ADDRESS_FROM_LOCATION HAS A BUSINESS LOCATION ATTACHED TO THE ADDRESS
-    try:
+    # try:
         return_tuple = find_destination_business_nominatim(lat, lon)
         logging.debug("Nominatim found destination business %s " % str(return_tuple))
         return return_tuple
-    except:
-        #USE GOOGLE API JUST IN CASE if nominatim doesn't work
-        return_tuple = return_address_from_google_nomfile(lat, lon)
-        logging.debug("Nominatim failed, Google found destination business %s "
-            % str(return_tuple))
-        return return_tuple
+    # except:
+    #     #USE GOOGLE API JUST IN CASE if nominatim doesn't work
+    #     return_tuple = return_address_from_google_nomfile(lat, lon)
+    #     logging.debug("Nominatim failed, Google found destination business %s "
+    #         % str(return_tuple))
+    #     return return_tuple
 
 ### BEGIN: Pulled out candidate functions so that we can evaluate individual accuracies
 def category_of_business_awesome(lat, lon):

--- a/emission/core/wrapper/suggestion_sys.py
+++ b/emission/core/wrapper/suggestion_sys.py
@@ -192,8 +192,11 @@ def find_destination_business_nominatim(lat, lon):
         try:
             city = address_dict["town"]
         except:
-            zipcode = address_dict["postcode"]
-            city = zipcode_to_city(zipcode)  
+            try:
+                zipcode = address_dict["postcode"]
+                city = zipcode_to_city(zipcode)  
+            except:
+                city = ''
 
     return (business_name, string_address, city,
         (not is_service_nominatim(business_name)))

--- a/emission/integrationTests/suggestionsys/find_destination_business.dataset.json
+++ b/emission/integrationTests/suggestionsys/find_destination_business.dataset.json
@@ -19,7 +19,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kettle", "Kettle Manhattan Beach"]
+        "output": ["Kettle", "The Kettle Manhattan Beach"]
     },
     {
         "test_name": "Manhattan Beach Beckers",
@@ -30,7 +30,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Becker's Bakery and Deli", "Becker's Bakery and Deli Manhattan Beach"]
+        "output": ["Becker's Bakery and Deli", "Becker's Bakery Manhattan Beach"]
     },
 
     {
@@ -42,7 +42,7 @@
                 "type": "Point"
             }
         },
-        "output": ["FISHBAR", "FISHBAR Manhattan Beach"]
+        "output": ["FISHBAR", "Fishbar Manhattan Beach 2"]
     },
 
     {
@@ -54,7 +54,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Umi", "Umi Los Angeles"]
+        "output": ["Umi", "Umi by Hamasuku El Segundo"]
     },
 
     {
@@ -66,7 +66,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Captain Kidd’s Fish Market", "Captain Kidd’s Fish Market Redondo Beach"]
+        "output": ["Captain Kidd’s Fish Market", "Captain Kidd’s Redondo Beach 4"]
     },
 
      {
@@ -148,7 +148,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Loving Hut", "Loving Hut Milpitas"]
+        "output": ["Loving Hut", "Loving Hut Milpitas Milpitas"]
     }, 
     {
         "test_name": "San Francisco Premium Outlets",
@@ -159,7 +159,7 @@
                 "type": "Point"
             }
         },
-        "output": ["San Francisco Premium Outlets", "San Francisco Premium Outlets Livermore"]
+        "output": ["San Francisco Premium Outlets", "San Francisco Premium Outlets Livermore 3"]
     },
     {
         "test_name": "San Ramon Valley High School",
@@ -170,7 +170,7 @@
                 "type": "Point"
             }
         },
-        "output": ["San Ramon Valley High School", "San Ramon Valley High School San Ramon"]
+        "output": ["San Ramon Valley High School", "San Ramon Valley High School Danville"]
     },
     {
         "test_name": "Bank of America",
@@ -192,7 +192,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Chevron Milpitas", "Chevron Milpitas"]
+        "output": ["Chevron Milpitas", "Chevron Milpitas 3"]
     },
     {
         "test_name": "Costco",
@@ -225,7 +225,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kaiser Permanente Pediatrics Building", "Kaiser Permanente Pediatrics Building Milpitas"]
+        "output": ["Kaiser Permanente Pediatrics Building", "Kaiser Permanente Pediatrics Building Milpitas 2"]
     }, 
     {
         "test_name": "Taco Bell",
@@ -248,7 +248,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Northbrook Village Hall", "Northbrook Village Hall Northbrook"]
+        "output": ["Northbrook Village Hall", "Village Hall Northbrook"]
     },
 
     {
@@ -320,7 +320,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Squash Blossom", "Squash Blossom Vail"]
+        "output": ["Squash Blossom", "Squash Blossom Vail 2"]
     },
 
     {
@@ -344,7 +344,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Art Institute's Gardens", "Art Institute's Gardens Chicago"]
+        "output": ["Art Institute's Gardens", "Art Institute of Chicago Chicago 3"]
     },
 
     {
@@ -356,7 +356,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Bitcoin of America", "Bitcoin of America Chicago"]
+        "output": ["Bitcoin of America", ""]
     },
     {
         "test_name": "Pekoe San Jose",
@@ -433,7 +433,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Holiday Inn San Jose - Silicon Valley", "Holiday Inn San Jose - Silicon Valley San Jose"]
+        "output": ["Holiday Inn San Jose - Silicon Valley", "Holiday Inn San Jose Silicon Valley San Jose"]
     },
     {
         "test_name": "Annie Hair & Beauty",
@@ -466,6 +466,6 @@
                 "type": "Point"
             }
         },
-        "output": ["Department of Motor Vehicles", "Department of Motor Vehicles Fremont"]
+        "output": ["Department of Motor Vehicles", "Department of Motor Vehicles Fremont 4"]
     }
 ]

--- a/emission/integrationTests/suggestionsys/find_destination_business.dataset.json
+++ b/emission/integrationTests/suggestionsys/find_destination_business.dataset.json
@@ -8,7 +8,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kohl's", "Kohl's Mountain View", true]
+        "output": ["Kohl's", "Kohl's Mountain View"]
     },
     {
         "test_name": "Manhattan Beach Kettle",
@@ -19,7 +19,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kettle", "Kettle Manhattan Beach", true]
+        "output": ["Kettle", "Kettle Manhattan Beach"]
     },
     {
         "test_name": "Manhattan Beach Beckers",
@@ -30,7 +30,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Becker's Bakery and Deli", "Becker's Bakery and Deli Manhattan Beach", true]
+        "output": ["Becker's Bakery and Deli", "Becker's Bakery and Deli Manhattan Beach"]
     },
 
     {
@@ -42,7 +42,7 @@
                 "type": "Point"
             }
         },
-        "output": ["FISHBAR", "FISHBAR Manhattan Beach", true]
+        "output": ["FISHBAR", "FISHBAR Manhattan Beach"]
     },
 
     {
@@ -54,7 +54,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Umi", "Umi Los Angeles", true]
+        "output": ["Umi", "Umi Los Angeles"]
     },
 
     {
@@ -66,7 +66,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Captain Kidd’s Fish Market", "Captain Kidd’s Fish Market Redondo Beach", true]
+        "output": ["Captain Kidd’s Fish Market", "Captain Kidd’s Fish Market Redondo Beach"]
     },
 
      {
@@ -78,7 +78,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Mira Costa High School", "Mira Costa High School Manhattan Beach", true]
+        "output": ["Mira Costa High School", "Mira Costa High School Manhattan Beach"]
     },
 
     {
@@ -90,7 +90,7 @@
                 "type": "Point"
             }
         },
-        "output": ["El Segundo High School", "El Segundo High School El Segundo", true]
+        "output": ["El Segundo High School", "El Segundo High School El Segundo"]
     },
 
      {
@@ -102,7 +102,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Black Bear Diner", "Black Bear Diner Torrance", true]
+        "output": ["Black Bear Diner", "Black Bear Diner Torrance"]
     },
 
      {
@@ -114,7 +114,7 @@
                 "type": "Point"
             }
         },
-        "output": ["In-N-Out Burger", "In-N-Out Burger Inglewood", true]
+        "output": ["In-N-Out Burger", "In-N-Out Burger Inglewood"]
     },
 
     {
@@ -126,7 +126,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Torrance Memorial Medical Center", "Torrance Memorial Medical Center Torrance", true]
+        "output": ["Torrance Memorial Medical Center", "Torrance Memorial Medical Center Torrance"]
     }, 
     {
         "test_name": "Walmart Supercenter",
@@ -137,7 +137,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Walmart Supercenter", "Walmart Supercenter Milpitas", true]
+        "output": ["Walmart Supercenter", "Walmart Supercenter Milpitas"]
     }, 
     {   
         "test_name": "Loving Hut",
@@ -148,7 +148,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Loving Hut", "Loving Hut Milpitas", true]
+        "output": ["Loving Hut", "Loving Hut Milpitas"]
     }, 
     {
         "test_name": "San Francisco Premium Outlets",
@@ -159,7 +159,7 @@
                 "type": "Point"
             }
         },
-        "output": ["San Francisco Premium Outlets", "San Francisco Premium Outlets Livermore", true]
+        "output": ["San Francisco Premium Outlets", "San Francisco Premium Outlets Livermore"]
     },
     {
         "test_name": "San Ramon Valley High School",
@@ -170,7 +170,7 @@
                 "type": "Point"
             }
         },
-        "output": ["San Ramon Valley High School", "San Ramon Valley High School San Ramon", true]
+        "output": ["San Ramon Valley High School", "San Ramon Valley High School San Ramon"]
     },
     {
         "test_name": "Bank of America",
@@ -181,7 +181,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Bank of America", "Bank of America Milpitas", true]
+        "output": ["Bank of America", "Bank of America Milpitas"]
     },
     {
         "test_name": "Chevron Milpitas",
@@ -192,7 +192,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Chevron Milpitas", "Chevron Milpitas", true]
+        "output": ["Chevron Milpitas", "Chevron Milpitas"]
     },
     {
         "test_name": "Costco",
@@ -203,7 +203,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Costco", "Costco Richmond", true]
+        "output": ["Costco", "Costco Richmond"]
     }, 
     {
         "test_name": "Layang Layang",
@@ -214,7 +214,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Layang Layang", "Layang Layang Milpitas", true]
+        "output": ["Layang Layang", "Layang Layang Milpitas"]
     }, 
     {
         "test_name": "Kaiser Permanente Pediatrics Building",
@@ -225,7 +225,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kaiser Permanente Pediatrics Building", "Kaiser Permanente Pediatrics Building Milpitas", true]
+        "output": ["Kaiser Permanente Pediatrics Building", "Kaiser Permanente Pediatrics Building Milpitas"]
     }, 
     {
         "test_name": "Taco Bell",
@@ -236,7 +236,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Taco Bell", "Taco Bell Milpitas", true]
+        "output": ["Taco Bell", "Taco Bell Milpitas"]
     },
 
     {
@@ -248,7 +248,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Northbrook Village Hall", "Cedar Lane", "Northbrook", true]
+        "output": ["Northbrook Village Hall", "Northbrook Village Hall Northbrook"]
     },
 
     {
@@ -260,7 +260,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Patisserie Coralie", "Davis Street", "Evanston", true]
+        "output": ["Patisserie Coralie", "Patisserie Coralie Evanston"]
     },
 
     {
@@ -272,7 +272,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Northbrook Public Library", "Cedar Lane", "Northbrook", true]
+        "output": ["Northbrook Public Library", "Northbrook Public Library Northbrook"]
     },
 
     {
@@ -284,7 +284,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Music Institute of Chicago", "Chicago Avenue", "Evanston", true]
+        "output": ["Music Institute of Chicago", "Music Institute of Chicago Evanston"]
     },
 
     {
@@ -296,7 +296,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Town Cleaners", "Chicago Avenue", "Evanston", true]
+        "output": ["Town Cleaners", "Town Cleaners Evanston"]
     },
 
     {
@@ -308,7 +308,7 @@
                 "type": "Point"
             }
         },
-        "output": ["RadioShack", "Church Street", "Evanston", true]
+        "output": ["RadioShack", "RadioShack Evanston"]
     },
 
     {
@@ -320,7 +320,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Squash Blossom", "Gore Creek Drive", "Vail", true]
+        "output": ["Squash Blossom", "Squash Blossom Vail"]
     },
 
     {
@@ -332,7 +332,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Garfinkel's", "East Lionshead Circle", "Vail", true]
+        "output": ["Garfinkel's", "Garfinkel's Vail"]
     },
 
     {
@@ -344,7 +344,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Art Institute's Gardens", "South Michigan Avenue", "Chicago", true]
+        "output": ["Art Institute's Gardens", "Art Institute's Gardens Chicago"]
     },
 
     {
@@ -356,7 +356,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Bitcoin of America", "East Monroe Street", "Chicago", true]
+        "output": ["Bitcoin of America", "Bitcoin of America Chicago"]
     },
     {
         "test_name": "Pekoe San Jose",
@@ -367,7 +367,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Pekoe", "Pekoe San Jose", true]
+        "output": ["Pekoe", "Pekoe San Jose"]
     },
     {
         "test_name": "99 Ranch Market Fremont",
@@ -378,7 +378,7 @@
                 "type": "Point"
             }
         },
-        "output": ["99 Ranch Market", "99 Ranch Market Fremont", true]
+        "output": ["99 Ranch Market", "99 Ranch Market Fremont"]
     },
     {
         "test_name": "Mission San Jose High School Fremont",
@@ -389,7 +389,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Mission San Jose High School", "Mission San Jose High School Fremont", true]
+        "output": ["Mission San Jose High School", "Mission San Jose High School Fremont"]
     },
     {
         "test_name": "Giraffe Learning Center",
@@ -400,7 +400,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Giraffe Learning Center", "Giraffe Learning Center Fremont", true]
+        "output": ["Giraffe Learning Center", "Giraffe Learning Center Fremont"]
     },
     {
         "test_name": "Costco",
@@ -411,7 +411,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Costco", "Costco Fremont", true]
+        "output": ["Costco", "Costco Fremont"]
     },
     {
         "test_name": "Ohlone College",
@@ -422,7 +422,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Ohlone College", "Ohlone College Fremont", true]
+        "output": ["Ohlone College", "Ohlone College Fremont"]
     },
     {
         "test_name": "Holiday Inn San Jose - Silicon Valley",
@@ -433,7 +433,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Holiday Inn San Jose - Silicon Valley", "Holiday Inn San Jose - Silicon Valley San Jose", true]
+        "output": ["Holiday Inn San Jose - Silicon Valley", "Holiday Inn San Jose - Silicon Valley San Jose"]
     },
     {
         "test_name": "Annie Hair & Beauty",
@@ -444,7 +444,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Annie Hair & Beauty", "Annie Hair & Beauty Fremont", true]
+        "output": ["Annie Hair & Beauty", "Annie Hair & Beauty Fremont"]
     },
     {
         "test_name": "Quik Stop",
@@ -455,7 +455,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Quik Stop", "Quik Stop Fremont", true]
+        "output": ["Quik Stop", "Quik Stop Fremont"]
     },
     {
         "test_name": "Department of Motor Vehicles",
@@ -466,6 +466,6 @@
                 "type": "Point"
             }
         },
-        "output": ["Department of Motor Vehicles", "Department of Motor Vehicles Fremont", true]
+        "output": ["Department of Motor Vehicles", "Department of Motor Vehicles Fremont"]
     }
 ]

--- a/emission/integrationTests/suggestionsys/find_destination_business.dataset.json
+++ b/emission/integrationTests/suggestionsys/find_destination_business.dataset.json
@@ -8,7 +8,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kohl's", "Showers Drive", "Mountain View", true]
+        "output": ["Kohl's", "Kohl's Mountain View", true]
     },
     {
         "test_name": "Manhattan Beach Kettle",
@@ -19,7 +19,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kettle", "North Highland Avenue", true]
+        "output": ["Kettle", "Kettle Manhattan Beach", true]
     },
     {
         "test_name": "Manhattan Beach Beckers",
@@ -30,7 +30,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Becker's Bakery and Deli", "Manhattan Beach Ave", "Manhattan Beach", true]
+        "output": ["Becker's Bakery and Deli", "Becker's Bakery and Deli Manhattan Beach", true]
     },
 
     {
@@ -42,7 +42,7 @@
                 "type": "Point"
             }
         },
-        "output": ["FISHBAR", "Highland Ave", "Manhattan Beach", true]
+        "output": ["FISHBAR", "FISHBAR Manhattan Beach", true]
     },
 
     {
@@ -54,7 +54,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Umi", "Sepulveda Boulevard", "Los Angeles", true]
+        "output": ["Umi", "Umi Los Angeles", true]
     },
 
     {
@@ -66,7 +66,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Captain Kidd’s Fish Market", "North Harbor Drive", "Redondo Beach", true]
+        "output": ["Captain Kidd’s Fish Market", "Captain Kidd’s Fish Market Redondo Beach", true]
     },
 
      {
@@ -78,7 +78,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Mira Costa High School", "Artesia Boulevard", "Manhattan Beach", true]
+        "output": ["Mira Costa High School", "Mira Costa High School Manhattan Beach", true]
     },
 
     {
@@ -90,7 +90,7 @@
                 "type": "Point"
             }
         },
-        "output": ["El Segundo High School", "Main Street", "El Segundo", true]
+        "output": ["El Segundo High School", "El Segundo High School El Segundo", true]
     },
 
      {
@@ -102,7 +102,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Black Bear Diner", "Hawthorne Boulevard", "Torrance", true]
+        "output": ["Black Bear Diner", "Black Bear Diner Torrance", true]
     },
 
      {
@@ -114,7 +114,7 @@
                 "type": "Point"
             }
         },
-        "output": ["In-N-Out Burger", "West Century Boulevard", "Inglewood", true]
+        "output": ["In-N-Out Burger", "In-N-Out Burger Inglewood", true]
     },
 
     {
@@ -126,7 +126,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Torrance Memorial Medical Center", "Lomita Boulevard", "Torrance", true]
+        "output": ["Torrance Memorial Medical Center", "Torrance Memorial Medical Center Torrance", true]
     }, 
     {
         "test_name": "Walmart Supercenter",
@@ -137,7 +137,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Walmart Supercenter", "Ranch Drive", "Milpitas", true]
+        "output": ["Walmart Supercenter", "Walmart Supercenter Milpitas", true]
     }, 
     {   
         "test_name": "Loving Hut",
@@ -148,7 +148,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Loving Hut", "Barber Lane", "Milpitas", true]
+        "output": ["Loving Hut", "Loving Hut Milpitas", true]
     }, 
     {
         "test_name": "San Francisco Premium Outlets",
@@ -159,7 +159,7 @@
                 "type": "Point"
             }
         },
-        "output": ["San Francisco Premium Outlets", "Livermore Outlets Drive", "Livermore", true]
+        "output": ["San Francisco Premium Outlets", "San Francisco Premium Outlets Livermore", true]
     },
     {
         "test_name": "San Ramon Valley High School",
@@ -170,7 +170,7 @@
                 "type": "Point"
             }
         },
-        "output": ["San Ramon Valley High School", "Danville Boulevard", "San Ramon", true]
+        "output": ["San Ramon Valley High School", "San Ramon Valley High School San Ramon", true]
     },
     {
         "test_name": "Bank of America",
@@ -181,7 +181,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Bank of America", "East Calaveras Boulevard", "Milpitas", true]
+        "output": ["Bank of America", "Bank of America Milpitas", true]
     },
     {
         "test_name": "Chevron Milpitas",
@@ -192,7 +192,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Chevron Milpitas", "California Circle", "Milpitas", true]
+        "output": ["Chevron Milpitas", "Chevron Milpitas", true]
     },
     {
         "test_name": "Costco",
@@ -203,7 +203,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Costco", "Central Avenue", "Richmond", true]
+        "output": ["Costco", "Costco Richmond", true]
     }, 
     {
         "test_name": "Layang Layang",
@@ -214,7 +214,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Layang Layang", "West Calaveras Boulevard", "Milpitas", true]
+        "output": ["Layang Layang", "Layang Layang Milpitas", true]
     }, 
     {
         "test_name": "Kaiser Permanente Pediatrics Building",
@@ -225,7 +225,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kaiser Permanente Pediatrics Building", "Los Coches Street", "Milpitas", true]
+        "output": ["Kaiser Permanente Pediatrics Building", "Kaiser Permanente Pediatrics Building Milpitas", true]
     }, 
     {
         "test_name": "Taco Bell",
@@ -236,7 +236,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Taco Bell", "South Park Victoria Drive", "Milpitas", true]
+        "output": ["Taco Bell", "Taco Bell Milpitas", true]
     },
     {
         "test_name": "Pekoe San Jose",
@@ -247,7 +247,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Pekoe", "South White Road", "San Jose", true]
+        "output": ["Pekoe", "Pekoe San Jose", true]
     },
     {
         "test_name": "99 Ranch Market Fremont",
@@ -258,7 +258,7 @@
                 "type": "Point"
             }
         },
-        "output": ["99 Ranch Market", "Warm Springs Boulevard", "Fremont", true]
+        "output": ["99 Ranch Market", "99 Ranch Market Fremont", true]
     },
     {
         "test_name": "Mission San Jose High School Fremont",
@@ -269,7 +269,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Mission San Jose High School", "Palm Avenue", "Fremont", true]
+        "output": ["Mission San Jose High School", "Mission San Jose High School Fremont", true]
     },
     {
         "test_name": "Giraffe Learning Center",
@@ -280,7 +280,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Giraffe Learning Center", "Driscoll Road", "Fremont", true]
+        "output": ["Giraffe Learning Center", "Giraffe Learning Center Fremont", true]
     },
     {
         "test_name": "Costco",
@@ -291,7 +291,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Costco", "Pacific Commons Boulevard", "Fremont", true]
+        "output": ["Costco", "Costco Fremont", true]
     },
     {
         "test_name": "Ohlone College",
@@ -302,7 +302,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Ohlone College", "Mission Boulevard", "Fremont", true]
+        "output": ["Ohlone College", "Ohlone College Fremont", true]
     },
     {
         "test_name": "Holiday Inn San Jose - Silicon Valley",
@@ -313,7 +313,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Holiday Inn San Jose - Silicon Valley", "North 1st Street", "San Jose", true]
+        "output": ["Holiday Inn San Jose - Silicon Valley", "Holiday Inn San Jose - Silicon Valley San Jose", true]
     },
     {
         "test_name": "Annie Hair & Beauty",
@@ -324,7 +324,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Annie Hair & Beauty", "Warm Springs Boulevard", "Fremont", true]
+        "output": ["Annie Hair & Beauty", "Annie Hair & Beauty Fremont", true]
     },
     {
         "test_name": "Quik Stop",
@@ -335,7 +335,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Quik Stop", "Washington Boulevard", "Fremont", true]
+        "output": ["Quik Stop", "Quik Stop Fremont", true]
     },
     {
         "test_name": "Department of Motor Vehicles",
@@ -346,6 +346,6 @@
                 "type": "Point"
             }
         },
-        "output": ["Department of Motor Vehicles", "Central Avenue", "Fremont", true]
+        "output": ["Department of Motor Vehicles", "Department of Motor Vehicles Fremont", true]
     }
 ]


### PR DESCRIPTION
This did not improve accuracy, but I found some tests that technically should've passed in terms of finding the correct business name, but didn't match the street address exactly. Because nominatim's street address includes the business name as well in the street address. --> Will need to address the expected results in the tests. 

Verdict: I think we should update our server, because when I tried changing the link to the public server like https://nominatim.openstreetmap.org/reverse? and the MapQuest version with our key http://open.mapquestapi.com/nominatim/v1/reverse.php?key=[our key], I got this error. 

```
Traceback (most recent call last):
  File "/Users/vanessalin/Desktop/e-mission-server/emission/net/ext_service/geocoder/nominatim.py", line 95, in reverse_geocode
    jsn = cls.get_json_reverse(lat, lng)
  File "/Users/vanessalin/Desktop/e-mission-server/emission/net/ext_service/geocoder/nominatim.py", line 87, in get_json_reverse
    response = urllib.request.urlopen(request)
  File "/Users/vanessalin/anaconda2/envs/emission/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/Users/vanessalin/anaconda2/envs/emission/lib/python3.6/urllib/request.py", line 532, in open
    response = meth(req, response)
  File "/Users/vanessalin/anaconda2/envs/emission/lib/python3.6/urllib/request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "/Users/vanessalin/anaconda2/envs/emission/lib/python3.6/urllib/request.py", line 570, in error
    return self._call_chain(*args)
  File "/Users/vanessalin/anaconda2/envs/emission/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/Users/vanessalin/anaconda2/envs/emission/lib/python3.6/urllib/request.py", line 650, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

Example of false tests: 
```
DEBUG:root:Test Mission San Jose High School Fremont failed, output = ['Mission San Jose High School', 'Mission San Jose High School, Mission Creek Trail, Mission San Jose District, Fremont, Alameda County, 94539, United States of America', 'Fremont', False], expected ['Mission San Jose High School', 'Palm Avenue', 'Fremont', True]
```
```
DEBUG:root:Test Kaiser Permanente Pediatrics Building failed, output = ['Kaiser Permanente Pediatrics Building', 'Kaiser Permanente Pediatrics Building, Los Coches Street, Milpitas, Santa Clara County, 95035, United States of America', 'Milpitas', False], expected ['Kaiser Permanente Pediatrics Building', 'Los Coches Street', 'Milpitas', True]
```
```
DEBUG:root:Test Bank of America failed, output = ['Bank of America', 'Bank of America, South Hillview Drive, Milpitas, Santa Clara County, 95035, United States of America', 'Milpitas', False], expected ['Bank of America', 'East Calaveras Boulevard', 'Milpitas', True]
```
Examples of same streets, but no business names included (streetnames become business_names)
```
DEBUG:root:Test San Ramon Valley High School failed, output = ['Danville Boulevard', 'Danville Boulevard, Danville, Contra Costa County, 94526, United States of America', 'Danville', False], expected ['San Ramon Valley High School', 'Danville Boulevard', 'San Ramon', True]
```