### PR TITLE
Add scripts to setup and teardown the miniconda version

### DIFF
--- a/.github/workflows/test-with-docker.yml
+++ b/.github/workflows/test-with-docker.yml
@@ -9,6 +9,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '5 4 * * 0'
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,7 @@ language: generic
 install:
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  - wget https://repo.continuum.io/miniconda/Miniconda3-4.5.12-Linux-x86_64.sh -O miniconda.sh;
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - source "$HOME/miniconda/etc/profile.d/conda.sh"
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  # Useful for debugging any issues with conda
-  - conda info -a
+  - source setup/setup_conda.sh
 services:
   - mongodb
 script:

--- a/setup/checks/check_for_conda.sh
+++ b/setup/checks/check_for_conda.sh
@@ -1,0 +1,10 @@
+CURR_CONDA_VER=`conda --version | cut -d " " -f 2`
+EXP_CONDA_VER=4.5.12
+
+if [ $CURR_CONDA_VER == $EXP_CONDA_VER ]; then
+    echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, all is good!"
+else
+    echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, run setup/setup_conda.sh to get the correct version"
+    exit 1
+fi
+

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -5,15 +5,7 @@
 # - on OSX: /Users/<user>/miniconda3/bin/conda
 # - on Windows: C:/Users/<user>/Miniconda3/Scripts/conda
 
-CURR_CONDA_VER=`conda --version | cut -d " " -f 2`
-EXP_CONDA_VER=4.5.12
-
-if [ $CURR_CONDA_VER == $EXP_CONDA_VER ]; then
-    echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, all is good!"
-else
-    echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, run setup/setup_conda.sh to get the correct version"
-    exit 1
-fi
+source setup/checks/check_for_conda.sh
 
 echo "Setting up blank environment"
 conda create --name emission python=3.6

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,10 +1,19 @@
-
 # If the conda binary is not found, specify the full path to it
 # you can find it by searching for "conda" under the miniconda3 directory
 # typical paths are:
 # - on linux: /home/<user>/miniconda3/bin/conda
 # - on OSX: /Users/<user>/miniconda3/bin/conda
 # - on Windows: C:/Users/<user>/Miniconda3/Scripts/conda
+
+CURR_CONDA_VER=`conda --version | cut -d " " -f 2`
+EXP_CONDA_VER=4.5.12
+
+if [ $CURR_CONDA_VER == $EXP_CONDA_VER ]; then
+    echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, all is good!"
+else
+    echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, run setup/setup_conda.sh to get the correct version"
+    exit 1
+fi
 
 echo "Setting up blank environment"
 conda create --name emission python=3.6

--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -1,0 +1,9 @@
+EXP_CONDA_VER=4.5.12
+
+wget https://repo.continuum.io/miniconda/Miniconda3-$EXP_CONDA_VER-Linux-x86_64.sh -O miniconda.sh;
+bash miniconda.sh -b -p $HOME/miniconda
+source "$HOME/miniconda/etc/profile.d/conda.sh"
+hash -r
+conda config --set always_yes yes --set changeps1 no
+# Useful for debugging any issues with conda
+conda info -a

--- a/setup/setup_nomkl.sh
+++ b/setup/setup_nomkl.sh
@@ -5,6 +5,8 @@
 # - on OSX: /Users/<user>/miniconda3/bin/conda
 # - on Windows: C:/Users/<user>/Miniconda3/Scripts/conda
 
+source setup/checks/check_for_conda.sh
+
 echo "Setting up blank environment"
 conda create --name emission python=3.6
 conda activate emission

--- a/setup/setup_notebook.sh
+++ b/setup/setup_notebook.sh
@@ -5,6 +5,8 @@
 # - on OSX: /Users/<user>/miniconda3/bin/conda
 # - on Windows: C:/Users/<user>/Miniconda3/Scripts/conda
 
+source setup/checks/check_for_conda.sh
+
 echo "Setting up blank environment"
 conda create --name emission python=3.6
 conda activate emission

--- a/setup/setup_tests.sh
+++ b/setup/setup_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash 
 
+source setup/checks/check_for_conda.sh
+
 echo "Setting up blank environment"
 conda create --name emissiontest python=3.6
 if [ ${CI} == "true" ] ; then

--- a/setup/teardown_conda.sh
+++ b/setup/teardown_conda.sh
@@ -1,0 +1,1 @@
+rm -rf $HOME/miniconda


### PR DESCRIPTION
+ schedule tests periodically

This should avoid weird issues caused by bitrotted miniconda versions similar to
https://github.com/e-mission/e-mission-docs/issues/511
or
https://github.com/e-mission/e-mission-docs/issues/513

If such bitrotting happens, we need to upgrade the packages, but at least we will know that we need to, and people won't have unpleasant surprises when they try to install manually. Apparently, some people prefer to install manually
https://github.com/e-mission/e-mission-docs/issues/513
