### PR TITLE
Return a non-null value from the sync update method

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -242,13 +242,15 @@ def putIntoCache():
 
 @post('/usercache/putone')
 def putIntoOneEntry():
-  logging.debug("Called userCache.putone with request " % request)
+  logging.debug("Called userCache.putone with request %s" % request)
   user_uuid=getUUID(request)
   logging.debug("user_uuid %s" % user_uuid)
   the_entry = request.json['the_entry']
+  logging.debug("About to save entry %s" % the_entry)
   # sync_phone_to_server requires a list, so we wrap our one entry in the list
   from_phone = [the_entry]
-  return usercache.sync_phone_to_server(user_uuid, from_phone)
+  usercache.sync_phone_to_server(user_uuid, from_phone)
+  return {"putone": True}
 
 @post('/timeline/getTrips/<day>')
 def getTrips(day):


### PR DESCRIPTION
This is a follow-on to
01f788e464cc11efd13777b0046fa00fd1468c27

If we don't do this, then the CommunicationHelper code that expects to parse
the result fails (see below) and we get an exception.

https://github.com/e-mission/cordova-server-communication/blob/master/src/ios/BEMCommunicationHelperPlugin.m#L20

```
            NSDictionary *parsedResult = [NSJSONSerialization JSONObjectWithData:data
                                                                options:kNilOptions
                                                                  error: &parseError];

```