### PR TITLE
Add support to compare algorithm changes

### DIFF
--- a/bin/compare_algo_changes.py
+++ b/bin/compare_algo_changes.py
@@ -1,0 +1,60 @@
+import logging
+import argparse
+import importlib
+import traceback
+
+import unittest.loader as loader
+import unittest.runner as runner
+
+import emission.tests.common as etc
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("branch", help="e.g. master, gis-based-mode-detection")
+    parser.add_argument("test_module",
+        help="""module containing the test
+            e.g. emission.tests.analysisTests.intakeTests.TestPipelineRealData""")
+    parser.add_argument("test_class",
+        help="""the class (subclass of unittest.TestCase) in the module
+            e.g. TestPipelineRealData""")
+    parser.add_argument("--test",
+        help="""the test to be run 
+            e.g. testJumpSmoothingSectionsStraddle""")
+    parser.add_argument("--clean", default=False, action='store_true',
+        help="""Clear out the existing data, since we don't automatically do so at the end of a test""")
+    parser.add_argument("--verbose",
+        help="""whether the result output should be verbose""", default=True)
+
+    args = parser.parse_args()
+    print(args)
+
+    # spec = importlib.util.spec_from_file_location("realtests", args.test_file_path)
+    # module = importlib.util.module_from_spec(spec)
+    module = importlib.import_module(args.test_module)
+    testcls = getattr(module, args.test_class)
+    suite = loader.TestLoader().loadTestsFromTestCase(testcls)
+
+    for (idx, test) in enumerate(suite):
+        logging.info("Checking test %s: %s" % (idx, test._testMethodName))
+        if args.test is not None and test._testMethodName == args.test:
+            if args.clean:
+                logging.info("Cleaning test %s: %s" % (idx, test._testMethodName))
+                test.branch = args.branch
+                etc.fillExistingUUID(test)
+                result = test.tearDown()
+            else:
+                logging.info("Running test %s: %s" % (idx, test._testMethodName))
+                test.evaluation = True
+                test.persistence = True
+                test.branch = args.branch
+                result = test()
+                print("====== errors =======")
+                for (tc, error) in result.errors:
+                    print("------ %s -------" % tc)
+                    print(error)
+                print("====== failures =======")
+                for tc, failure in result.failures:
+                    print("------ %s -------" % tc)
+                    print(failure)

--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -317,9 +317,6 @@ class TestPipelineRealData(unittest.TestCase):
         dataFile = "emission/tests/data/real_examples/gabe_2016-06-15"
         start_ld = ecwl.LocalDate({'year': 2016, 'month': 6, 'day': 15})
         cacheKey = "diary/trips-2016-06-15"
-        print("self = %s" % type(self))
-        print("self.evaluation = %s" % self.evaluation)
-        print("self.methodname = %s" % self._testMethodName)
         self.standardMatchDataGroundTruth(dataFile, start_ld, cacheKey)
 
     def testJumpSmoothingSectionEnd(self):

--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -37,6 +37,8 @@ import attrdict as ad
 import arrow
 import numpy as np
 import os
+import os.path
+import argparse
 
 # Our imports
 import emission.core.get_database as edb
@@ -56,16 +58,24 @@ class TestPipelineRealData(unittest.TestCase):
         np.random.seed(61297777)
         self.analysis_conf_path = \
             etc.set_analysis_config("analysis.result.section.key", "analysis/cleaned_section")
+        logging.info("setUp complete")
 
     def tearDown(self):
-        logging.debug("Clearing related databases")
-        self.clearRelatedDb()
-        os.remove(self.analysis_conf_path)
+        logging.debug("Clearing related databases for %s" % self.testUUID)
+        # Clear the database only if it is not an evaluation run
+        # A testing run validates that nothing has changed
+        # An evaluation run compares to different algorithm implementations
+        # to determine whether to switch to a new implementation
+        if not hasattr(self, "evaluation") or not self.evaluation:
+            self.clearRelatedDb()
+        if hasattr(self, "analysis_conf_path"):
+            os.remove(self.analysis_conf_path)
+        logging.info("tearDown complete")
 
     def clearRelatedDb(self):
-        edb.get_timeseries_db().delete_many({"user_id": self.testUUID})
-        edb.get_analysis_timeseries_db().delete_many({"user_id": self.testUUID})
-        edb.get_usercache_db().delete_many({"user_id": self.testUUID})
+        logging.info("Timeseries delete result %s" % edb.get_timeseries_db().delete_many({"user_id": self.testUUID}).raw_result)
+        logging.info("Analysis delete result %s" % edb.get_analysis_timeseries_db().delete_many({"user_id": self.testUUID}).raw_result)
+        logging.info("Usercache delete result %s" % edb.get_usercache_db().delete_many({"user_id": self.testUUID}).raw_result)
 
     def compare_result(self, result, expect):
         # This is basically a bunch of asserts to ensure that the timeline is as
@@ -173,6 +183,21 @@ class TestPipelineRealData(unittest.TestCase):
                 logging.debug(20 * "-")
             logging.debug(20 * "=")
 
+    def persistGroundTruthIfNeeded(self, api_result, dataFile, ld, cacheKey):
+        if hasattr(self, "persistence") and self.persistence:
+            savedFn = "/tmp/"+os.path.basename(dataFile)+".ground_truth"
+            logging.info("Persisting ground truth to "+savedFn)
+            with open(savedFn, "w") as gofp:
+                wrapped_gt = {
+                    "data": api_result,
+                    "metadata": {
+                        "key": cacheKey,
+                        "type": "document",
+                        "write_ts": arrow.now().timestamp
+                    }
+                }
+                json.dump(wrapped_gt, gofp, indent=4, default=bju.default)
+
     def standardMatchDataGroundTruth(self, dataFile, ld, cacheKey):
         with open(dataFile+".ground_truth") as gfp:
             ground_truth = json.load(gfp, object_hook=bju.object_hook)
@@ -187,6 +212,7 @@ class TestPipelineRealData(unittest.TestCase):
         # cached_result = edb.get_usercache_db().find_one({'user_id': self.testUUID,
         #                                                  "metadata.key": cacheKey})
         api_result = gfc.get_geojson_for_dt(self.testUUID, ld, ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, ld, cacheKey)
 
         # self.compare_result(cached_result, ground_truth)
         self.compare_result(ad.AttrDict({'result': api_result}).result,
@@ -283,6 +309,7 @@ class TestPipelineRealData(unittest.TestCase):
         etc.runIntakePipeline(self.testUUID)
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, start_ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, start_ld, cacheKey)
         # Although we process the day's data in two batches, we should get the same result
         self.assertEqual(api_result, [])
 
@@ -290,6 +317,9 @@ class TestPipelineRealData(unittest.TestCase):
         dataFile = "emission/tests/data/real_examples/gabe_2016-06-15"
         start_ld = ecwl.LocalDate({'year': 2016, 'month': 6, 'day': 15})
         cacheKey = "diary/trips-2016-06-15"
+        print("self = %s" % type(self))
+        print("self.evaluation = %s" % self.evaluation)
+        print("self.methodname = %s" % self._testMethodName)
         self.standardMatchDataGroundTruth(dataFile, start_ld, cacheKey)
 
     def testJumpSmoothingSectionEnd(self):
@@ -309,6 +339,7 @@ class TestPipelineRealData(unittest.TestCase):
         etc.runIntakePipeline(self.testUUID)
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, start_ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, start_ld, cacheKey)
         # Although we process the day's data in two batches, we should get the same result
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                             ad.AttrDict(ground_truth).data)
@@ -324,6 +355,7 @@ class TestPipelineRealData(unittest.TestCase):
         etc.runIntakePipeline(self.testUUID)
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, start_ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, start_ld, cacheKey)
         # Although we process the day's data in two batches, we should get the same result
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                             ad.AttrDict(ground_truth).data)
@@ -393,6 +425,7 @@ class TestPipelineRealData(unittest.TestCase):
         etc.setupRealExampleWithEntries(self)
         etc.runIntakePipeline(self.testUUID)
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, end_ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, start_ld, cacheKey)
 
         # Although we process the day's data in two batches, we should get the same result
         self.compare_approx_result(ad.AttrDict({'result': api_result}).result,
@@ -432,6 +465,7 @@ class TestPipelineRealData(unittest.TestCase):
         etc.setupRealExampleWithEntries(self)
         etc.runIntakePipeline(self.testUUID)
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, end_ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, start_ld, cacheKey)
 
         # Although we process the day's data in two batches, we should get the same result
         self.compare_approx_result(ad.AttrDict({'result': api_result}).result,
@@ -474,6 +508,7 @@ class TestPipelineRealData(unittest.TestCase):
         etc.setupRealExampleWithEntries(self)
         etc.runIntakePipeline(self.testUUID)
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, end_ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, start_ld, cacheKey)
 
         # Although we process the day's data in two batches, we should get the same result
         self.compare_approx_result(ad.AttrDict({'result': api_result}).result,
@@ -499,11 +534,13 @@ class TestPipelineRealData(unittest.TestCase):
         etc.runIntakePipeline(self.testUUID)
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld_1, start_ld_1)
+        self.persistGroundTruthIfNeeded(api_result, dataFile_1, start_ld_1, cacheKey_1)
         # Although we process the day's data in two batches, we should get the same result
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                             ad.AttrDict(ground_truth_1).data)
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld_2, start_ld_2)
+        self.persistGroundTruthIfNeeded(api_result, dataFile_2, start_ld_2, cacheKey_2)
         # Although we process the day's data in two batches, we should get the same result
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                             ad.AttrDict(ground_truth_2).data)
@@ -543,6 +580,7 @@ class TestPipelineRealData(unittest.TestCase):
         etc.setupRealExampleWithEntries(self)
         etc.runIntakePipeline(self.testUUID)
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, end_ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, start_ld, cacheKey)
 
         # Although we process the day's data in two batches, we should get the same result
         self.compare_approx_result(ad.AttrDict({'result': api_result}).result,
@@ -583,6 +621,7 @@ class TestPipelineRealData(unittest.TestCase):
         etc.setupRealExampleWithEntries(self)
         etc.runIntakePipeline(self.testUUID)
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, end_ld)
+        self.persistGroundTruthIfNeeded(api_result, dataFile, start_ld, cacheKey)
 
         # Although we process the day's data in two batches, we should get the same result
         self.compare_approx_result(ad.AttrDict({'result': api_result}).result,
@@ -609,11 +648,14 @@ class TestPipelineRealData(unittest.TestCase):
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld_1, start_ld_1)
         # Although we process the day's data in two batches, we should get the same result
+        self.persistGroundTruthIfNeeded(api_result, dataFile_1, start_ld_1, cacheKey_1)
+
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                             ad.AttrDict(ground_truth_1).data)
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld_2, start_ld_2)
         # Although we process the day's data in two batches, we should get the same result
+        self.persistGroundTruthIfNeeded(api_result, dataFile_2, start_ld_2, cacheKey_2)
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                             ad.AttrDict(ground_truth_2).data)
 
@@ -639,11 +681,13 @@ class TestPipelineRealData(unittest.TestCase):
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld_1, start_ld_1)
         # Although we process the day's data in two batches, we should get the same result
+        self.persistGroundTruthIfNeeded(api_result, dataFile_1, start_ld_1, cacheKey_1)
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                             ad.AttrDict(ground_truth_1).data)
 
         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld_2, start_ld_2)
         # Although we process the day's data in two batches, we should get the same result
+        self.persistGroundTruthIfNeeded(api_result, dataFile_2, start_ld_2, cacheKey_2)
         self.compare_result(ad.AttrDict({'result': api_result}).result,
                             ad.AttrDict(ground_truth_2).data)
 
@@ -670,4 +714,8 @@ class TestPipelineRealData(unittest.TestCase):
 
 if __name__ == '__main__':
     etc.configLogging()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--algo_change",
+        help="modifications to the algorithm", action="store_true")
     unittest.main()

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -18,6 +18,7 @@ import pymongo
 import emission.core.get_database as edb
 from emission.core.get_database import get_client_db, get_section_db
 import emission.core.get_database as edb
+import emission.core.wrapper.user as ecwu
 
 def makeValid(client):
   client.clientJSON['start_date'] = str(datetime.now() + timedelta(days=-2))
@@ -99,11 +100,27 @@ def updateSections(testCase):
       testCase.uuid_list.append(curr_uuid)
       testCase.SectionsColl.save(section)
 
+def getRealExampleEmail(testObj):
+    return testObj.branch + "_" + testObj._testMethodName
+
+def fillExistingUUID(testObj):
+    userObj = ecwu.User.fromEmail(getRealExampleEmail(testObj))
+    print("Setting testUUID to %s" % userObj.uuid)
+    testObj.testUUID = userObj.uuid
+
 def setupRealExample(testObj, dump_file):
     logging.info("Before loading, timeseries db size = %s" % edb.get_timeseries_db().count())
     with open(dump_file) as dfp:
+        print(testObj.__dict__)
         testObj.entries = json.load(dfp, object_hook = bju.object_hook)
-        testObj.testUUID = uuid.uuid4()
+        if hasattr(testObj, "evaluation") and testObj.evaluation:
+            reg_email = getRealExampleEmail(testObj)
+            logging.info("registering email = %s" % reg_email)
+            user = ecwu.User.register(reg_email)
+            testObj.testUUID = user.uuid
+        else:
+            testObj.testUUID = uuid.uuid4()
+
         print("Setting up real example for %s" % testObj.testUUID)
         setupRealExampleWithEntries(testObj)
 

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -111,7 +111,6 @@ def fillExistingUUID(testObj):
 def setupRealExample(testObj, dump_file):
     logging.info("Before loading, timeseries db size = %s" % edb.get_timeseries_db().count())
     with open(dump_file) as dfp:
-        print(testObj.__dict__)
         testObj.entries = json.load(dfp, object_hook = bju.object_hook)
         if hasattr(testObj, "evaluation") and testObj.evaluation:
             reg_email = getRealExampleEmail(testObj)


### PR DESCRIPTION
This is primarily focused at updating the ground truth for unit tests in
response to algorithm changes. Since the algorithm changes will change the
output in subtle ways, we need to compare the old and new outputs and manually
confirm that the newer is better. We can't use automated techniques since we
don't have "ground truth", only a reference output.

The new `bin/compare_algo_changes.py` script facilitates this by running the
test cases outside the test framework and passing in additional flags. The
additional flags cause a user to be registered, so that we can access the
visualization in the phone, and download the ground truth so we can easily
update it after checking.

More details at https://github.com/e-mission/e-mission-docs/tree/master/docs/dev/back/algo_changes_outcome.md

Testing done:

```
./e-mission-py.bash bin/compare_algo_changes.py master emission.tests.analysisTests.intakeTests.TestPipelineRealData TestPipelineRealData --test testGabeShortTrips
```
generated `/tmp/gabe_2016-06-15.ground_truth`

Connecting from phones showed the diary

-------

```
./e-mission-py.bash bin/compare_algo_changes.py master emission.tests.analysisTests.intakeTests.TestPipelineRealData TestPipelineRealData --test testGabeShortTrips
```
resulted in

```
DEBUG:root:Clearing related databases for 19a82bd8-aef3-4f9c-a158-bf3826296196
INFO:root:Timeseries delete result {'n': 1419, 'ok': 1.0}
INFO:root:Analysis delete result {'n': 249, 'ok': 1.0}
INFO:root:Usercache delete result {'n': 0, 'ok': 1.0}
```

Connecting from phones did not show the diary

-------

Manually inserting an error into the test caused the error to be printed out