### PR TITLE
Add a new method to store data synchronously

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -240,6 +240,16 @@ def putIntoCache():
   from_phone = request.json['phone_to_server']
   return usercache.sync_phone_to_server(user_uuid, from_phone)
 
+@post('/usercache/putone')
+def putIntoOneEntry():
+  logging.debug("Called userCache.putone with request " % request)
+  user_uuid=getUUID(request)
+  logging.debug("user_uuid %s" % user_uuid)
+  the_entry = request.json['the_entry']
+  # sync_phone_to_server requires a list, so we wrap our one entry in the list
+  from_phone = [the_entry]
+  return usercache.sync_phone_to_server(user_uuid, from_phone)
+
 @post('/timeline/getTrips/<day>')
 def getTrips(day):
   logging.debug("Called timeline.getTrips/%s" % day)


### PR DESCRIPTION
This is intended for **foreground use only**, primarily to synchronously save
user inputs in case we need it for server-specific services (e.g. generating a
suggestion) or in case we want to ensure that the data is saved before the app
is uninstalled.

Since it is used in the foreground, users can be interactively notified if the
save failed.

In order to reduce abuse for sending background sensed data, this can accept one entry at a time.

For client integrators, as you can see, this is similar to `/profile/update`, but the data is under `the_entry` instead of `update_doc`

Testing done:

We have 76 entries

```
In [16]: edb.get_usercache_db().find({"metadata.key": "manual/mode_confirm"}).count()
Out[16]: 76
```

We save one more

```
In [17]: test_input = {
    ...:   "user": "test_mode_purpose",
    ...:   "the_entry" : {
    ...:      "metadata": {"key": "manual/mode_confirm", "write_ts": 12345678, "type": "
    ...: message"},
    ...:      "data": {"start_ts": 1234, "end_ts": 5678, "label": "pogo_sticking"}
    ...:   }
    ...: }

In [18]: requests.post("http://localhost:8080/usercache/putone", data=json.dumps(test_in
    ...: put), headers=headers)
Out[18]: <Response [200]>
```

```
START 2019-05-08 19:17:35.633951 POST /usercache/putone
END 2019-05-08 19:17:35.649836 POST /usercache/putone 49e72fc4-f1d8-4f4d-9666-57dc597d1133 0.015433073043823242
```

We now have 77 entries

```
In [19]: edb.get_usercache_db().find({"metadata.key": "manual/mode_confirm"}).count()
Out[19]: 77
```

and the new one is the right one

```
In [20]: edb.get_usercache_db().find({"metadata.key": "manual/mode_confirm", "data.label
    ...: ": "pogo_sticking"}).count()
Out[20]: 1

In [21]: edb.get_usercache_db().find_one({"metadata.key": "manual/mode_confirm", "data.l
    ...: abel": "pogo_sticking"})
Out[21]:
{'_id': ObjectId('5cd38dbfbe04ee70f576335d'),
 'data': {'end_ts': 5678, 'label': 'pogo_sticking', 'start_ts': 1234},
 'metadata': {'key': 'manual/mode_confirm',
  'type': 'message',
  'write_ts': 12345678},
 'user_id': UUID('49e72fc4-f1d8-4f4d-9666-57dc597d1133')}
```

This also fixes https://github.com/e-mission/e-mission-docs/issues/351 in a
more principled way.