### PR TITLE
Remove get_local_date from the storage code

### DIFF
--- a/bin/historical/migrations/populate_local_dt.py
+++ b/bin/historical/migrations/populate_local_dt.py
@@ -18,7 +18,7 @@ import argparse
 import json
 
 import emission.core.get_database as edb
-import emission.storage.decorations.local_date_queries as ecsdlq
+import emission.core.wrapper.localdate as ecwld
 
 # For entries in the timeseries, this is simple because all of them follow the "ts" -> "local_dt" -> "fmt_time" pattern.
 # We can just parse the fmt_time to get an arrow object and then get all the components
@@ -36,7 +36,7 @@ def get_local_date(fmt_time, timezone):
     """
     adt = arrow.get(fmt_time)
     logging.debug("after parsing, adt = %s" % adt)
-    return ecsdlq.get_local_date(adt.timestamp, timezone)
+    return ecwld.LocalDate.get_local_date(adt.timestamp, timezone)
         
 def fix_timeseries(key):
     tsdb = edb.get_timeseries_db()

--- a/emission/analysis/intake/cleaning/clean_and_resample.py
+++ b/emission/analysis/intake/cleaning/clean_and_resample.py
@@ -31,7 +31,7 @@ import emission.analysis.config as eac
 import emission.storage.decorations.timeline as esdtl
 import emission.storage.decorations.trip_queries as esdtq
 import emission.storage.decorations.analysis_timeseries_queries as esda
-import emission.storage.decorations.local_date_queries as esdl
+import emission.core.wrapper.localdate as ecwld
 import emission.storage.decorations.place_queries as esdp
 
 import emission.storage.timeseries.abstract_timeseries as esta
@@ -609,7 +609,7 @@ def _add_start_point(filtered_loc_df, raw_start_place, ts):
     logging.debug("After copy, new data = %s" % new_first_point_data)
     new_first_point_data["ts"] = new_start_ts
     tz = raw_start_place_enter_loc_entry.data.local_dt.timezone
-    new_first_point_data["local_dt"] = esdl.get_local_date(new_start_ts, tz)
+    new_first_point_data["local_dt"] = ecwld.LocalDate.get_local_date(new_start_ts, tz)
     new_first_point_data["fmt_time"] = arrow.get(new_start_ts).to(tz).isoformat()
     new_first_point = ecwe.Entry.create_entry(curr_first_point.user_id,
                             "background/filtered_location",
@@ -716,7 +716,7 @@ def _overwrite_from_loc_row(filtered_section_data, fixed_loc, prefix):
 
 def _overwrite_from_timestamp(filtered_trip_like, prefix, ts, tz, loc):
     filtered_trip_like[prefix+"_ts"] = float(ts)
-    filtered_trip_like[prefix+"_local_dt"] = esdl.get_local_date(ts, tz)
+    filtered_trip_like[prefix+"_local_dt"] = ecwld.LocalDate.get_local_date(ts, tz)
     filtered_trip_like[prefix+"_fmt_time"] = arrow.get(ts).to(tz).isoformat()
     filtered_trip_like[prefix+"_loc"] = loc
 
@@ -790,7 +790,7 @@ def resample(filtered_loc_df, interval):
     lng_new = lng_fn(ts_new)
     alt_new = altitude_fn(ts_new)
     tz_new = [_get_timezone(ts, tz_ranges_df) for ts in ts_new]
-    ld_new = [esdl.get_local_date(ts, tz) for (ts, tz) in zip(ts_new, tz_new)]
+    ld_new = [ecwld.LocalDate.get_local_date(ts, tz) for (ts, tz) in zip(ts_new, tz_new)]
     loc_new = [gj.Point((lng, lat)) for (lng, lat) in zip(lng_new, lat_new)]
     fmt_time_new = [arrow.get(ts).to(tz).isoformat() for
                         (ts, tz) in zip(ts_new, tz_new)]

--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -65,7 +65,7 @@ def group_by_timestamp(user_id, start_ts, end_ts, freq, summary_fn_list):
 def timestamp_fill_times(key, ignored, metric_summary):
     dt = arrow.get(key)
     metric_summary.ts = dt.timestamp
-    metric_summary.local_dt = esdl.get_local_date(dt.timestamp, 'UTC')
+    metric_summary.local_dt = ecwl.LocalDate.get_local_date(dt.timestamp, 'UTC')
     metric_summary.fmt_time = dt.isoformat()
 
 class LocalFreq(enum.Enum):

--- a/emission/core/wrapper/metadata.py
+++ b/emission/core/wrapper/metadata.py
@@ -32,7 +32,7 @@ class Metadata(ecwb.WrapperBase):
 
   @staticmethod
   def create_metadata_for_result(key):
-      import emission.storage.decorations.local_date_queries as esdl
+      import emission.core.wrapper.localdate as ecwld
       import arrow
 
       m = Metadata()
@@ -40,12 +40,13 @@ class Metadata(ecwb.WrapperBase):
       m.platform = "server"
       m.write_ts = time.time()
       m.time_zone = "America/Los_Angeles"
-      m.write_local_dt = esdl.get_local_date(m.write_ts, m.time_zone)
+      m.write_local_dt = ecwld.LocalDate.get_local_date(m.write_ts, m.time_zone)
       m.write_fmt_time = arrow.get(m.write_ts).to(m.time_zone).isoformat()
       return m
+
   @staticmethod
   def create_metadata_for_fake_result(key, write_ts):
-      import emission.storage.decorations.local_date_queries as esdl
+      import emission.core.wrapper.localdate as ecwld
       import arrow
 
       m = Metadata()
@@ -53,7 +54,7 @@ class Metadata(ecwb.WrapperBase):
       m.platform = "server"
       m.write_ts = write_ts
       m.time_zone = "America/Los_Angeles"
-      m.write_local_dt = esdl.get_local_date(m.write_ts, m.time_zone)
+      m.write_local_dt = ecwld.LocalDate.get_local_date(m.write_ts, m.time_zone)
       m.write_fmt_time = arrow.get(m.write_ts).to(m.time_zone).isoformat()
       return m
       

--- a/emission/integrationTests/netTests/TestHabiticaAutocheck.py
+++ b/emission/integrationTests/netTests/TestHabiticaAutocheck.py
@@ -22,8 +22,8 @@ import emission.core.get_database as edb
 import emission.core.wrapper.entry as ecwe
 import emission.core.wrapper.modeprediction as ecwm
 import emission.core.wrapper.section as ecws
+import emission.core.wrapper.localdate as ecwl
 import emission.storage.decorations.analysis_timeseries_queries as esda
-import emission.storage.decorations.local_date_queries as esdl
 import emission.storage.timeseries.abstract_timeseries as esta
 
 import emission.net.ext_service.habitica.proxy as proxy
@@ -94,7 +94,7 @@ class TestHabiticaAutocheck(unittest.TestCase):
 
   def _fillDates(self, object, prefix, ardt, timezone):
     object["%sts" % prefix] = ardt.timestamp
-    object["%slocal_dt" % prefix] = esdl.get_local_date(ardt.timestamp, timezone)
+    object["%slocal_dt" % prefix] = ecwl.LocalDate.get_local_date(ardt.timestamp, timezone)
     object["%sfmt_time" % prefix] = ardt.to(timezone).isoformat()
     #logging.debug("After filling entries, keys are %s" % object.keys())
     return object

--- a/emission/net/ext_service/otp/test_otp.py
+++ b/emission/net/ext_service/otp/test_otp.py
@@ -3,7 +3,7 @@ import random
 import datetime 
 import emission.net.ext_service.otp.otp as otp
 import emission.core.wrapper.location as ecwl
-import emission.storage.decorations.local_date_queries as ecsdlq
+import emission.core.wrapper.localdate as ecwld
 import emission.core.wrapper.user as ecwu
 import emission.storage.timeseries.cache_series as estcs
 import emission.storage.timeseries.abstract_timeseries as esta
@@ -46,7 +46,7 @@ class TestOTPMethods(unittest.TestCase):
         first_leg = legs[0]
         start_loc = otp.create_start_location_from_leg(first_leg)
         self.assertEqual(start_loc.ts,otp.otp_time_to_ours(first_leg['startTime']).timestamp )
-        self.assertEqual(start_loc.local_dt, ecsdlq.get_local_date(start_loc.ts, 'UTC'))
+        self.assertEqual(start_loc.local_dt, ecwld.LocalDate.get_local_date(start_loc.ts, 'UTC'))
         #print(start_loc)
 
     def test_create_start_location_form_trip_plan(self):

--- a/emission/net/usercache/formatters/common.py
+++ b/emission/net/usercache/formatters/common.py
@@ -9,7 +9,7 @@ import pytz
 import logging
 import arrow
 
-import emission.storage.decorations.local_date_queries as ecsdlq
+import emission.core.wrapper.localdate as ecwl
 
 def expand_metadata_times(m):
     logging.debug("write_ts = %s" % m.write_ts)
@@ -20,15 +20,15 @@ def expand_metadata_times(m):
     # The timestamp is in UTC and doesn't know the local time.
     # The fmt_time is in local time, but is a string, so query ranges are hard
     # to search for
-    m.write_local_dt = ecsdlq.get_local_date(m.write_ts, m.time_zone)
+    m.write_local_dt = ecwl.LocalDate.get_local_date(m.write_ts, m.time_zone)
     m.write_fmt_time = arrow.get(m.write_ts).to(m.time_zone).isoformat()
 
 def expand_data_times(d,m):
-    d.local_dt = ecsdlq.get_local_date(d.ts, m.time_zone)
+    d.local_dt = ecwl.LocalDate.get_local_date(d.ts, m.time_zone)
     d.fmt_time = arrow.get(d.ts).to(m.time_zone).isoformat()
 
 def expand_start_end_data_times(d,m):
-    d.start_local_dt = ecsdlq.get_local_date(d.start_ts, m.time_zone)
+    d.start_local_dt = ecwl.LocalDate.get_local_date(d.start_ts, m.time_zone)
     d.start_fmt_time = arrow.get(d.start_ts).to(m.time_zone).isoformat()
-    d.end_local_dt = ecsdlq.get_local_date(d.end_ts, m.time_zone)
+    d.end_local_dt = ecwl.LocalDate.get_local_date(d.end_ts, m.time_zone)
     d.end_fmt_time = arrow.get(d.end_ts).to(m.time_zone).isoformat()

--- a/emission/net/usercache/formatters/ios/incident.py
+++ b/emission/net/usercache/formatters/ios/incident.py
@@ -9,7 +9,7 @@ import logging
 import arrow
 
 import emission.net.usercache.formatters.common as fc
-import emission.storage.decorations.local_date_queries as ecsdlq
+import emission.core.wrapper.localdate as ecwl
 import attrdict as ad
 
 def format(entry):
@@ -26,7 +26,7 @@ def format(entry):
 
     data = entry.data
     fc.expand_data_times(data, metadata)
-    data.local_dt = ecsdlq.get_local_date(data.ts, metadata.time_zone)
+    data.local_dt = ecwl.LocalDate.get_local_date(data.ts, metadata.time_zone)
     data.fmt_time = arrow.get(data.ts).to(metadata.time_zone).isoformat()
     formatted_entry.data = data
 

--- a/emission/storage/decorations/local_date_queries.py
+++ b/emission/storage/decorations/local_date_queries.py
@@ -11,12 +11,6 @@ import arrow
 
 import emission.core.wrapper.localdate as ecwl
 
-def get_local_date(ts, timezone):
-    adt = arrow.get(ts).to(timezone)
-    return ecwl.LocalDate({'year': adt.year, 'month': adt.month, 'day': adt.day,
-    'hour': adt.hour, 'minute': adt.minute, 'second': adt.second,
-    'weekday': adt.weekday(), 'timezone': timezone})
-
 def get_range_query(field_name, start_local_dt, end_local_dt):
     if list(start_local_dt.keys()) != list(end_local_dt.keys()):
         raise RuntimeError("start_local_dt.keys() = %s does not match end_local_dt.keys() = %s" %

--- a/emission/tests/analysisTests/resultTests/TestTimeGrouping.py
+++ b/emission/tests/analysisTests/resultTests/TestTimeGrouping.py
@@ -29,7 +29,6 @@ import emission.core.wrapper.localdate as ecwl
 
 import emission.storage.timeseries.abstract_timeseries as esta
 import emission.storage.decorations.analysis_timeseries_queries as esda
-import emission.storage.decorations.local_date_queries as esdl
 
 import emission.tests.common as etc
 
@@ -82,7 +81,7 @@ class TestTimeGrouping(unittest.TestCase):
 
     def _fillDates(self, object, prefix, ardt, timezone):
         object["%sts" % prefix] = ardt.timestamp
-        object["%slocal_dt" % prefix] = esdl.get_local_date(ardt.timestamp,
+        object["%slocal_dt" % prefix] = ecwl.LocalDate.get_local_date(ardt.timestamp,
                                                      timezone)
         object["%sfmt_time" % prefix] = ardt.to(timezone).isoformat()
         logging.debug("After filling entries, keys are %s" % list(object.keys()))

--- a/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
+++ b/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
@@ -26,7 +26,7 @@ import emission.storage.timeseries.abstract_timeseries as esta
 import emission.net.usercache.abstract_usercache_handler as enuah
 import emission.net.api.usercache as mauc
 import emission.core.wrapper.trip as ecwt
-import emission.storage.decorations.local_date_queries as ecsdlq
+import emission.core.wrapper.localdate as ecwld
 
 # These are the current formatters, so they are included here for testing.
 # However, it is unclear whether or not we need to add other tests as we add other formatters,
@@ -81,7 +81,7 @@ class TestBuiltinUserCacheHandlerOutput(unittest.TestCase):
     # Let's add a new test for this
     def testGetLocalDay(self):
         adt = arrow.get(pydt.datetime(2016, 1, 1, 9, 46, 0, 0))
-        test_dt = ecsdlq.get_local_date(adt.timestamp, "America/Los_Angeles")
+        test_dt = ecwld.LocalDate.get_local_date(adt.timestamp, "America/Los_Angeles")
         test_trip = ecwt.Trip({'start_local_dt': test_dt, 'start_fmt_time': adt.isoformat()})
         test_handler = enuah.UserCacheHandler.getUserCacheHandler(self.testUserUUID1)
         self.assertEqual(test_handler.get_local_day_from_fmt_time(test_trip), "2016-01-01")

--- a/emission/tests/netTests/TestMetricsCleanedSections.py
+++ b/emission/tests/netTests/TestMetricsCleanedSections.py
@@ -18,7 +18,6 @@ import emission.tests.common as etc
 import emission.analysis.intake.cleaning.filter_accuracy as eaicf
 
 import emission.storage.timeseries.format_hacks.move_filter_field as estfm
-import emission.storage.decorations.local_date_queries as esdldq
 
 from emission.net.api import metrics
 
@@ -37,8 +36,8 @@ class TestMetrics(unittest.TestCase):
             "After loading, timeseries db size = %s" % edb.get_timeseries_db().count())
         self.aug_start_ts = 1438387200
         self.aug_end_ts = 1441065600
-        self.day_start_dt = esdldq.get_local_date(self.aug_start_ts, "America/Los_Angeles")
-        self.day_end_dt = esdldq.get_local_date(self.aug_end_ts, "America/Los_Angeles")
+        self.day_start_dt = ecwl.LocalDate.get_local_date(self.aug_start_ts, "America/Los_Angeles")
+        self.day_end_dt = ecwl.LocalDate.get_local_date(self.aug_end_ts, "America/Los_Angeles")
 
     def tearDown(self):
         self.clearRelatedDb()

--- a/emission/tests/netTests/TestVisualize.py
+++ b/emission/tests/netTests/TestVisualize.py
@@ -22,7 +22,7 @@ import emission.analysis.intake.segmentation.section_segmentation as eaiss
 import emission.analysis.intake.cleaning.filter_accuracy as eaicf
 import emission.storage.timeseries.format_hacks.move_filter_field as estfm
 import emission.core.wrapper.motionactivity as ecwm
-import emission.storage.decorations.local_date_queries as esdldq
+import emission.core.wrapper.localdate as ecwl
 
 
 class TestVisualize(unittest.TestCase):
@@ -36,8 +36,8 @@ class TestVisualize(unittest.TestCase):
             "After loading, timeseries db size = %s" % edb.get_timeseries_db().count())
         self.day_start_ts = 1440658800
         self.day_end_ts = 1440745200
-        self.day_start_dt = esdldq.get_local_date(self.day_start_ts, "America/Los_Angeles")
-        self.day_end_dt = esdldq.get_local_date(self.day_end_ts, "America/Los_Angeles")
+        self.day_start_dt = ecwl.LocalDate.get_local_date(self.day_start_ts, "America/Los_Angeles")
+        self.day_end_dt = ecwl.LocalDate.get_local_date(self.day_end_ts, "America/Los_Angeles")
 
         # If we don't delete the time components, we end up with the upper and
         # lower bounds = 0, which basically matches nothing.

--- a/emission/tests/storageTests/TestLocalDateQueries.py
+++ b/emission/tests/storageTests/TestLocalDateQueries.py
@@ -41,7 +41,7 @@ class TestLocalDateQueries(unittest.TestCase):
         ts = esta.TimeSeries.get_time_series(self.testUUID)
         start_ts = arrow.now().timestamp
         ma_ts = 1460586729
-        local_dt = esdl.get_local_date(ma_ts, "America/Los_Angeles")
+        local_dt = ecwl.LocalDate.get_local_date(ma_ts, "America/Los_Angeles")
         fmt_time = arrow.get(ma_ts).to("America/Los_Angeles").isoformat()
         ma = ecwm.Motionactivity({
             "ts": 1460586729,


### PR DESCRIPTION
We already added it to the wrapper class in fdaac6baec28424e74be666f8a102a9f14829491 

We now remove it from the storage class to avoid duplicate code, and change all references to use the new location