### PR TITLE
Ensure that the localdate entries are serialized properly as well

### DIFF
--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -121,6 +121,8 @@ def fix_int64_key_if_needed(key):
         mod_keys = tuple([int(k) for k in key])
         # print("after conversion, types = %s" % str(tuple([type(k) for k in key])))
         return mod_keys
+    else:
+        return key
 
 def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
     ret_list = []

--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -99,6 +99,7 @@ def group_by_local_date(user_id, from_dt, to_dt, freq, summary_fn_list):
             "last_ts_processed": None,
             "result": [[] for i in range(len(summary_fn_list))]
         }
+
     groupby_arr = _get_local_group_by(freq)
     time_grouped_df = section_df.groupby(groupby_arr)
     local_dt_fill_fn = _get_local_key_to_fill_fn(freq)
@@ -108,11 +109,25 @@ def group_by_local_date(user_id, from_dt, to_dt, freq, summary_fn_list):
                         for summary_fn in summary_fn_list]
     }
 
+# by default, the incoming values for the keys are `numpy.int64` for reasons
+# that I don't understand. This breaks serialization
+# (https://github.com/e-mission/e-mission-docs/issues/530)
+# converting to regular ints to avoid this issue
+
+def fix_int64_key_if_needed(key):
+    if isinstance(key, tuple):
+        logging.debug("Converting %d fields from int64 to regular integer" % len(key))
+        # print("before conversion, types = %s" % str(tuple([type(k) for k in key])))
+        mod_keys = tuple([int(k) for k in key])
+        # print("after conversion, types = %s" % str(tuple([type(k) for k in key])))
+        return mod_keys
+
 def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
     ret_list = []
     # When we group by a time range, the key is the end of the range
     for key, section_group_df in time_grouped_df:
         curr_msts = ecwms.ModeStatTimeSummary()
+        key = fix_int64_key_if_needed(key)
         key_to_fill_fn(key, section_group_df, curr_msts)
         curr_msts.nUsers = len(section_group_df.user_id.unique())
         mode_grouped_df = section_group_df.groupby('sensed_mode')
@@ -123,6 +138,12 @@ def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
             else:
                 curr_msts[ecwm.MotionTypes(mode).name] = result
         ret_list.append(curr_msts)
+#         import bson.json_util as bju
+#         logging.debug("After appending %s, ret_list = %s" % (curr_msts, ret_list))
+#         for k in curr_msts.keys():
+#             print("Serializing key = %s" % k)
+#             logging.debug("Serializing key %s = %s" %
+#                 (k, bju.dumps(curr_msts[k])))
     return ret_list
 
 def _get_local_group_by(local_freq):


### PR DESCRIPTION
In 88fef81582d7706d22525d0beefcba4149441f0a, we fixed the serialization of all
the **values** returned by the pandas grouping. However, in the case of the
localdate calls, the **keys** are also `numpy.int64` types.

So we need to fix their serialization as well. We do this by casting them to
basic ints. We do this only in the case where the key is a tuple, since the key
in the timestamp case is a single value that we cannot interate over.

I am checking this in with commented out debugging statements just in case it
breaks again in the near future. These can be removed in a future checkin.

This is a regression caused by the migration to python3
(https://github.com/e-mission/e-mission-docs/issues/294)

It was not caught because it occurs during serialization, and we currently
don't have tests that make API calls to the server, as opposed to the database.
That is also why this commit doesn't include an additional test. We need to add
such tests in the future but that is beyond the scope of this change.

This fixes https://github.com/e-mission/e-mission-docs/issues/530

Testing done:

timestamp MVCE (https://github.com/e-mission/e-mission-docs/issues/530#issuecomment-623199938) continues to work

```
{'user': 'test_july_22', 'start_time': 1437548400, 'end_time': 1437634800}
{'user_metrics': [[{'ts': 1588553407, 'local_dt': {'year': 2020, 'month': 5, 'day': 4, 'hour': 0, 'minute': 50, 'second': 7, 'weekday': 0, 'timezone': 'UTC'}, 'fmt_time': '2020-05-04T00:50:07.490516+00:00', 'nUsers': 1, 'WALKING': 6295.9773474392405, 'BICYCLING': 11584.339997579958, 'CAR': 33749.95118568352}]]}
```

local date MVCE (https://github.com/e-mission/e-mission-docs/issues/530#issuecomment-623199938)

```
{'user': 'test_july_22', 'start_time': {'year': 2015, 'month': 7, 'day': 22, 'timezone': 'America/Los_Angeles'}, 'end_time': {'year': 2015, 'month': 7, 'day': 23, 'timezone': 'America/Los_Angeles'}}
{'user_metrics': [[{'ts': 1437548400, 'local_dt': {'year': 2015, 'month': 7, 'day': 22, 'timezone': 'America/Los_Angeles'}, 'fmt_time': '2015-07-22', 'nUsers': 1, 'WALKING': 6295.9773474392405, 'BICYCLING': 11584.339997579958, 'CAR': 33749.95118568352}]]}
```