### PR TITLE
fix empty function

### DIFF
--- a/emission/pipeline/model_stage.py
+++ b/emission/pipeline/model_stage.py
@@ -38,6 +38,7 @@ How to know if the section has never been predicted?
 
 '''
 def setup(self):
+	pass
 
 
 def run_model_pipeline(process_number, uuid_list):


### PR DESCRIPTION
Running `./e-mission-py.bash emission/pipeline/model_stage.py` was outputing:

```
  File "emission/pipeline/model_stage.py", line 43
    def run_model_pipeline(process_number, uuid_list):
      ^
IndentationError: expected an indented block
```