### PR TITLE
Check for the name in `find_destination_business` + add noise + run on test at a time

### DIFF
--- a/emission/integrationTests/suggestionsys/algorithm_test_harness.py
+++ b/emission/integrationTests/suggestionsys/algorithm_test_harness.py
@@ -4,11 +4,44 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 import argparse
 import json
+import random
+import geojson as gj
+import math
 
 import emission.core.wrapper.suggestion_sys as sugg
 
-def test_find_destination_business(cfn, params, exp_output):
-    lat, lon = sugg.geojson_to_lat_lon_separated(params["loc"])
+### Add noise from a uniform distribution with range `noise_in_meters`
+def add_noise(loc_geojson, noise_in_meters):
+    # Formula from
+    # http://www.movable-type.co.uk/scripts/latlong.html
+    # section "Destination point given distance and bearing from start point"
+    R = 6371e3 # radius of the earth in meters from the same location
+
+    # if we don't have this check, then the subsequent randrange call fails
+    # with the error
+    # ValueError: empty range for randrange()
+    if noise_in_meters == 0:
+        logging.info("noise_in_meters = 0, skipping add_noise")
+        return loc_geojson
+    delta_dist = float(random.randrange(noise_in_meters))
+    brng = math.radians(random.randrange(360))
+
+    old_lat = math.radians(loc_geojson["coordinates"][1])
+    new_lat = math.asin(math.sin(old_lat)*math.cos(delta_dist/R) +
+                    math.cos(old_lat)*math.sin(delta_dist/R)*math.cos(brng) );
+    old_lng = math.radians(loc_geojson["coordinates"][0])
+    new_lng = old_lng + math.atan2(
+        math.sin(brng)*math.sin(delta_dist/R)*math.cos(old_lat),
+        math.cos(delta_dist/R)-math.sin(old_lat)*math.sin(old_lat));
+    new_loc = gj.Point((math.degrees(new_lng), math.degrees(new_lat)))
+    logging.info("After adding noise, converted %s -> %s" %
+        (loc_geojson["coordinates"], new_loc["coordinates"]))
+    return new_loc
+
+
+def test_find_destination_business(cfn, params, exp_output, noise_in_meters):
+    noisy_loc = add_noise(params["loc"], noise_in_meters)
+    lat, lon = sugg.geojson_to_lat_lon_separated(noisy_loc)
     result = cfn(lat, lon)
     name = result[0]
     # exp_output is a list of valid names
@@ -21,26 +54,29 @@ def test_find_destination_business(cfn, params, exp_output):
             (name, exp_output))
         return False
 
-def test_category_of_business_nominatim(cfn, params, exp_output):
-    lat, lon = sugg.geojson_to_lat_lon_separated(params["loc"])
+def test_category_of_business_nominatim(cfn, params, exp_output, noise_in_meters):
+    noisy_loc = add_noise(params["loc"], noise_in_meters)
+    lat, lon = sugg.geojson_to_lat_lon_separated(noisy_loc)
     result = cfn(lat, lon)
     return exp_output == result
 
-def test_calculate_yelp_server_suggestion_for_locations(cfn, params, exp_output):
-    start_loc = params["start_loc"]
-    end_loc = params["end_loc"]
-    distance_in_miles = sugg.distance(sugg.geojson_to_latlon(start_loc), sugg.geojson_to_latlon(end_loc))
+def test_calculate_yelp_server_suggestion_for_locations(cfn, params, exp_output, noise_in_meters):
+    noisy_start_loc = add_noise(params["start_loc"], noise_in_meters)
+    noisy_end_loc = add_noise(params["end_loc"], noise_in_meters)
+    distance_in_miles = sugg.distance(
+        sugg.geojson_to_latlon(noisy_start_loc),
+        sugg.geojson_to_latlon(noisy_end_loc))
     distance_in_meters = distance_in_miles / 0.000621371
     logging.debug("distance in meters = %s" % distance_in_meters)
     # calculation function expects distance in meters
     result = cfn(start_loc, end_loc, distance_in_meters)
     return result.get('businessid', None) == exp_output
 
-def test_single_instance(test_fn, cfn, instance):
+def test_single_instance(test_fn, cfn, instance, noise_in_meters):
     logging.debug("-----" + instance["test_name"] + "------")
     param = instance["input"]
     exp_output = instance["output"]
-    result = test_fn(cfn, param, exp_output)
+    result = test_fn(cfn, param, exp_output, noise_in_meters)
     if not result:
         logging.debug("Test %s failed, output = %s, expected %s "
             % (instance["test_name"], result, exp_output))
@@ -88,12 +124,19 @@ if __name__ == '__main__':
         help="the file that has the inputs and expected outputs. default is emission/integrationTests/suggestionsys/{algorithm}.dataset.json")
     parser.add_argument("-t", "--test", nargs="+",
         help="run only the test with the specific name, to make it easier to debug individual instances")
+    parser.add_argument("-n", "--noise", type=int, default=0,
+        help="maximum noise (in meters) to add to the locations. Noise from a uniform distribution with this range will be added")
+    parser.add_argument("-s", "--seed",
+        help="random seed to use for reproducibility while trying to debug lookup")
 
     args = parser.parse_args()
 #     if args.debug:
 #         logging.basicConfig(level=logging.DEBUG)
 #     else:
 #         logging.basicConfig(level=logging.INFO)
+
+    logging.info("Configuring random with seed %s" % args.seed)
+    random.seed(args.seed)
 
     if args.infile is None:
         args.infile = ("emission/integrationTests/suggestionsys/%s.dataset.json"
@@ -124,7 +167,7 @@ if __name__ == '__main__':
         test_instance = [i for i in dataset if i["test_name"] == " ".join(args.test)][0]
         logging.debug("Found test instance %s" % test_instance)
         for cfn in candidate_fns:
-            test_single_instance(test_fn, cfn, test_instance)
+            test_single_instance(test_fn, cfn, test_instance, args.noise)
         exit(0)
 
     cfn2resultlist= []
@@ -132,7 +175,7 @@ if __name__ == '__main__':
         successfulTests = 0
         failedTests = 0
         for instance in dataset:
-            result = test_single_instance(test_fn, cfn, instance)
+            result = test_single_instance(test_fn, cfn, instance, args.noise)
             if result:
                 successfulTests = successfulTests + 1
             else:

--- a/emission/integrationTests/suggestionsys/algorithm_test_harness.py
+++ b/emission/integrationTests/suggestionsys/algorithm_test_harness.py
@@ -13,8 +13,12 @@ def test_find_destination_business(cfn, params, exp_output):
     name = result[0]
     # exp_output is a list of valid names
     if name in exp_output:
+        logging.debug("found match! name = %s, comparing with %s" %
+            (name, exp_output))
         return True
     else:
+        logging.debug("no match! name = %s, comparing with %s" %
+            (name, exp_output))
         return False
 
 def test_category_of_business_nominatim(cfn, params, exp_output):
@@ -82,6 +86,8 @@ if __name__ == '__main__':
         help="the candidate implementations of the algorithm; see suggestion_sys for details")
     parser.add_argument("-f", "--infile",
         help="the file that has the inputs and expected outputs. default is emission/integrationTests/suggestionsys/{algorithm}.dataset.json")
+    parser.add_argument("-t", "--test", nargs="+",
+        help="run only the test with the specific name, to make it easier to debug individual instances")
 
     args = parser.parse_args()
 #     if args.debug:
@@ -112,6 +118,15 @@ if __name__ == '__main__':
     logging.info("Comparing candidate functions %s" % candidate_fns)
 
     dataset = json.load(open(args.infile))
+
+    if args.test is not None:
+        logging.info("Running single test %s" % args.test)
+        test_instance = [i for i in dataset if i["test_name"] == " ".join(args.test)][0]
+        logging.debug("Found test instance %s" % test_instance)
+        for cfn in candidate_fns:
+            test_single_instance(test_fn, cfn, test_instance)
+        exit(0)
+
     cfn2resultlist= []
     for cfn in candidate_fns:
         successfulTests = 0

--- a/emission/integrationTests/suggestionsys/find_destination_business.dataset.json
+++ b/emission/integrationTests/suggestionsys/find_destination_business.dataset.json
@@ -8,7 +8,7 @@
                 "type": "Point"
             }
         },
-        "output": ["Kohl's", "Showers Drive", "Mountain View", true]
+        "output": ["Kohl's", "Kohl's Mountain View"]
     },
     {
         "test_name": "Manhattan Beach Kettle",


### PR DESCRIPTION
- Change the `find_destination_business` harness to check for the name only
instead of all matches. See https://github.com/e-mission/e-mission-server/pull/676 for the request.
See below for more details on the change. (https://github.com/e-mission/e-mission-server/pull/677/commits/1b2ebc0bda5beaab5df229f589bdb4acbce1e4e5)
- Support running one test at a time with the `-t` option to make it easier to debug errors in the lookup 
(https://github.com/e-mission/e-mission-server/pull/677/commits/c9a1ed5ea4aa461e142b66139db2a1d8386c27d5)
- Support adding noise, and specifying a seed to reproduce given the new source of randomness (https://github.com/e-mission/e-mission-server/pull/677/commits/1ed6ba0e2df3306b289e8c76e1df4ecd9b45734d)