### PR TITLE
Add config options to control more asserts

### DIFF
--- a/emission/analysis/classification/inference/mode/rule_engine.py
+++ b/emission/analysis/classification/inference/mode/rule_engine.py
@@ -45,8 +45,11 @@ class RuleEngineModeInferencePipeline:
             time_query=timerange)
         if (len(self.toPredictSections) == 0):
             logging.debug("len(toPredictSections) == 0, early return")
-            assert self.last_section_done is None, ("self.last_section_done == %s, expecting None" % \
-                self.last_section_done)
+            if self.last_section_done is not None:
+                logging.error("self.last_section_done == %s, expecting None" %
+                    self.last_section_done)
+                if eac.get_config()["classification.validityAssertions"]:
+                    assert False
             return None
     
         self.predictedProb = self.predictModesStep()
@@ -211,8 +214,10 @@ def collapse_modes(section_entry, modes):
     if len(unique_modes) == 1:
         return unique_modes[0]
 
-    assert sorted(unique_modes) == ['BUS', 'TRAIN'],\
-        "unique_modes = %s, but we support only two, [BUS, TRAIN]" % sorted(unique_modes)
+    if sorted(unique_modes) != ['BUS', 'TRAIN']:
+        logging.error("unique_modes = %s, but we support only two, [BUS, TRAIN]" % sorted(unique_modes))
+        if eac.get_config()["classification.validityAssertions"]:
+            assert False
    
     # could be either bus or train. Let's use the speed to decide
     # local bus speeds are pretty close to bike, which is why it is hard to

--- a/emission/analysis/intake/segmentation/section_segmentation_methods/flip_flop_detection.py
+++ b/emission/analysis/intake/segmentation/section_segmentation_methods/flip_flop_detection.py
@@ -8,6 +8,7 @@ import emission.core.common as ecc
 
 import emission.analysis.intake.cleaning.location_smoothing as eaicl
 import emission.analysis.intake.domain_assumptions as eaid
+import emission.analysis.config as eac
 
 @enum.unique
 class Direction(enum.Enum):
@@ -191,8 +192,11 @@ class FlipFlopDetection():
         the travel will be long enough that we will get at least a couple of
         activity points. It's not worth it otherwise
         """
-        assert (streak_start == streak_end) or (streak_start + 1 == streak_end), \
-            "1 flip check called with streak %d -> %d" % (streak_start, streak_end)
+        if not ((streak_start == streak_end) or (streak_start + 1 == streak_end)):
+            logging.error("1 flip check called with streak %d -> %d" % (streak_start, streak_end))
+            if eac.get_config()["intake.segmentation.section_segmentation.sectionValidityAssertions"]:
+                assert False
+
         start_change = self.motion_changes[streak_start]
         if not eaid.is_walking_type(start_change[0].type):
             logging.debug("single transition %s, not WALKING, merging" % start_change[0].type)
@@ -202,8 +206,11 @@ class FlipFlopDetection():
         return MergeResult.NONE()
 
     def check_no_location_walk(self, streak_start, streak_end):
-        assert (streak_start == streak_end) or (streak_start + 1 == streak_end), \
-            "1 flip check called with streak %d -> %d" % (streak_start, streak_end)
+        if not ((streak_start == streak_end) or (streak_start + 1 == streak_end)):
+            logging.error("1 flip check called with streak %d -> %d" % (streak_start, streak_end))
+            if eac.get_config()["intake.segmentation.section_segmentation.sectionValidityAssertions"]:
+                assert False
+
         ssm, sem = self.motion_changes[streak_start]
         streak_locs = self.seg_method.filter_points_for_range(
             self.seg_method.location_points, ssm, sem)


### PR DESCRIPTION
This is an analog to https://github.com/e-mission/e-mission-server/pull/711
(https://github.com/e-mission/e-mission-server/pull/711/commits/a2acdfbf9c44953ab5390667572abc52350af68f) but for the files that are specific to the gis pipeline code

While developing the pipeline, I added several asserts to flag "issues that
need to be investigated" while retaining fallbacks so that we could comment out
the assertions if there was no time to investigate.

As other groups start using this, they don't have the energy and skill to
invesigate issues, and I certainly don't have the energy to investigate every
single one of them.

Let's add the ability to ignore these asserts in production, replacing them by
log errors instead.

I have not added config options for the zig-zag detection asserts since we have
not encountered them so far, but everything else should be covered.