### PR TITLE
Very minor change

### DIFF
--- a/emission/storage/decorations/trip_queries.py
+++ b/emission/storage/decorations/trip_queries.py
@@ -106,4 +106,4 @@ def get_user_input_from_cache_series(user_id, trip_obj, user_input_key):
     most_recent_entry = potential_candidates[-1]
     logging.debug("most recent entry has id %s" % most_recent_entry["_id"])
     logging.debug("and is mapped to entry %s" % most_recent_entry)
-    return most_recent_entry
+    return ecwe.Entry(most_recent_entry)

--- a/emission/tests/storageTests/TestTripQueries.py
+++ b/emission/tests/storageTests/TestTripQueries.py
@@ -140,7 +140,7 @@ class TestTripQueries(unittest.TestCase):
 
         # WHen there is only one input, it is roller_blading
         self.assertEqual(new_mce, user_input)
-        self.assertEqual(ecwe.Entry(user_input).data.label, 'roller_blading')
+        self.assertEqual(user_input.data.label, 'roller_blading')
 
         new_mc["label"] = 'pogo_sticking'
 
@@ -153,7 +153,7 @@ class TestTripQueries(unittest.TestCase):
 
         # When it is overridden, it is pogo sticking
         self.assertEqual(new_mce, user_input)
-        self.assertEqual(ecwe.Entry(user_input).data.label, 'pogo_sticking')
+        self.assertEqual(user_input.data.label, 'pogo_sticking')
 
 
     def testUserInputForTripTwoInput(self):


### PR DESCRIPTION
- Return an Entry from the newly added method (added in
  5ef5868cd382576e5d1afc0a8f528e2021f25af1) to be consistent with the existing
  timeseries based method

Testing done:
- Updated the two new tests in TestTripQueries. Both pass.