### PR TITLE
Handle the motion activity entries properly in the formatter

### DIFF
--- a/emission/net/usercache/formatters/android/motion_activity.py
+++ b/emission/net/usercache/formatters/android/motion_activity.py
@@ -25,6 +25,7 @@ def format(entry):
     #logging.info('*** Motion Data write_ts: %d' % metadata.write_ts)
     
     data = ad.AttrDict()
+
     if 'agb' in entry.data:
         data.type = ecwa.MotionTypes(entry.data.agb).value
     elif 'zzaEg' in entry.data:
@@ -35,7 +36,7 @@ def format(entry):
         data.type = ecwa.MotionTypes(entry.data.ajO).value
     elif 'zzaKM' in entry.data:
         data.type = ecwa.MotionTypes(entry.data.zzaKM).value
-    else:
+    elif 'zzbhB' in entry.data:
         data.type = ecwa.MotionTypes(entry.data.zzbhB).value
 
 
@@ -49,10 +50,12 @@ def format(entry):
         data.confidence = entry.data.ajP
     elif 'zzaKN' in entry.data:
         data.confidence = entry.data.zzaKN
-    else:
+    elif 'zzbhC' in entry.data:
         data.confidence = entry.data.zzbhC
 
-    data.ts = formatted_entry.metadata.write_ts
+    if 'ts' not in entry.data:
+        data.ts = formatted_entry.metadata.write_ts
+
     data.local_dt = formatted_entry.metadata.write_local_dt
     data.fmt_time = formatted_entry.metadata.write_fmt_time
     formatted_entry.data = data


### PR DESCRIPTION
This corresponds to
https://github.com/e-mission/e-mission-data-collection/pull/186/commits/944c091ecab7b91740d80c3693d48731b6581bac

- Change the fallback `if` statements to only be executed if the field actually exists
    Since the new format directly has `type` and `confidence`, they should
        represent the fallback for the `if` statement. And in that case, we
        shouldn't do anything.

- Similarly, only overwrite the `ts` if it doesn't already exist