### PR TITLE
Ensure that we register the user email on more complex tests as well

### DIFF
--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -450,8 +450,7 @@ class TestPipelineRealData(unittest.TestCase):
         after_1800_entries = [e for e in all_entries if ad.AttrDict(e).metadata.write_ts > ts_1800]
 
         # Sync at 18:00 to capture all the points on the trip *to* the optometrist
-        import uuid
-        self.testUUID = uuid.uuid4()
+        etc.createAndFillUUID(self)
         self.entries = before_1800_entries
         etc.setupRealExampleWithEntries(self)
         etc.runIntakePipeline(self.testUUID)
@@ -565,8 +564,7 @@ class TestPipelineRealData(unittest.TestCase):
 
         # Sync at 18:00 to capture all the points on the trip *to* the optometrist
         # Skip the last few points to ensure that the trip end is skipped
-        import uuid
-        self.testUUID = uuid.uuid4()
+        etc.createAndFillUUID(self)
         self.entries = before_1800_entries[0:-2]
         etc.setupRealExampleWithEntries(self)
         etc.runIntakePipeline(self.testUUID)
@@ -606,8 +604,7 @@ class TestPipelineRealData(unittest.TestCase):
 
         # Sync at 18:00 to capture all the points on the trip *to* the optometrist
         # Skip the last few points to ensure that the trip end is skipped
-        import uuid
-        self.testUUID = uuid.uuid4()
+        etc.createAndFillUUID(self)
         self.entries = before_1800_entries
         etc.setupRealExampleWithEntries(self)
         etc.runIntakePipeline(self.testUUID)

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -108,18 +108,21 @@ def fillExistingUUID(testObj):
     print("Setting testUUID to %s" % userObj.uuid)
     testObj.testUUID = userObj.uuid
 
+def createAndFillUUID(testObj):
+    if hasattr(testObj, "evaluation") and testObj.evaluation:
+        reg_email = getRealExampleEmail(testObj)
+        logging.info("registering email = %s" % reg_email)
+        user = ecwu.User.register(reg_email)
+        testObj.testUUID = user.uuid
+    else:
+        logging.info("No evaluation flag found, not registering email")
+        testObj.testUUID = uuid.uuid4()
+
 def setupRealExample(testObj, dump_file):
     logging.info("Before loading, timeseries db size = %s" % edb.get_timeseries_db().count())
     with open(dump_file) as dfp:
         testObj.entries = json.load(dfp, object_hook = bju.object_hook)
-        if hasattr(testObj, "evaluation") and testObj.evaluation:
-            reg_email = getRealExampleEmail(testObj)
-            logging.info("registering email = %s" % reg_email)
-            user = ecwu.User.register(reg_email)
-            testObj.testUUID = user.uuid
-        else:
-            testObj.testUUID = uuid.uuid4()
-
+        createAndFillUUID(testObj)
         print("Setting up real example for %s" % testObj.testUUID)
         setupRealExampleWithEntries(testObj)
 


### PR DESCRIPTION
This is a follow-on to
https://github.com/e-mission/e-mission-server/commit/0fd0fd81be75c6e30cf7f36ebc3a1d859bfa1139

For the more complex tests, we were calling `etc.setupRealExampleWithEntries` directly
which didn't create a new UUID. So the test created the UUID using
`self.testUUID = uuid.uuid4()` and our comparison registration didn't work.

So we refactor the UUID creation code into a separate function and call that
from the complex tests instead.