### PR TITLE
Minor fixes to push notifications

### DIFF
--- a/conf/net/ext_service/push.json.sample
+++ b/conf/net/ext_service/push.json.sample
@@ -1,4 +1,5 @@
 {
     "provider": "firebase",
     "server_auth_token": "Get from firebase console"
+    "app_package_name": "full package name from config.xml. e.g. edu.berkeley.eecs.emission or edu.berkeley.eecs.embase. Defaults to edu.berkeley.eecs.embase"
 }

--- a/emission/net/ext_service/push/notify_interface_impl/firebase.py
+++ b/emission/net/ext_service/push/notify_interface_impl/firebase.py
@@ -8,6 +8,7 @@ from builtins import *
 import logging
 import requests
 import copy
+import time
 
 # Our imports
 import emission.core.get_database as edb
@@ -21,6 +22,11 @@ def get_interface(push_config):
 class FirebasePush(pni.NotifyInterface):
     def __init__(self, push_config):
         self.server_auth_token = push_config["server_auth_token"]
+        if "app_package_name" in push_config:
+            self.app_package_name = push_config["app_package_name"]
+        else:
+            logging.warning("No package name specified, defaulting to embase")
+            self.app_package_name = "edu.berkeley.eecs.embase"
 
     def get_and_invalidate_entries(self):
         # Need to figure out how to do this on firebase
@@ -60,7 +66,7 @@ class FirebasePush(pni.NotifyInterface):
         importHeaders = {"Authorization": "key=%s" % self.server_auth_token,
                          "Content-Type": "application/json"}
         importMessage = {
-            "application": "edu.berkeley.eecs.emission",
+            "application": self.app_package_name,
             "sandbox": dev,
             "apns_tokens":token_list
         }
@@ -140,9 +146,12 @@ class FirebasePush(pni.NotifyInterface):
         # convert tokens if necessary
         fcm_token_map = self.convert_to_fcm_if_necessary(token_map, dev)
 
-        response = push_service.notify_multiple_devices(registration_ids=fcm_token_list,
+        response = {}
+        response["ios"] = push_service.notify_multiple_devices(registration_ids=fcm_token_map["ios"],
                                                    data_message=ios_raw_data,
                                                    content_available=True)
+        response["android"] = {"success": "skipped", "failure": "skipped",
+                               "results": "skipped"}
         logging.debug(response)
         return response
 


### PR DESCRIPTION
- Make the package name configurable so that it works with apps other than
  emission. This fixes https://github.com/e-mission/e-mission-docs/issues/373
- Makes the iOS silent push consistent with the visible push notifications wrt
  return type

Testing done: Generated iOS silent push notifications. Output

```
DEBUG:root:{'ios': {'multicast_ids': [6201858508613677751], 'success': 4, 'failure': 0, 'canonical_ids': 0, 'results': [{'message_id': '1560234116610162'}, {'message_id': '1560234116609706'}, {'message_id': '1560234116609705'}, {'message_id': '1560234116609608'}], 'topic_message_id': None}, 'android': {'success': 'skipped', 'failure': 'skipped', 'results': 'skipped'}}
DEBUG:root:module_name = emission.net.ext_service.push.notify_interface_impl.firebase
DEBUG:root:module = <module 'emission.net.ext_service.push.notify_interface_impl.firebase' from '/Users/shankari/e-mission/e-mission-server/emission/net/ext_service/push/notify_interface_impl/firebase.py'>
DEBUG:root:interface_obj_fn = <function get_interface at 0x10ba4ad90>
WARNING:root:No package name specified, defaulting to embase
DEBUG:root:interface_obj = <emission.net.ext_service.push.notify_interface_impl.firebase.FirebasePush object at 0x10a328da0>
DEBUG:root:interface_obj = <emission.net.ext_service.push.notify_interface_impl.firebase.FirebasePush object at 0x10a328da0>
DEBUG:root:firebase push result for ios: success 4 failure 0 results [{'message_id': '1560234116610162'}, {'message_id': '1560234116609706'}, {'message_id': '1560234116609705'}, {'message_id': '1560234116609608'}]
DEBUG:root:firebase push result for android: success skipped failure skipped results skipped
```