### PR TITLE
Read the OTP server URL from the OTP_SERVER environment variable

### DIFF
--- a/emission/analysis/modelling/user_model/query.py
+++ b/emission/analysis/modelling/user_model/query.py
@@ -12,6 +12,7 @@ import uuid
 import logging
 import crontab
 import optparse
+import os
 
 # Our imports
 import emission.core.get_database as edb
@@ -39,7 +40,7 @@ def obtain_alternatives(trip_id, user_id):
 	
         for mode in otp_modes:
                 try:
-                    otp_trip = otp.OTP(start_coord, end_coord, mode, write_day(curr_month, curr_day, curr_year), write_time(curr_hour, curr_minute), False)
+                    otp_trip = otp.OTP(os.environ("OTP_SERVER")).route(start_coord, end_coord, mode, write_day(curr_month, curr_day, curr_year), write_time(curr_hour, curr_minute), False)
                     otp_trip = otp_trip.turn_into_trip(None, user_id, trip_id) 
                     otp_trip.save_to_db()
                 except otp.PathNotFoundException as e:

--- a/emission/analysis/modelling/user_model_josh/utility_model.py
+++ b/emission/analysis/modelling/user_model_josh/utility_model.py
@@ -26,6 +26,7 @@ import heapq
 import time
 import requests
 import random
+import os
 
 CENTER_OF_CAMPUS = to.Coordinate(37.871790, -122.260005)
 RANDOM_RADIUS = .3  # 300 meters around center of campus; for randomization
@@ -150,7 +151,7 @@ class UserModel(object):
         if self.has_bike:
             mode = "BICYCLE"
 
-        walk_otp = otp.OTP(start, end, "WALK", write_day(curr_month, curr_day, curr_year), write_time(curr_hour, curr_minute), False)
+        walk_otp = otp.OTP(os.environ("OTP_SERVER")).route(start, end, "WALK", write_day(curr_month, curr_day, curr_year), write_time(curr_hour, curr_minute), False)
         lst_of_trips = walk_otp.get_all_trips(0, 0, 0)
 
         our_gmaps = gmaps.GoogleMaps(GOOGLE_MAPS_KEY) 

--- a/emission/incomplete_tests/TestUserModel.py
+++ b/emission/incomplete_tests/TestUserModel.py
@@ -9,6 +9,7 @@ import unittest
 import emission.user_model_josh.utility_model as eum
 import emission.net.ext_service.otp.otp as otp
 import datetime
+import os
 
 
 class UserModelTests(unittest.TestCase):
@@ -60,8 +61,9 @@ class UserModelTests(unittest.TestCase):
         curr_day = curr_time.day
         curr_hour = curr_time.hour
 
-        walk_otp = otp.OTP(start, end, "WALK", eum.write_day(curr_month, curr_day, curr_year), eum.write_time(curr_hour, curr_minute), False)
-        bike_otp = otp.OTP(start, end, "BICYCLE", eum.write_day(curr_month, curr_day, curr_year), eum.write_time(curr_hour, curr_minute), True)
+        self.base_url = os.environ("OTP_SERVER")
+        walk_otp = otp.OTP(self.base_url).route(start, end, "WALK", eum.write_day(curr_month, curr_day, curr_year), eum.write_time(curr_hour, curr_minute), False)
+        bike_otp = otp.OTP(self.base_url).route(start, end, "BICYCLE", eum.write_day(curr_month, curr_day, curr_year), eum.write_time(curr_hour, curr_minute), True)
 
         
         choices = walk_otp.get_all_trips(0,0,0) + bike_otp.get_all_trips(0,0,0)
@@ -97,8 +99,9 @@ class UserModelTests(unittest.TestCase):
         curr_day = curr_time.day
         curr_hour = curr_time.hour
 
-        walk_otp = otp.OTP(start, end, "WALK", eum.write_day(curr_month, curr_day, curr_year), eum.write_time(curr_hour, curr_minute), False)
-        bike_otp = otp.OTP(start, end, "BICYCLE", eum.write_day(curr_month, curr_day, curr_year), eum.write_time(curr_hour, curr_minute), False)
+        self.base_url = os.environ("OTP_SERVER")
+        walk_otp = otp.OTP(self.base_url).route(start, end, "WALK", eum.write_day(curr_month, curr_day, curr_year), eum.write_time(curr_hour, curr_minute), False)
+        bike_otp = otp.OTP(self.base_url).route(start, end, "BICYCLE", eum.write_day(curr_month, curr_day, curr_year), eum.write_time(curr_hour, curr_minute), False)
 
         choices = walk_otp.get_all_trips(0,0,0) + bike_otp.get_all_trips(0,0,0)
 

--- a/emission/net/ext_service/otp/otp.py
+++ b/emission/net/ext_service/otp/otp.py
@@ -54,7 +54,10 @@ class OTP(object):
 
     """ A class that exists to create an alternative trip object out of a call to our OTP server"""
 
-    def __init__(self, start_point, end_point, mode, date, time, bike, max_walk_distance=10000000000000000000000000000000000):
+    def __init__(self, url):
+        self.base_url = url
+
+    def route(start_point, end_point, mode, date, time, bike, max_walk_distance=10000000000000000000000000000000000):
         self.accepted_modes = {"CAR", "WALK", "BICYCLE", "TRANSIT", "BICYCLE_RENT"}
         self.start_point = start_point
         self.end_point = end_point
@@ -69,11 +72,11 @@ class OTP(object):
         self.date = date
         self.time = time
         self.max_walk_distance = max_walk_distance
+        return self
 
     def make_url(self):
         """Returns the url for request """
         params = {
-
             "fromPlace" : self.start_point,
             "toPlace" : self.end_point,
             "time" : self.time,
@@ -85,10 +88,7 @@ class OTP(object):
             "arriveBy" : "false"
         }
 
-        add_file = open("emission/net/ext_service/otp/planner.json")
-        add_file_1 = json.loads(add_file.read())
-        address = add_file_1["open_trip_planner_instance_address"]
-        query_url = "%s/otp/routers/default/plan?" % address
+        query_url = "%s/otp/routers/default/plan?" % self.base_url
         encoded_params = urllib.parse.urlencode(params)
         url = query_url + encoded_params
         #print(url)

--- a/emission/net/ext_service/otp/planner.json
+++ b/emission/net/ext_service/otp/planner.json
@@ -1,3 +1,0 @@
-{
-	"open_trip_planner_instance_address" : "http://18.209.111.117"
-}

--- a/emission/net/ext_service/otp/test_otp.py
+++ b/emission/net/ext_service/otp/test_otp.py
@@ -11,6 +11,7 @@ from past.utils import old_div
 import arrow
 import geocoder
 import requests
+import os
 
 
 class TestOTPMethods(unittest.TestCase):
@@ -37,9 +38,10 @@ class TestOTPMethods(unittest.TestCase):
         time_2 = "%s:%s" % (hour_2, curr_minute) 
         time_3 = "%s:%s" % (hour_3, curr_minute) 
 
-        self.opt_trip_1 = otp.OTP(start_point_1, end_point_1, mode_1, date, time_1, bike=True)
-        self.opt_trip_2 = otp.OTP(start_point_2, end_point_2, mode_2, date, time_2, bike=False)
-        self.opt_trip_3 = otp.OTP(start_point_2, end_point_2, mode_2, date, time_3, bike=False)
+        self.base_url = os.environ("OTP_SERVER")
+        self.opt_trip_1 = otp.OTP(self.base_url).route(start_point_1, end_point_1, mode_1, date, time_1, bike=True)
+        self.opt_trip_2 = otp.OTP(self.base_url).route(start_point_2, end_point_2, mode_2, date, time_2, bike=False)
+        self.opt_trip_3 = otp.OTP(self.base_url).route(start_point_2, end_point_2, mode_2, date, time_3, bike=False)
 
     def test_create_start_location_form_leg(self):
         legs = self.opt_trip_1.get_json()["plan"]["itineraries"][0]['legs']


### PR DESCRIPTION
Still debating a bit about environment variable v/s conf file.
But environment variable is clearly easier for docker to deal with and the conf
file may be overkill given that there is only one variable.

We pass in the server URL to the OTP class, and then use the environment
variables in the calling functions for now.

Also remove the `planner.json` file since it is no longer used