### PR TITLE
Multiple fixes to get conda setup working in more environments

### DIFF
--- a/.github/workflows/osx-ubuntu-manual-install.yml
+++ b/.github/workflows/osx-ubuntu-manual-install.yml
@@ -39,7 +39,10 @@ jobs:
       shell: bash -l {0}
       run: |
         source setup/setup_conda.sh ${{ matrix.PLATFORM }}
+        echo "About to see where conda is"
         which conda
+        echo "Finished conda location check, forcing success code"
+        exit 0
 
     - name: Check whether the CI environment variable is set
       shell: bash -l {0}

--- a/.github/workflows/osx-ubuntu-manual-install.yml
+++ b/.github/workflows/osx-ubuntu-manual-install.yml
@@ -35,10 +35,6 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Check existing version of miniconda
-      shell: bash -l {0}
-      run: conda info -a
-
     - name: Install miniconda
       shell: bash -l {0}
       run: |

--- a/.github/workflows/osx-ubuntu-manual-install.yml
+++ b/.github/workflows/osx-ubuntu-manual-install.yml
@@ -1,6 +1,4 @@
-# This is a basic workflow to help you get started with Actions
-
-name: ubuntu-only-test-with-manual-install
+name: osx-ubuntu-manual-install
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
@@ -21,17 +19,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest, macos-latest]
+        include:
+        - os: macos-latest
+          PLATFORM: MacOSX-x86_64
+        - os: ubuntu-16.04
+          PLATFORM: Linux-x86_64
+        - os: ubuntu-18.04
+          PLATFORM: Linux-x86_64
+        - os: ubuntu-latest
+          PLATFORM: Linux-x86_64
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-
-    - name: Install and start MongoDB
-      uses: supercharge/mongodb-github-action@1.3.0
-      with:
-        mongodb-version: 3.4
 
     - name: Check existing version of miniconda
       shell: bash -l {0}
@@ -40,7 +42,7 @@ jobs:
     - name: Install miniconda
       shell: bash -l {0}
       run: |
-        source setup/setup_conda.sh Linux-x86_64
+        source setup/setup_conda.sh ${{ matrix.PLATFORM }}
         which conda
 
     - name: Check whether the CI environment variable is set
@@ -49,23 +51,17 @@ jobs:
         source "$HOME/miniconda/etc/profile.d/conda.sh"
         echo $CI
 
-    - name: Setup the emission environment for testing
+    - name: Setup the emission environment
       shell: bash -l {0}
       run: |
         conda --version
         which conda
         source "$HOME/miniconda/etc/profile.d/conda.sh"
         conda --version
-        source setup/setup_tests.sh
+        source setup/setup.sh
 
-    - name: Switch to emission and run the tests
+    - name: Teardown the emission environment
       shell: bash -l {0}
       run: |
         source "$HOME/miniconda/etc/profile.d/conda.sh"
-        conda --version
-        conda activate emissiontest
-        ./runAllTests.sh
-
-    - name: Teardown the test environment
-      shell: bash -l {0}
-      run: source setup/teardown_tests.sh
+        source setup/teardown.sh

--- a/.github/workflows/osx-ubuntu-manual-install.yml
+++ b/.github/workflows/osx-ubuntu-manual-install.yml
@@ -39,10 +39,14 @@ jobs:
       shell: bash -l {0}
       run: |
         source setup/setup_conda.sh ${{ matrix.PLATFORM }}
-        echo "About to see where conda is"
-        which conda
-        echo "Finished conda location check, forcing success code"
-        exit 0
+        if [ ${{ matrix.PLATFORM }} == "Linux-x86_64" ]; then
+            echo "Linux install, going to check conda path"
+            which conda
+        else
+            echo "OSX install, skipping conda path check"
+            echo "    since 'which conda' inexplicably returns with status code 1"
+            echo "    only in the CI environment"
+        fi
 
     - name: Check whether the CI environment variable is set
       shell: bash -l {0}

--- a/.github/workflows/osx-ubuntu-manual-install.yml
+++ b/.github/workflows/osx-ubuntu-manual-install.yml
@@ -62,7 +62,9 @@ jobs:
         source "$HOME/miniconda/etc/profile.d/conda.sh"
         conda --version
         source setup/setup.sh
+        echo "About to activate environment"
         conda activate emission
+        conda env list
 
     - name: Teardown the emission environment
       shell: bash -l {0}

--- a/.github/workflows/osx-ubuntu-manual-install.yml
+++ b/.github/workflows/osx-ubuntu-manual-install.yml
@@ -62,6 +62,7 @@ jobs:
         source "$HOME/miniconda/etc/profile.d/conda.sh"
         conda --version
         source setup/setup.sh
+        conda activate emission
 
     - name: Teardown the emission environment
       shell: bash -l {0}

--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -21,7 +21,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest, macos-latest]
+        include:
+        - os: macos-latest
+          PLATFORM: MacOSX-x86_64
+        - os: ubuntu-16.04
+          PLATFORM: Linux-x86_64
+        - os: ubuntu-18.04
+          PLATFORM: Linux-x86_64
+        - os: ubuntu-latest
+          PLATFORM: Linux-x86_64
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -40,7 +49,7 @@ jobs:
     - name: Install miniconda
       shell: bash -l {0}
       run: |
-        source setup/setup_conda.sh
+        source setup/setup_conda.sh ${{ matrix.PLATFORM }}
         which conda
 
     - name: Check whether the CI environment variable is set

--- a/setup/checks/check_for_conda.sh
+++ b/setup/checks/check_for_conda.sh
@@ -4,7 +4,7 @@ EXP_CONDA_VER=4.5.12
 if [ $CURR_CONDA_VER == $EXP_CONDA_VER ]; then
     echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, all is good!"
 else
-    echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, run setup/setup_conda.sh to get the correct version"
-    exit 1
+    echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, run 'bash setup/setup_conda.sh' to get the correct version"
+    # exit 1
 fi
 

--- a/setup/checks/check_for_conda.sh
+++ b/setup/checks/check_for_conda.sh
@@ -5,6 +5,5 @@ if [ $CURR_CONDA_VER == $EXP_CONDA_VER ]; then
     echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, all is good!"
 else
     echo "For conda, found $CURR_CONDA_VER, expected $EXP_CONDA_VER, run 'bash setup/setup_conda.sh' to get the correct version"
-    # exit 1
 fi
 

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -9,7 +9,7 @@ source setup/checks/check_for_conda.sh
 
 echo "Setting up blank environment"
 conda create --name emission python=3.6
-source activate emission
+conda activate emission
 
 echo "Downloading packages"
 curl -o /tmp/cachetools-2.1.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/cachetools/2.1.0/download/noarch/cachetools-2.1.0-py_0.tar.bz2

--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -1,9 +1,18 @@
 EXP_CONDA_VER=4.5.12
 
-wget https://repo.continuum.io/miniconda/Miniconda3-$EXP_CONDA_VER-Linux-x86_64.sh -O miniconda.sh;
-bash miniconda.sh -b -p $HOME/miniconda
-source "$HOME/miniconda/etc/profile.d/conda.sh"
-hash -r
-conda config --set always_yes yes --set changeps1 no
-# Useful for debugging any issues with conda
-conda info -a
+PLATFORM=$1
+echo "Installing for platform $PLATFORM"
+
+if [ -z $PLATFORM ]; then
+    echo "Usage: setup_conda.sh <platform>"
+    echo "   Platform options are Linux-x86_64, MacOSX-x86_64"
+    echo "   For Windows, manually download and install https://repo.anaconda.com/miniconda/Miniconda3-$EXP_CONDA_VER-Windows-x86_64.exe"
+else
+    curl -o miniconda.sh -L https://repo.continuum.io/miniconda/Miniconda3-$EXP_CONDA_VER-$PLATFORM.sh;
+    bash miniconda.sh -b -p $HOME/miniconda
+    source "$HOME/miniconda/etc/profile.d/conda.sh"
+    hash -r
+    conda config --set always_yes yes --set changeps1 no
+    # Useful for debugging any issues with conda
+    conda info -a
+fi

--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -2,6 +2,7 @@ EXP_CONDA_VER=4.5.12
 
 PLATFORM=$1
 echo "Installing for platform $PLATFORM"
+echo $?
 
 if [ -z $PLATFORM ]; then
     echo "Usage: setup_conda.sh <platform>"
@@ -9,10 +10,16 @@ if [ -z $PLATFORM ]; then
     echo "   For Windows, manually download and install https://repo.anaconda.com/miniconda/Miniconda3-$EXP_CONDA_VER-Windows-x86_64.exe"
 else
     curl -o miniconda.sh -L https://repo.continuum.io/miniconda/Miniconda3-$EXP_CONDA_VER-$PLATFORM.sh;
+    echo $?
     bash miniconda.sh -b -p $HOME/miniconda
+    echo $?
     source "$HOME/miniconda/etc/profile.d/conda.sh"
+    echo $?
     hash -r
+    echo $?
     conda config --set always_yes yes --set changeps1 no
+    echo $?
     # Useful for debugging any issues with conda
     conda info -a
+    echo $?
 fi

--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -2,7 +2,6 @@ EXP_CONDA_VER=4.5.12
 
 PLATFORM=$1
 echo "Installing for platform $PLATFORM"
-echo $?
 
 if [ -z $PLATFORM ]; then
     echo "Usage: setup_conda.sh <platform>"
@@ -10,16 +9,10 @@ if [ -z $PLATFORM ]; then
     echo "   For Windows, manually download and install https://repo.anaconda.com/miniconda/Miniconda3-$EXP_CONDA_VER-Windows-x86_64.exe"
 else
     curl -o miniconda.sh -L https://repo.continuum.io/miniconda/Miniconda3-$EXP_CONDA_VER-$PLATFORM.sh;
-    echo $?
     bash miniconda.sh -b -p $HOME/miniconda
-    echo $?
     source "$HOME/miniconda/etc/profile.d/conda.sh"
-    echo $?
     hash -r
-    echo $?
     conda config --set always_yes yes --set changeps1 no
-    echo $?
     # Useful for debugging any issues with conda
     conda info -a
-    echo $?
 fi

--- a/setup/setup_tests.sh
+++ b/setup/setup_tests.sh
@@ -4,11 +4,7 @@ source setup/checks/check_for_conda.sh
 
 echo "Setting up blank environment"
 conda create --name emissiontest python=3.6
-if [ ${CI} == "true" ] ; then
-    conda activate emissiontest
-else
-    source activate emissiontest
-fi
+conda activate emissiontest
 
 echo "Downloading packages"
 curl -o /tmp/cachetools-2.1.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/cachetools/2.1.0/download/noarch/cachetools-2.1.0-py_0.tar.bz2

--- a/setup/teardown.sh
+++ b/setup/teardown.sh
@@ -1,2 +1,2 @@
-source deactivate emission
+conda deactivate emission
 conda env remove --name emission

--- a/setup/teardown_tests.sh
+++ b/setup/teardown_tests.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
 echo "Removing environment from "${CONDA_TEMP_PREFIX}
-if [ ${CI} == "true" ] ; then
-    conda deactivate
-else
-    source deactivate emissiontest
-fi
+conda deactivate
 
 conda env remove --yes --name emissiontest
 # rm conf/net/ext_service/habitica.json


### PR DESCRIPTION
My personal laptop had a version of conda even older than the docker container.
So old that it only supported `source activate` and not `conda activate`.
So we used `source activate` in the setup script and checked for the CI
variable before using it in `conda activate`.

This:
- supports `setup_conda` on multiple platforms
- upgrades all setup scripts to use `conda install`
- stops exiting from `check_for_conda` so it doesn't kill the shell
- updates the manual install test to also include osx, and to add osx to the
  list of oses that we test against
    - also pass in the platform correctly per OS so that the installation will
      happen correctly