### PR TITLE
Add github tests with the manual install as well

### DIFF
--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -43,6 +43,12 @@ jobs:
         source setup/setup_conda.sh
         which conda
 
+    - name: Check whether the CI environment variable is set
+      shell: bash -l {0}
+      run: |
+        source "$HOME/miniconda/etc/profile.d/conda.sh"
+        echo $CI
+
     - name: Setup the emission environment for testing
       shell: bash -l {0}
       run: |
@@ -50,7 +56,7 @@ jobs:
         which conda
         source "$HOME/miniconda/etc/profile.d/conda.sh"
         conda --version
-        source setup/setup.sh
+        source setup/setup_tests.sh
 
     - name: Switch to emission and run the tests
       shell: bash -l {0}

--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -1,0 +1,52 @@
+# This is a basic workflow to help you get started with Actions
+
+name: osx-ubuntu-build-android
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '5 4 * * 0'
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    - name: Install and start MongoDB
+      uses: supercharge/mongodb-github-action@1.3.0
+      with:
+        mongodb-version: 3.4
+
+    - name: Install miniconda
+      shell: bash -l {0}
+      run: source setup/setup_conda.sh
+
+    - name: Setup the emission environment for testing
+      shell: bash -l {0}
+      run: source setup/setup.sh
+
+    - name: Switch to emission and run the tests
+      shell: bash -l {0}
+      run: |
+        source activate emission
+        ./runAllTests.sh
+
+    - name: Teardown the test environment
+      shell: bash -l {0}
+      run: source setup/teardown_tests.sh

--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -33,17 +33,30 @@ jobs:
       with:
         mongodb-version: 3.4
 
+    - name: Check existing version of miniconda
+      shell: bash -l {0}
+      run: conda info -a
+
     - name: Install miniconda
       shell: bash -l {0}
-      run: source setup/setup_conda.sh
+      run: |
+        source setup/setup_conda.sh
+        which conda
 
     - name: Setup the emission environment for testing
       shell: bash -l {0}
-      run: source setup/setup.sh
+      run: |
+        conda --version
+        which conda
+        source "$HOME/miniconda/etc/profile.d/conda.sh"
+        conda --version
+        source setup/setup.sh
 
     - name: Switch to emission and run the tests
       shell: bash -l {0}
       run: |
+        source "$HOME/miniconda/etc/profile.d/conda.sh"
+        conda --version
         source activate emission
         ./runAllTests.sh
 

--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         source "$HOME/miniconda/etc/profile.d/conda.sh"
         conda --version
-        source activate emission
+        conda activate emission
         ./runAllTests.sh
 
     - name: Teardown the test environment

--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -1,6 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
-name: osx-ubuntu-build-android
+name: test-with-manual-install
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -63,7 +63,7 @@ jobs:
       run: |
         source "$HOME/miniconda/etc/profile.d/conda.sh"
         conda --version
-        conda activate emission
+        conda activate emissiontest
         ./runAllTests.sh
 
     - name: Teardown the test environment

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ backend server - the phone apps are available in the [e-mission-phone
 repo](https://github.com/amplab/e-mission-phone)
 
 The current build status is:
-[![Build Status](https://travis-ci.org/shankari/e-mission-server.svg?branch=master)](https://travis-ci.org/shankari/e-mission-server) ![test-with-docker](https://github.com/e-mission/e-mission-server/workflows/test-with-docker/badge.svg)
+[![Build Status](https://travis-ci.org/shankari/e-mission-server.svg?branch=master)](https://travis-ci.org/shankari/e-mission-server) ![test-with-docker](https://github.com/e-mission/e-mission-server/workflows/test-with-docker/badge.svg) ![test-with-manual-install](https://github.com/e-mission/e-mission-server/workflows/test-with-manual-install/badge.svg)
 
 **Issues:** Since this repository is part of a larger project, all issues are tracked [in the central docs repository](https://github.com/e-mission/e-mission-docs/issues). If you have a question, [as suggested by the open source guide](https://opensource.guide/how-to-contribute/#communicating-effectively), please file an issue instead of sending an email. Since issues are public, other contributors can try to answer the question and benefit from the answer.
 


### PR DESCRIPTION
This is very similar to the travis.yml, but it is in Github actions, so it can
run on all PRs to the repo, not just mine.
Also includes a weekly scheduled run + runs on various ubuntu OSes to catch any
bitrotting similar to

https://github.com/e-mission/e-mission-docs/issues/511
or
https://github.com/e-mission/e-mission-docs/issues/513