### PR TITLE
Upgrade all dependencies to the latest versions

### DIFF
--- a/setup/environment36.notebook.additions.yml
+++ b/setup/environment36.notebook.additions.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- branca=0.2.0=py_1
-- folium=0.5.0=py_0
-- ipython=5.3.0=py36_0
-- jupyter=1.0.0=py36_3
+- branca=0.4.1
+- folium=0.11.0
+- ipython=7.17.0
+- jupyter=1.0.0

--- a/setup/environment36.yml
+++ b/setup/environment36.yml
@@ -3,24 +3,23 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- arrow=0.12.1
-- attrdict=2.0.0
-- cheroot=6.2.*=py36_0
-- future=0.16.0
-- google-auth=1.2.1
-- numpy=1.12.1=py36_0
-- pandas=0.20.1=np112py36_0
-- pip=9.0.1=py36_1
-- python=3.6.1=2
-- python-dateutil=2.6.0=py36_0
-- pytz=2017.2=py36_0
-- requests=2.14.2=py36_0
-- scikit-learn=0.18.1=np112py36_1
-- scipy=0.19.0=np112py36_0
-- utm=0.4.2
+- arrow=0.13.1
+- attrdict=2.0.1
+- cheroot=8.4.2
+- future=0.18.0
+- google-auth=1.20.1
+- numpy=1.19.1
+- pandas=1.1.0
+- pip=20.2.2
+- python-dateutil=2.8.1
+- pytz=2020.1
+- requests=2.24.0
+- scikit-learn=0.23.2
+- scipy=1.5.2
+- utm=0.5.0
 - pip:
-  - jwcrypto==0.4.2
-  - pyfcm==1.4.3
+  - jwcrypto==0.7
+  - pyfcm==1.4.7
   - pygeocoder==1.2.5
-  - pymongo==3.5.1
+  - pymongo==3.11.0
 prefix: /Users/shankari/OSS/anaconda/envs/emission

--- a/setup/export_versions.sh
+++ b/setup/export_versions.sh
@@ -1,1 +1,1 @@
-export EXP_CONDA_VER=4.5.12
+export EXP_CONDA_VER=4.8.3

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -7,20 +7,5 @@
 
 source setup/checks/check_for_conda.sh
 
-echo "Setting up blank environment"
-conda create --name emission python=3.6
-conda activate emission
-
-echo "Downloading packages"
-curl -o /tmp/cachetools-2.1.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/cachetools/2.1.0/download/noarch/cachetools-2.1.0-py_0.tar.bz2
-curl -o /tmp/geojson-2.3.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/geojson/2.3.0/download/noarch/geojson-2.3.0-py_0.tar.bz2
-curl -o /tmp/jsonpickle-0.9.6-py_1.tar.bz2 -L https://anaconda.org/conda-forge/jsonpickle/0.9.6/download/noarch/jsonpickle-0.9.6-py_1.tar.bz2
-curl -o /tmp/more-itertools-8.2.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/more-itertools/8.2.0/download/noarch/more-itertools-8.2.0-py_0.tar.bz2
-curl -o /tmp/pyasn1-0.4.8-py_0.tar.bz2 -L https://anaconda.org/conda-forge/pyasn1/0.4.8/download/noarch/pyasn1-0.4.8-py_0.tar.bz2
-curl -o /tmp/pyasn1-modules-0.2.7-py_0.tar.bz2 -L https://anaconda.org/conda-forge/pyasn1-modules/0.2.7/download/noarch/pyasn1-modules-0.2.7-py_0.tar.bz2
-
-echo "Installing manually downloaded packages"
-conda install /tmp/*.bz2
-
-echo "Updating using conda now"
+echo "Installing using conda now"
 conda env update --name emission --file setup/environment36.yml

--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -12,7 +12,7 @@ else
     INSTALL_PREFIX=$HOME/miniconda-$EXP_CONDA_VER
     SOURCE_SCRIPT="$HOME/miniconda-$EXP_CONDA_VER/etc/profile.d/conda.sh"
     
-    curl -o miniconda.sh -L https://repo.continuum.io/miniconda/Miniconda3-$EXP_CONDA_VER-$PLATFORM.sh;
+    curl -o miniconda.sh -L https://repo.continuum.io/miniconda/Miniconda3-py38_$EXP_CONDA_VER-$PLATFORM.sh;
     bash miniconda.sh -b -p $INSTALL_PREFIX
     source $SOURCE_SCRIPT
     hash -r

--- a/setup/setup_notebook.sh
+++ b/setup/setup_notebook.sh
@@ -7,21 +7,6 @@
 
 source setup/checks/check_for_conda.sh
 
-echo "Setting up blank environment"
-conda create --name emission python=3.6
-conda activate emission
-
-echo "Downloading packages"
-curl -o /tmp/cachetools-2.1.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/cachetools/2.1.0/download/noarch/cachetools-2.1.0-py_0.tar.bz2
-curl -o /tmp/geojson-2.3.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/geojson/2.3.0/download/noarch/geojson-2.3.0-py_0.tar.bz2
-curl -o /tmp/jsonpickle-0.9.6-py_1.tar.bz2 -L https://anaconda.org/conda-forge/jsonpickle/0.9.6/download/noarch/jsonpickle-0.9.6-py_1.tar.bz2
-curl -o /tmp/more-itertools-8.2.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/more-itertools/8.2.0/download/noarch/more-itertools-8.2.0-py_0.tar.bz2
-curl -o /tmp/pyasn1-0.4.8-py_0.tar.bz2 -L https://anaconda.org/conda-forge/pyasn1/0.4.8/download/noarch/pyasn1-0.4.8-py_0.tar.bz2
-curl -o /tmp/pyasn1-modules-0.2.7-py_0.tar.bz2 -L https://anaconda.org/conda-forge/pyasn1-modules/0.2.7/download/noarch/pyasn1-modules-0.2.7-py_0.tar.bz2
-
-echo "Installing manually downloaded packages"
-conda install /tmp/*.bz2
-
 echo "Updating using conda now"
 conda env update --name emission --file setup/environment36.yml
 conda env update --name emission --file setup/environment36.notebook.additions.yml

--- a/setup/setup_tests.sh
+++ b/setup/setup_tests.sh
@@ -2,21 +2,6 @@
 
 source setup/checks/check_for_conda.sh
 
-echo "Setting up blank environment"
-conda create --name emissiontest python=3.6
-conda activate emissiontest
-
-echo "Downloading packages"
-curl -o /tmp/cachetools-2.1.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/cachetools/2.1.0/download/noarch/cachetools-2.1.0-py_0.tar.bz2
-curl -o /tmp/geojson-2.3.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/geojson/2.3.0/download/noarch/geojson-2.3.0-py_0.tar.bz2
-curl -o /tmp/jsonpickle-0.9.6-py_1.tar.bz2 -L https://anaconda.org/conda-forge/jsonpickle/0.9.6/download/noarch/jsonpickle-0.9.6-py_1.tar.bz2
-curl -o /tmp/more-itertools-8.2.0-py_0.tar.bz2 -L https://anaconda.org/conda-forge/more-itertools/8.2.0/download/noarch/more-itertools-8.2.0-py_0.tar.bz2
-curl -o /tmp/pyasn1-0.4.8-py_0.tar.bz2 -L https://anaconda.org/conda-forge/pyasn1/0.4.8/download/noarch/pyasn1-0.4.8-py_0.tar.bz2
-curl -o /tmp/pyasn1-modules-0.2.7-py_0.tar.bz2 -L https://anaconda.org/conda-forge/pyasn1-modules/0.2.7/download/noarch/pyasn1-modules-0.2.7-py_0.tar.bz2
-
-echo "Installing manually downloaded packages"
-conda install /tmp/*.bz2
-
 conda env update --name emissiontest --file setup/environment36.yml
 # python bin/deploy/habitica_conf.py
 python bin/deploy/push_conf.py


### PR DESCRIPTION
- Upgraded to the most recent version of everything, with the following caveats:
    - miniconda is 4.8.3 instead of 4.8.4 since there doesn't appear to be a
      4.8.4 labelled binary yet and I don't want to use `latest`
    - remove versioned python since it is installed automatically
    - specifying python also causes major dependency incompatibilities, since
      all packages have not been upgraded to the latest version
- Remove the manual installs since we are upgrading to the most recent version

Testing done:
- Setup works locally
- Running tests on CI; might run locally with persistent failures