### PR TITLE
Add config options to control more asserts

### DIFF
--- a/conf/analysis/debug.conf.json.sample
+++ b/conf/analysis/debug.conf.json.sample
@@ -1,7 +1,11 @@
 {
+    "intake.segmentation.section_segmentation.sectionValidityAssertions": true,
     "intake.cleaning.clean_and_resample.speedDistanceAssertions": true,
+    "intake.cleaning.clean_and_resample.sectionValidityAssertions": true,
     "intake.cleaning.filter_accuracy.enable": false,
     "classification.inference.mode.useAdvancedFeatureIndices": true,
     "classification.inference.mode.useBusTrainFeatureIndices": true,
+    "classification.validityAssertions": true,
+    "output.conversion.validityAssertions": true,
     "analysis.result.section.key": "analysis/inferred_section"
 }

--- a/emission/analysis/classification/inference/mode/pipeline.py
+++ b/emission/analysis/classification/inference/mode/pipeline.py
@@ -129,8 +129,11 @@ class ModeInferencePipeline:
         time_query=timerange)
     if (len(self.toPredictSections) == 0):
         logging.debug("len(toPredictSections) == 0, early return")
-        assert self.last_section_done is None, ("self.last_section_done == %s, expecting None" % \
-            self.last_section_done)
+        if self.last_section_done is not None:
+            logging.error("self.last_section_done == %s, expecting None" %
+                self.last_section_done)
+            if eac.get_config()["classification.validityAssertions"]:
+                assert False
         return None
 
     self.loadModelStage()

--- a/emission/analysis/intake/cleaning/clean_and_resample.py
+++ b/emission/analysis/intake/cleaning/clean_and_resample.py
@@ -583,9 +583,10 @@ def _add_start_point(filtered_loc_df, raw_start_place, ts):
                 ts.get_entry_from_id(esda.RAW_TRIP_KEY,
                                      raw_start_place.data.ending_trip))
             if ending_trip_entry is None or ending_trip_entry.metadata.key != "segmentation/raw_untracked":
-                logging.debug("place %s has zero duration but is after %s!" % 
+                logging.error("place %s has zero duration but is after %s!" %
                              (raw_start_place.get_id(), ending_trip_entry))
-                assert False
+                if eac.get_config()["intake.segmentation.section_segmentation.sectionValidityAssertions"]:
+                    assert False
             else:
                 logging.debug("place %s is after untracked_time %s, has zero duration!" %
                              (raw_start_place.get_id(), ending_trip_entry.get_id()))
@@ -633,7 +634,11 @@ def _add_end_point(filtered_loc_df, raw_end_place, ts):
     # to extrapolate to the place
 
     # because the enter_ts is None
-    assert(raw_end_place.data.enter_ts is not None)
+    if raw_end_place.data.enter_ts is None:
+        logging.error("raw_end_place.data.enter_ts == None, should not have to extrapolate")
+        if eac.get_config()["intake.cleaning.clean_and_resample.sectionValidityAssertions"]:
+            assert False
+
     logging.debug("Found mismatch of %s in last section %s -> %s, "
                    "appending location %s, %s, %s to fill the gap" %
                   (add_dist, curr_last_loc.coordinates, raw_end_place_enter_loc_entry.data.loc.coordinates,
@@ -1102,7 +1107,10 @@ def _fix_squished_place_mismatch(user_id, trip_id, ts, cleaned_trip_data, cleane
         logging.debug("section counts = %s" % list(zip(related_sections, section_counts)))
         # This code should work even if this assert is removed
         # but this is the expectation we have based on the use cases we have seen so far
-        assert(min(section_counts) == 1)
+        if min(section_counts) != 1:
+            logging.error("Section counts = %s, expecting 1" % section_counts)
+            if eac.get_config()["intake.cleaning.clean_and_resample.sectionValidityAssertions"]:
+                assert False
        
         # the most common section is the one at the same index as the max
         # count. This is the valid section

--- a/emission/analysis/plotting/geojson/geojson_feature_converter.py
+++ b/emission/analysis/plotting/geojson/geojson_feature_converter.py
@@ -131,7 +131,8 @@ def section_to_geojson(section, tl):
                                       digits=4):
             logging.info("section_location_array[-1].data.loc %s != section.data.end_loc %s even after df.ts fix, filling gap" % \
                     (section_location_entries[-1].data.loc, section.data.end_loc))
-            assert(False)
+            if eac.get_config()["output.conversion.validityAssertions"]:
+                assert(False)
             last_loc_doc = ts.get_entry_at_ts("background/filtered_location", "data.ts", section.data.end_ts)
             if last_loc_doc is None:
                 logging.warning("can't find entry to patch gap, leaving gap")

--- a/emission/analysis/point_features.py
+++ b/emission/analysis/point_features.py
@@ -41,8 +41,8 @@ def calSpeed(point1, point2):
             # Distance between points ... 59.8499494256
             # happens fairly frequently actually
             # https://github.com/e-mission/e-mission-server/issues/407#issuecomment-248974661
-            # logging.debug("Distance between points %s, %s is %s, although the time delta = 0" %
-            #     (point1, point2, distanceDelta))
+            logging.warning("Distance between points %s, %s is %s, although the time delta = 0" %
+                (point1, point2, distanceDelta))
             pass
             # assert(distanceDelta < 0.01)
         return 0


### PR DESCRIPTION
While developing the pipeline, I added several asserts to flag "issues that
need to be investigated" while retaining fallbacks so that we could comment out
the assertions if there was no time to investigate.

As other groups start using this, they don't have the energy and skill to
invesigate issues, and I certainly don't have the energy to investigate every
single one of them.

Let's add the ability to ignore these asserts in production, replacing them by
log errors instead.

I have not added config options for the zig-zag detection asserts since we have
not encountered them so far, but everything else should be covered.

Testing done:

without this change, ran into the error reported in
https://github.com/e-mission/e-mission-server/pull/709#issuecomment-518142916

After setting `output.conversion.validityAssertions` to false, I get

```
(emission) C02KT61MFFT0:e-mission-server shankari$ ./e-mission-py.bash bin/debug/intake_single_user.py -e test-subway-tram
Connecting to database URL localhost
google maps key not configured, falling back to nominatim
transit stops query not configured, falling back to default
2019-08-05T14:44:58.147111-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: moving to long term**********
2019-08-05T14:44:58.178816-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: filter accuracy if needed**********
2019-08-05T14:44:58.190401-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: segmenting into trips**********
2019-08-05T14:45:09.418732-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: segmenting into sections**********
/Users/shankari/e-mission/e-mission-server/emission/analysis/intake/segmentation/section_segmentation_methods/flip_flop_detection.py:58: RuntimeWarning: invalid value encountered in double_scalars
  sm.update({"trip_pct": (curr_section_time * 100)/total_trip_time})
2019-08-05T14:45:11.659074-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: smoothing sections**********
/Users/shankari/OSS/anaconda/envs/emission/lib/python3.6/site-packages/pandas/core/frame.py:891: UserWarning: DataFrame columns are not unique, some columns will be omitted.
  "columns will be omitted.", UserWarning)
2019-08-05T14:45:12.473511-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: cleaning and resampling timeline**********
2019-08-05T14:45:25.036210-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: inferring transportation mode**********
2019-08-05T14:46:09.598051-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: checking active mode trips to autocheck habits**********
2019-08-05T14:46:09.601302-07:00**********UUID 0f1e49b9-c928-43d5-a079-70be130d4a94: storing views to cache**********
```