### PR TITLE
Enable the Aug 27 2015 test

### DIFF
--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -267,21 +267,12 @@ class TestPipelineRealData(unittest.TestCase):
         cacheKey = "diary/trips-2016-02-22"
         self.standardMatchDataGroundTruth(dataFile, start_ld, cacheKey)
 
-#     def testAug27TooMuchExtrapolation(self):
-#         dataFile = "emission/tests/data/real_examples/shankari_2015-aug-27"
-#         start_ld = ecwl.LocalDate({'year': 2015, 'month': 8, 'day': 27})
-#         end_ld = ecwl.LocalDate({'year': 2015, 'month': 8, 'day': 27})
-#         cacheKey = "diary/trips-2015-08-27"
-#         with open(dataFile+".ground_truth") as gfp:
-#             ground_truth = json.load(gfp, object_hook=bju.object_hook)
-# 
-#         etc.setupRealExample(self, dataFile)
-#         etc.runIntakePipeline(self.testUUID)
-#         api_result = gfc.get_geojson_for_dt(self.testUUID, start_ld, end_ld)
-# 
-#         # Although we process the day's data in two batches, we should get the same result
-#         self.compare_result(ad.AttrDict({'result': api_result}).result,
-#                             ad.AttrDict(ground_truth).data)
+    def testAug27TooMuchExtrapolation(self):
+        dataFile = "emission/tests/data/real_examples/shankari_2015-aug-27"
+        start_ld = ecwl.LocalDate({'year': 2015, 'month': 8, 'day': 27})
+        end_ld = ecwl.LocalDate({'year': 2015, 'month': 8, 'day': 27})
+        cacheKey = "diary/trips-2015-08-27"
+        self.standardMatchDataGroundTruth(dataFile, start_ld, cacheKey)
 
     def testAirTripToHawaii(self):
         dataFile = "emission/tests/data/real_examples/shankari_2016-07-27"

--- a/emission/tests/data/real_examples/shankari_2015-aug-27.ground_truth
+++ b/emission/tests/data/real_examples/shankari_2015-aug-27.ground_truth
@@ -1,6318 +1,7542 @@
 {
     "data": [
         {
+            "type": "FeatureCollection",
+            "properties": {
+                "source": "DwellSegmentationTimeFilter",
+                "end_ts": 1440689408.302,
+                "end_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 8,
+                    "minute": 30,
+                    "second": 8,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "end_fmt_time": "2015-08-27T08:30:08.302000-07:00",
+                "end_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.0835641,
+                        37.4034802
+                    ]
+                },
+                "raw_trip": {
+                    "$oid": "5f3d68ec6fdd485ce81b5ba3"
+                },
+                "start_ts": 1440688739.672,
+                "start_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 8,
+                    "minute": 18,
+                    "second": 59,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "start_fmt_time": "2015-08-27T08:18:59.672000-07:00",
+                "start_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.0846749,
+                        37.393415
+                    ]
+                },
+                "duration": 668.6300001144409,
+                "distance": 1713.21374176403,
+                "start_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e56"
+                },
+                "end_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e57"
+                },
+                "feature_type": "trip"
+            },
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.084979, 
-                            37.3929098
+                            -122.0846749,
+                            37.393415
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19345f6858f0a02a4a5c9", 
+                    },
                     "properties": {
-                        "exit_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 59, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 18
-                        }, 
-                        "display_name": "South Shoreline Boulevard, Mountain View", 
-                        "feature_type": "start_place", 
-                        "exit_fmt_time": "2015-08-27T08:18:27.867000-07:00", 
-                        "starting_trip": {
-                            "$oid": "57e19340f6858f0a02a4a352"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
+                        "source": "DwellSegmentationTimeFilter",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a315"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5ba2"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a315"
+                                "$oid": "5f3d68ec6fdd485ce81b5ba2"
                             }
-                        ], 
-                        "exit_ts": 1440688707.867
-                    }
-                }, 
+                        ],
+                        "starting_trip": {
+                            "$oid": "5f3d68ee6fdd485ce81b5bdf"
+                        },
+                        "exit_ts": 1440688739.672,
+                        "exit_fmt_time": "2015-08-27T08:18:59.672000-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 8,
+                            "minute": 18,
+                            "second": 59,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "feature_type": "start_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e56"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.0835641, 
+                            -122.0835641,
                             37.4034802
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19345f6858f0a02a4a5ca", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T08:30:08.302000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 20, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 32
-                        }, 
-                        "display_name": "San Pierre Way, Mountain View", 
-                        "feature_type": "end_place", 
-                        "exit_fmt_time": "2015-08-27T08:32:20.701227-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440689408.302,
                         "enter_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 8, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 8,
+                            "month": 8,
+                            "second": 8,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 30
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19340f6858f0a02a4a352"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19340f6858f0a02a4a36f"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440689408.302, 
-                        "duration": 132.39922738075256, 
+                        },
+                        "enter_fmt_time": "2015-08-27T08:30:08.302000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a317"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5ba4"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a317"
+                                "$oid": "5f3d68ec6fdd485ce81b5ba4"
                             }
-                        ], 
-                        "exit_ts": 1440689540.7012274
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68ee6fdd485ce81b5bdf"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68ee6fdd485ce81b5bfc"
+                        },
+                        "exit_ts": 1440689540.7012274,
+                        "exit_fmt_time": "2015-08-27T08:32:20.701227-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 8,
+                            "minute": 32,
+                            "second": 20,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 132.39922738075256,
+                        "feature_type": "end_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e57"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "LineString", 
+                        "type": "LineString",
                         "coordinates": [
                             [
-                                -122.0847081, 
+                                -122.0847081,
                                 37.4033491
-                            ], 
+                            ],
                             [
-                                -122.0845296, 
+                                -122.0845296,
                                 37.4034667
                             ]
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19340f6858f0a02a4a36e", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T08:27:45.092000-07:00", 
-                        "distance": 20.484032507971882, 
-                        "exit_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 16, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 28
-                        }, 
-                        "feature_type": "stop", 
+                        "trip_id": {
+                            "$oid": "5f3d68ee6fdd485ce81b5bdf"
+                        },
+                        "source": "SmoothedHighConfidenceMotion",
                         "ending_section": {
-                            "$oid": "57e19340f6858f0a02a4a354"
-                        }, 
+                            "$oid": "5f3d68ee6fdd485ce81b5be1"
+                        },
                         "starting_section": {
-                            "$oid": "57e19340f6858f0a02a4a368"
-                        }, 
-                        "exit_fmt_time": "2015-08-27T08:28:16.912000-07:00", 
+                            "$oid": "5f3d68ee6fdd485ce81b5bf5"
+                        },
+                        "enter_ts": 1440689265.092,
                         "enter_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 45, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 27
-                        }, 
-                        "exit_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.0845296, 
-                                37.4034667
-                            ]
-                        }, 
-                        "source": "SmoothedHighConfidenceMotion", 
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 8,
+                            "minute": 27,
+                            "second": 45,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "enter_fmt_time": "2015-08-27T08:27:45.092000-07:00",
                         "enter_loc": {
-                            "type": "Point", 
+                            "type": "Point",
                             "coordinates": [
-                                -122.0847081, 
+                                -122.0847081,
                                 37.4033491
                             ]
-                        }, 
-                        "enter_ts": 1440689265.092, 
-                        "duration": 31.819999933242798, 
-                        "trip_id": {
-                            "$oid": "57e19340f6858f0a02a4a352"
-                        }, 
-                        "exit_ts": 1440689296.912
-                    }
-                }, 
+                        },
+                        "exit_ts": 1440689296.912,
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 8,
+                            "minute": 28,
+                            "second": 16,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "exit_fmt_time": "2015-08-27T08:28:16.912000-07:00",
+                        "exit_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.0845296,
+                                37.4034667
+                            ]
+                        },
+                        "duration": 31.819999933242798,
+                        "distance": 20.484032507971882,
+                        "feature_type": "stop"
+                    },
+                    "id": "5f3d68ee6fdd485ce81b5bfb"
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.084979, 
-                                        37.3929098
-                                    ], 
+                                        -122.0846749,
+                                        37.393415
+                                    ],
                                     [
-                                        -122.08367716219298, 
+                                        -122.08367716219298,
                                         37.3948067779213
-                                    ], 
+                                    ],
                                     [
-                                        -122.08310408579901, 
+                                        -122.08310408579901,
                                         37.3956920043855
-                                    ], 
+                                    ],
                                     [
-                                        -122.08303055467863, 
+                                        -122.08303055467863,
                                         37.39583125008914
-                                    ], 
+                                    ],
                                     [
-                                        -122.08297393900254, 
+                                        -122.08297393900254,
                                         37.39593205132939
-                                    ], 
+                                    ],
                                     [
-                                        -122.08287328402464, 
+                                        -122.08287328402464,
                                         37.39603598782679
-                                    ], 
+                                    ],
                                     [
-                                        -122.08217139950614, 
+                                        -122.08217139950614,
                                         37.39586915745068
-                                    ], 
+                                    ],
                                     [
-                                        -122.08121687635078, 
+                                        -122.08121687635078,
                                         37.39662502176472
-                                    ], 
+                                    ],
                                     [
-                                        -122.08083540229008, 
+                                        -122.08083540229008,
                                         37.397986347667576
-                                    ], 
+                                    ],
                                     [
-                                        -122.0807141489917, 
+                                        -122.0807141489917,
                                         37.39929928253347
-                                    ], 
+                                    ],
                                     [
-                                        -122.0805674333962, 
+                                        -122.0805674333962,
                                         37.39999204611759
-                                    ], 
+                                    ],
                                     [
-                                        -122.08069534712718, 
+                                        -122.08069534712718,
                                         37.39996179457042
-                                    ], 
+                                    ],
                                     [
-                                        -122.08142813111742, 
+                                        -122.08142813111742,
                                         37.39994239741808
-                                    ], 
+                                    ],
                                     [
-                                        -122.08307863820072, 
+                                        -122.08307863820072,
                                         37.400177859918735
-                                    ], 
+                                    ],
                                     [
-                                        -122.08468667951159, 
+                                        -122.08468667951159,
                                         37.40064209653733
-                                    ], 
+                                    ],
                                     [
-                                        -122.08484181367525, 
+                                        -122.08484181367525,
                                         37.401718181087354
-                                    ], 
+                                    ],
                                     [
-                                        -122.08479822727575, 
+                                        -122.08479822727575,
                                         37.40260859261417
-                                    ], 
+                                    ],
                                     [
-                                        -122.08471328637039, 
+                                        -122.08471328637039,
                                         37.403095985737
-                                    ], 
+                                    ],
                                     [
-                                        -122.0847081, 
+                                        -122.0847081,
                                         37.4033491
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19340f6858f0a02a4a354", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    178.09897477350873, 
-                                    110.6886198399058, 
-                                    16.790791203329707, 
-                                    12.27381558032231, 
-                                    14.581962096458845, 
-                                    64.71980136164962, 
-                                    119.05585562976155, 
-                                    155.07818907588387, 
-                                    146.3840932547465, 
-                                    78.11442544563927, 
-                                    11.789328121598372, 
-                                    64.76634807952239, 
-                                    148.12946704385357, 
-                                    151.13432601485562, 
-                                    120.43728738749792, 
-                                    99.08407367484293, 
-                                    54.71254024091751, 
-                                    28.148750060607483
-                                ], 
-                                "end_ts": 1440689265.092, 
-                                "feature_type": "section", 
-                                "distance": 1573.988648884902, 
-                                "sensed_mode": "MotionTypes.BICYCLING", 
-                                "start_ts": 1440688707.867, 
-                                "start_fmt_time": "2015-08-27T08:18:27.867000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T08:27:45.092000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 8, 
-                                    "month": 8, 
-                                    "second": 45, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 27
-                                }, 
-                                "duration": 525.420000076294, 
-                                "end_stop": {
-                                    "$oid": "57e19340f6858f0a02a4a36e"
-                                }, 
+                                "times": [
+                                    1440688739.672,
+                                    1440688769.672,
+                                    1440688799.672,
+                                    1440688829.672,
+                                    1440688859.672,
+                                    1440688889.672,
+                                    1440688919.672,
+                                    1440688949.672,
+                                    1440688979.672,
+                                    1440689009.672,
+                                    1440689039.672,
+                                    1440689069.672,
+                                    1440689099.672,
+                                    1440689129.672,
+                                    1440689159.672,
+                                    1440689189.672,
+                                    1440689219.672,
+                                    1440689249.672,
+                                    1440689265.092
+                                ],
+                                "timestamps": [
+                                    1440688739672,
+                                    1440688769672,
+                                    1440688799672,
+                                    1440688829672,
+                                    1440688859672,
+                                    1440688889672,
+                                    1440688919672,
+                                    1440688949672,
+                                    1440688979672,
+                                    1440689009672,
+                                    1440689039672,
+                                    1440689069672,
+                                    1440689099672,
+                                    1440689129672,
+                                    1440689159672,
+                                    1440689189672,
+                                    1440689219672,
+                                    1440689249672,
+                                    1440689265092
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19340f6858f0a02a4a352"
-                                }, 
+                                    "$oid": "5f3d68ee6fdd485ce81b5bdf"
+                                },
+                                "start_ts": 1440688739.672,
                                 "start_local_dt": {
-                                    "hour": 8, 
-                                    "month": 8, 
-                                    "second": 59, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 18
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 8,
+                                    "minute": 18,
+                                    "second": 59,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T08:18:59.672000-07:00",
+                                "end_ts": 1440689265.092,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 8,
+                                    "minute": 27,
+                                    "second": 45,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T08:27:45.092000-07:00",
+                                "duration": 525.420000076294,
                                 "speeds": [
-                                    0.0, 
-                                    5.936632492450291, 
-                                    3.6896206613301934, 
-                                    0.5596930401109902, 
-                                    0.40912718601074366, 
-                                    0.48606540321529484, 
-                                    2.1573267120549873, 
-                                    3.9685285209920518, 
-                                    5.169272969196129, 
-                                    4.879469775158216, 
-                                    2.603814181521309, 
-                                    0.39297760405327903, 
-                                    2.158878269317413, 
-                                    4.9376489014617855, 
-                                    5.037810867161854, 
-                                    4.014576246249931, 
-                                    3.3028024558280977, 
-                                    1.823751341363917, 
+                                    0.0,
+                                    5.936632492450291,
+                                    3.6896206613301934,
+                                    0.5596930401109902,
+                                    0.40912718601074366,
+                                    0.48606540321529484,
+                                    2.1573267120549873,
+                                    3.9685285209920518,
+                                    5.169272969196129,
+                                    4.879469775158216,
+                                    2.603814181521309,
+                                    0.39297760405327903,
+                                    2.158878269317413,
+                                    4.9376489014617855,
+                                    5.037810867161854,
+                                    4.014576246249931,
+                                    3.3028024558280977,
+                                    1.823751341363917,
                                     1.825470163510711
-                                ]
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    178.09897477350873,
+                                    110.6886198399058,
+                                    16.790791203329707,
+                                    12.27381558032231,
+                                    14.581962096458845,
+                                    64.71980136164962,
+                                    119.05585562976155,
+                                    155.07818907588387,
+                                    146.3840932547465,
+                                    78.11442544563927,
+                                    11.789328121598372,
+                                    64.76634807952239,
+                                    148.12946704385357,
+                                    151.13432601485562,
+                                    120.43728738749792,
+                                    99.08407367484293,
+                                    54.71254024091751,
+                                    28.148750060607483
+                                ],
+                                "distance": 1573.988648884902,
+                                "sensed_mode": "MotionTypes.BICYCLING",
+                                "end_stop": {
+                                    "$oid": "5f3d68ee6fdd485ce81b5bfb"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68ee6fdd485ce81b5be1"
                         }
                     ]
-                }, 
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.0845296, 
+                                        -122.0845296,
                                         37.4034667
-                                    ], 
+                                    ],
                                     [
-                                        -122.08442844992497, 
+                                        -122.08442844992497,
                                         37.403380444344215
-                                    ], 
+                                    ],
                                     [
-                                        -122.08389589236029, 
+                                        -122.08389589236029,
                                         37.4034029103248
-                                    ], 
+                                    ],
                                     [
-                                        -122.08405722269404, 
+                                        -122.08405722269404,
                                         37.40343414535875
-                                    ], 
+                                    ],
                                     [
-                                        -122.0835641, 
+                                        -122.0835641,
                                         37.4034802
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19340f6858f0a02a4a368", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    13.107986040605232, 
-                                    47.107560490081966, 
-                                    14.667588016993776, 
-                                    43.857925823474915
-                                ], 
-                                "feature_type": "section", 
-                                "sensed_mode": "MotionTypes.ON_FOOT", 
-                                "end_ts": 1440689408.302, 
-                                "start_ts": 1440689296.912, 
-                                "start_fmt_time": "2015-08-27T08:28:16.912000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T08:30:08.302000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 8, 
-                                    "month": 8, 
-                                    "second": 8, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 30
-                                }, 
-                                "duration": 111.39000010490417, 
-                                "start_stop": {
-                                    "$oid": "57e19340f6858f0a02a4a36e"
-                                }, 
+                                "times": [
+                                    1440689296.912,
+                                    1440689326.912,
+                                    1440689356.912,
+                                    1440689386.912,
+                                    1440689408.302
+                                ],
+                                "timestamps": [
+                                    1440689296912,
+                                    1440689326912,
+                                    1440689356912,
+                                    1440689386912,
+                                    1440689408302
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19340f6858f0a02a4a352"
-                                }, 
+                                    "$oid": "5f3d68ee6fdd485ce81b5bdf"
+                                },
+                                "start_ts": 1440689296.912,
                                 "start_local_dt": {
-                                    "hour": 8, 
-                                    "month": 8, 
-                                    "second": 16, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 28
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 8,
+                                    "minute": 28,
+                                    "second": 16,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T08:28:16.912000-07:00",
+                                "end_ts": 1440689408.302,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 8,
+                                    "minute": 30,
+                                    "second": 8,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T08:30:08.302000-07:00",
+                                "duration": 111.39000010490417,
                                 "speeds": [
-                                    0.0, 
-                                    0.4369328680201744, 
-                                    1.5702520163360656, 
-                                    0.48891960056645917, 
+                                    0.0,
+                                    0.4369328680201744,
+                                    1.5702520163360656,
+                                    0.48891960056645917,
                                     2.0503939040850883
-                                ], 
-                                "distance": 118.7410603711559
-                            }
-                        }
-                    ]
-                }
-            ], 
-            "type": "FeatureCollection", 
-            "id": "57e19340f6858f0a02a4a352", 
-            "properties": {
-                "distance": 1772.479712753613, 
-                "end_place": {
-                    "$oid": "57e19345f6858f0a02a4a5ca"
-                }, 
-                "raw_trip": {
-                    "$oid": "57e1933df6858f0a02a4a316"
-                }, 
-                "feature_type": "trip", 
-                "start_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.084979, 
-                        37.3929098
-                    ]
-                }, 
-                "end_ts": 1440689408.302, 
-                "start_ts": 1440688707.867, 
-                "start_fmt_time": "2015-08-27T08:18:27.867000-07:00", 
-                "end_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.0835641, 
-                        37.4034802
-                    ]
-                }, 
-                "source": "DwellSegmentationTimeFilter", 
-                "start_place": {
-                    "$oid": "57e19345f6858f0a02a4a5c9"
-                }, 
-                "end_fmt_time": "2015-08-27T08:30:08.302000-07:00", 
-                "end_local_dt": {
-                    "hour": 8, 
-                    "month": 8, 
-                    "second": 8, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 30
-                }, 
-                "duration": 668.6300001144409, 
-                "start_local_dt": {
-                    "hour": 8, 
-                    "month": 8, 
-                    "second": 59, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 18
-                }
-            }
-        }, 
-        {
-            "features": [
-                {
-                    "geometry": {
-                        "type": "Point", 
-                        "coordinates": [
-                            -122.0835641, 
-                            37.4034802
-                        ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19345f6858f0a02a4a5ca", 
-                    "properties": {
-                        "enter_fmt_time": "2015-08-27T08:30:08.302000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 20, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 32
-                        }, 
-                        "display_name": "San Pierre Way, Mountain View", 
-                        "feature_type": "start_place", 
-                        "exit_fmt_time": "2015-08-27T08:32:20.701227-07:00", 
-                        "enter_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 8, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 30
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19340f6858f0a02a4a352"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19340f6858f0a02a4a36f"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440689408.302, 
-                        "duration": 132.39922738075256, 
-                        "raw_places": [
-                            {
-                                "$oid": "57e1933df6858f0a02a4a317"
-                            }, 
-                            {
-                                "$oid": "57e1933df6858f0a02a4a317"
-                            }
-                        ], 
-                        "exit_ts": 1440689540.7012274
-                    }
-                }, 
-                {
-                    "geometry": {
-                        "type": "Point", 
-                        "coordinates": [
-                            -122.0778188, 
-                            37.3957356
-                        ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19345f6858f0a02a4a5cb", 
-                    "properties": {
-                        "enter_fmt_time": "2015-08-27T08:41:16.784000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 18, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 51
-                        }, 
-                        "display_name": "Moffett Boulevard, Mountain View", 
-                        "feature_type": "end_place", 
-                        "exit_fmt_time": "2015-08-27T08:51:18.068474-07:00", 
-                        "enter_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 16, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 41
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19340f6858f0a02a4a36f"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19341f6858f0a02a4a385"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440690076.784, 
-                        "duration": 601.2844743728638, 
-                        "raw_places": [
-                            {
-                                "$oid": "57e1933df6858f0a02a4a319"
-                            }, 
-                            {
-                                "$oid": "57e1933df6858f0a02a4a319"
-                            }
-                        ], 
-                        "exit_ts": 1440690678.0684743
-                    }
-                }, 
-                {
-                    "type": "FeatureCollection", 
-                    "features": [
-                        {
-                            "geometry": {
-                                "type": "LineString", 
-                                "coordinates": [
-                                    [
-                                        -122.0835641, 
-                                        37.4034802
-                                    ], 
-                                    [
-                                        -122.08324947759913, 
-                                        37.403249485086526
-                                    ], 
-                                    [
-                                        -122.08293485519823, 
-                                        37.403018770173055
-                                    ], 
-                                    [
-                                        -122.08262023279735, 
-                                        37.402788055259585
-                                    ], 
-                                    [
-                                        -122.08230561039646, 
-                                        37.402557340346114
-                                    ], 
-                                    [
-                                        -122.08146304068424, 
-                                        37.40240305189178
-                                    ], 
-                                    [
-                                        -122.0798705375145, 
-                                        37.40192739503022
-                                    ], 
-                                    [
-                                        -122.0791330715329, 
-                                        37.401570416313966
-                                    ], 
-                                    [
-                                        -122.07900239094822, 
-                                        37.40154684580483
-                                    ], 
-                                    [
-                                        -122.07839491401299, 
-                                        37.40110036136816
-                                    ], 
-                                    [
-                                        -122.07793701515128, 
-                                        37.39922447059321
-                                    ], 
-                                    [
-                                        -122.07727089547438, 
-                                        37.39817899676297
-                                    ], 
-                                    [
-                                        -122.0763436450106, 
-                                        37.39786335105958
-                                    ], 
-                                    [
-                                        -122.07721299122628, 
-                                        37.39661146003307
-                                    ], 
-                                    [
-                                        -122.0778060271274, 
-                                        37.39579266489395
-                                    ], 
-                                    [
-                                        -122.0778487389895, 
-                                        37.39573904255864
-                                    ], 
-                                    [
-                                        -122.07784370441615, 
-                                        37.39575069197053
-                                    ], 
-                                    [
-                                        -122.07781181592573, 
-                                        37.395726926020124
-                                    ], 
-                                    [
-                                        -122.0778188, 
-                                        37.3957356
-                                    ]
-                                ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19341f6858f0a02a4a371", 
-                            "properties": {
+                                ],
                                 "distances": [
-                                    0.0, 
-                                    37.821656471425634, 
-                                    37.82171934756227, 
-                                    37.82178222161217, 
-                                    37.82184509726472, 
-                                    76.37758376499968, 
-                                    150.2841583396648, 
-                                    76.28348087578676, 
-                                    11.837213039553651, 
-                                    73.10437219356047, 
-                                    212.47509056879474, 
-                                    130.29519720589417, 
-                                    89.11368730792431, 
-                                    158.98246624379556, 
-                                    105.04234777736924, 
-                                    7.056098167565988, 
-                                    1.3695808449654496, 
-                                    3.8625446169801814, 
-                                    1.144954240021904
-                                ], 
-                                "feature_type": "section", 
-                                "distance": 1248.5157783247416, 
-                                "end_ts": 1440690076.784, 
-                                "start_ts": 1440689540.7012274, 
-                                "start_fmt_time": "2015-08-27T08:32:20.701227-07:00", 
-                                "sensed_mode": "MotionTypes.BICYCLING", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T08:41:16.784000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 8, 
-                                    "month": 8, 
-                                    "second": 16, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 41
-                                }, 
-                                "duration": 536.0827724933624, 
-                                "trip_id": {
-                                    "$oid": "57e19340f6858f0a02a4a36f"
-                                }, 
-                                "start_local_dt": {
-                                    "hour": 8, 
-                                    "month": 8, 
-                                    "second": 20, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 32
-                                }, 
-                                "speeds": [
-                                    0.0, 
-                                    1.2607218823808544, 
-                                    1.2607239782520758, 
-                                    1.260726074053739, 
-                                    1.260728169908824, 
-                                    2.545919458833323, 
-                                    5.009471944655493, 
-                                    2.5427826958595587, 
-                                    0.3945737679851217, 
-                                    2.4368124064520154, 
-                                    7.082503018959825, 
-                                    4.343173240196473, 
-                                    2.970456243597477, 
-                                    5.299415541459852, 
-                                    3.501411592578975, 
-                                    0.2352032722521996, 
-                                    0.04565269483218166, 
-                                    0.1287514872326727, 
-                                    0.04389695306790232
-                                ]
-                            }
+                                    0.0,
+                                    13.107986040605232,
+                                    47.107560490081966,
+                                    14.667588016993776,
+                                    43.857925823474915
+                                ],
+                                "distance": 118.7410603711559,
+                                "sensed_mode": "MotionTypes.ON_FOOT",
+                                "start_stop": {
+                                    "$oid": "5f3d68ee6fdd485ce81b5bfb"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68ee6fdd485ce81b5bf5"
                         }
                     ]
                 }
-            ], 
-            "type": "FeatureCollection", 
-            "id": "57e19340f6858f0a02a4a36f", 
+            ],
+            "id": "5f3d68ee6fdd485ce81b5bdf"
+        },
+        {
+            "type": "FeatureCollection",
             "properties": {
-                "distance": 1248.5157783247416, 
-                "end_place": {
-                    "$oid": "57e19345f6858f0a02a4a5cb"
-                }, 
-                "raw_trip": {
-                    "$oid": "57e1933df6858f0a02a4a318"
-                }, 
-                "feature_type": "trip", 
-                "start_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.0835641, 
-                        37.4034802
-                    ]
-                }, 
-                "end_ts": 1440690076.784, 
-                "start_ts": 1440689540.7012274, 
-                "start_fmt_time": "2015-08-27T08:32:20.701227-07:00", 
+                "source": "DwellSegmentationTimeFilter",
+                "end_ts": 1440690076.784,
+                "end_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 8,
+                    "minute": 41,
+                    "second": 16,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "end_fmt_time": "2015-08-27T08:41:16.784000-07:00",
                 "end_loc": {
-                    "type": "Point", 
+                    "type": "Point",
                     "coordinates": [
-                        -122.0778188, 
+                        -122.0778188,
                         37.3957356
                     ]
-                }, 
-                "source": "DwellSegmentationTimeFilter", 
-                "start_place": {
-                    "$oid": "57e19345f6858f0a02a4a5ca"
-                }, 
-                "end_fmt_time": "2015-08-27T08:41:16.784000-07:00", 
-                "end_local_dt": {
-                    "hour": 8, 
-                    "month": 8, 
-                    "second": 16, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 41
-                }, 
-                "duration": 536.0827724933624, 
+                },
+                "raw_trip": {
+                    "$oid": "5f3d68ec6fdd485ce81b5ba5"
+                },
+                "start_ts": 1440689540.7012274,
                 "start_local_dt": {
-                    "hour": 8, 
-                    "month": 8, 
-                    "second": 20, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 32
-                }
-            }
-        }, 
-        {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 8,
+                    "minute": 32,
+                    "second": 20,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "start_fmt_time": "2015-08-27T08:32:20.701227-07:00",
+                "start_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.0835641,
+                        37.4034802
+                    ]
+                },
+                "duration": 536.0827724933624,
+                "distance": 1248.5157783247416,
+                "start_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e57"
+                },
+                "end_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e58"
+                },
+                "feature_type": "trip"
+            },
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.0778188, 
+                            -122.0835641,
+                            37.4034802
+                        ]
+                    },
+                    "properties": {
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440689408.302,
+                        "enter_local_dt": {
+                            "hour": 8,
+                            "month": 8,
+                            "second": 8,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
+                            "minute": 30
+                        },
+                        "enter_fmt_time": "2015-08-27T08:30:08.302000-07:00",
+                        "raw_places": [
+                            {
+                                "$oid": "5f3d68ec6fdd485ce81b5ba4"
+                            },
+                            {
+                                "$oid": "5f3d68ec6fdd485ce81b5ba4"
+                            }
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68ee6fdd485ce81b5bdf"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68ee6fdd485ce81b5bfc"
+                        },
+                        "exit_ts": 1440689540.7012274,
+                        "exit_fmt_time": "2015-08-27T08:32:20.701227-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 8,
+                            "minute": 32,
+                            "second": 20,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 132.39922738075256,
+                        "feature_type": "start_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e57"
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            -122.0778188,
                             37.3957356
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19345f6858f0a02a4a5cb", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T08:41:16.784000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 18, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 51
-                        }, 
-                        "display_name": "Moffett Boulevard, Mountain View", 
-                        "feature_type": "start_place", 
-                        "exit_fmt_time": "2015-08-27T08:51:18.068474-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440690076.784,
                         "enter_local_dt": {
-                            "hour": 8, 
-                            "month": 8, 
-                            "second": 16, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 8,
+                            "month": 8,
+                            "second": 16,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 41
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19340f6858f0a02a4a36f"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19341f6858f0a02a4a385"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440690076.784, 
-                        "duration": 601.2844743728638, 
+                        },
+                        "enter_fmt_time": "2015-08-27T08:41:16.784000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a319"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5ba6"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a319"
+                                "$oid": "5f3d68ec6fdd485ce81b5ba6"
                             }
-                        ], 
-                        "exit_ts": 1440690678.0684743
-                    }
-                }, 
-                {
-                    "geometry": {
-                        "type": "Point", 
-                        "coordinates": [
-                            -122.3872605, 
-                            37.5995036
-                        ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19345f6858f0a02a4a5cc", 
-                    "properties": {
-                        "enter_fmt_time": "2015-08-27T09:53:44.894000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 10, 
-                            "month": 8, 
-                            "second": 16, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 2
-                        }, 
-                        "display_name": "El Camino Real, Millbrae", 
-                        "feature_type": "end_place", 
-                        "exit_fmt_time": "2015-08-27T10:02:16.470599-07:00", 
-                        "enter_local_dt": {
-                            "hour": 9, 
-                            "month": 8, 
-                            "second": 44, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 53
-                        }, 
+                        ],
                         "ending_trip": {
-                            "$oid": "57e19341f6858f0a02a4a385"
-                        }, 
+                            "$oid": "5f3d68ee6fdd485ce81b5bfc"
+                        },
                         "starting_trip": {
-                            "$oid": "57e19341f6858f0a02a4a409"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440694424.894, 
-                        "duration": 511.57659935951233, 
-                        "raw_places": [
-                            {
-                                "$oid": "57e1933df6858f0a02a4a31b"
-                            }, 
-                            {
-                                "$oid": "57e1933df6858f0a02a4a31b"
-                            }
-                        ], 
-                        "exit_ts": 1440694936.4705994
-                    }
-                }, 
-                {
-                    "geometry": {
-                        "type": "LineString", 
-                        "coordinates": [
-                            [
-                                -122.3871681, 
-                                37.5992489
-                            ], 
-                            [
-                                -122.3872958, 
-                                37.5992574
-                            ]
-                        ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19341f6858f0a02a4a408", 
-                    "properties": {
-                        "enter_fmt_time": "2015-08-27T09:52:14.783000-07:00", 
-                        "distance": 11.289935021388207, 
+                            "$oid": "5f3d68ef6fdd485ce81b5c12"
+                        },
+                        "exit_ts": 1440690678.0684743,
+                        "exit_fmt_time": "2015-08-27T08:51:18.068474-07:00",
                         "exit_local_dt": {
-                            "hour": 9, 
-                            "month": 8, 
-                            "second": 44, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 52
-                        }, 
-                        "feature_type": "stop", 
-                        "ending_section": {
-                            "$oid": "57e19341f6858f0a02a4a387"
-                        }, 
-                        "starting_section": {
-                            "$oid": "57e19341f6858f0a02a4a403"
-                        }, 
-                        "exit_fmt_time": "2015-08-27T09:52:44.740000-07:00", 
-                        "enter_local_dt": {
-                            "hour": 9, 
-                            "month": 8, 
-                            "second": 14, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 52
-                        }, 
-                        "exit_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.3872958, 
-                                37.5992574
-                            ]
-                        }, 
-                        "source": "SmoothedHighConfidenceMotion", 
-                        "enter_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.3871681, 
-                                37.5992489
-                            ]
-                        }, 
-                        "enter_ts": 1440694334.783, 
-                        "duration": 29.957000017166138, 
-                        "trip_id": {
-                            "$oid": "57e19341f6858f0a02a4a385"
-                        }, 
-                        "exit_ts": 1440694364.74
-                    }
-                }, 
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 8,
+                            "minute": 51,
+                            "second": 18,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 601.2844743728638,
+                        "feature_type": "end_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e58"
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.0778188, 
+                                        -122.0835641,
+                                        37.4034802
+                                    ],
+                                    [
+                                        -122.08324947759913,
+                                        37.403249485086526
+                                    ],
+                                    [
+                                        -122.08293485519823,
+                                        37.403018770173055
+                                    ],
+                                    [
+                                        -122.08262023279735,
+                                        37.402788055259585
+                                    ],
+                                    [
+                                        -122.08230561039646,
+                                        37.402557340346114
+                                    ],
+                                    [
+                                        -122.08146304068424,
+                                        37.40240305189178
+                                    ],
+                                    [
+                                        -122.0798705375145,
+                                        37.40192739503022
+                                    ],
+                                    [
+                                        -122.0791330715329,
+                                        37.401570416313966
+                                    ],
+                                    [
+                                        -122.07900239094822,
+                                        37.40154684580483
+                                    ],
+                                    [
+                                        -122.07839491401299,
+                                        37.40110036136816
+                                    ],
+                                    [
+                                        -122.07793701515128,
+                                        37.39922447059321
+                                    ],
+                                    [
+                                        -122.07727089547438,
+                                        37.39817899676297
+                                    ],
+                                    [
+                                        -122.0763436450106,
+                                        37.39786335105958
+                                    ],
+                                    [
+                                        -122.07721299122628,
+                                        37.39661146003307
+                                    ],
+                                    [
+                                        -122.0778060271274,
+                                        37.39579266489395
+                                    ],
+                                    [
+                                        -122.0778487389895,
+                                        37.39573904255864
+                                    ],
+                                    [
+                                        -122.07784370441615,
+                                        37.39575069197053
+                                    ],
+                                    [
+                                        -122.07781181592573,
+                                        37.395726926020124
+                                    ],
+                                    [
+                                        -122.0778188,
                                         37.3957356
-                                    ], 
+                                    ]
+                                ]
+                            },
+                            "properties": {
+                                "times": [
+                                    1440689540.7012274,
+                                    1440689570.7012274,
+                                    1440689600.7012274,
+                                    1440689630.7012274,
+                                    1440689660.7012274,
+                                    1440689690.7012274,
+                                    1440689720.7012274,
+                                    1440689750.7012274,
+                                    1440689780.7012274,
+                                    1440689810.7012274,
+                                    1440689840.7012274,
+                                    1440689870.7012274,
+                                    1440689900.7012274,
+                                    1440689930.7012274,
+                                    1440689960.7012274,
+                                    1440689990.7012274,
+                                    1440690020.7012274,
+                                    1440690050.7012274,
+                                    1440690076.784
+                                ],
+                                "timestamps": [
+                                    1440689540701,
+                                    1440689570701,
+                                    1440689600701,
+                                    1440689630701,
+                                    1440689660701,
+                                    1440689690701,
+                                    1440689720701,
+                                    1440689750701,
+                                    1440689780701,
+                                    1440689810701,
+                                    1440689840701,
+                                    1440689870701,
+                                    1440689900701,
+                                    1440689930701,
+                                    1440689960701,
+                                    1440689990701,
+                                    1440690020701,
+                                    1440690050701,
+                                    1440690076784
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
+                                "trip_id": {
+                                    "$oid": "5f3d68ee6fdd485ce81b5bfc"
+                                },
+                                "start_ts": 1440689540.7012274,
+                                "start_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 8,
+                                    "minute": 32,
+                                    "second": 20,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T08:32:20.701227-07:00",
+                                "end_ts": 1440690076.784,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 8,
+                                    "minute": 41,
+                                    "second": 16,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T08:41:16.784000-07:00",
+                                "duration": 536.0827724933624,
+                                "speeds": [
+                                    0.0,
+                                    1.2607218823808544,
+                                    1.2607239782520758,
+                                    1.260726074053739,
+                                    1.260728169908824,
+                                    2.545919458833323,
+                                    5.009471944655493,
+                                    2.5427826958595587,
+                                    0.3945737679851217,
+                                    2.4368124064520154,
+                                    7.082503018959825,
+                                    4.343173240196473,
+                                    2.970456243597477,
+                                    5.299415541459852,
+                                    3.501411592578975,
+                                    0.2352032722521996,
+                                    0.04565269483218166,
+                                    0.1287514872326727,
+                                    0.04389695306790232
+                                ],
+                                "distances": [
+                                    0.0,
+                                    37.821656471425634,
+                                    37.82171934756227,
+                                    37.82178222161217,
+                                    37.82184509726472,
+                                    76.37758376499968,
+                                    150.2841583396648,
+                                    76.28348087578676,
+                                    11.837213039553651,
+                                    73.10437219356047,
+                                    212.47509056879474,
+                                    130.29519720589417,
+                                    89.11368730792431,
+                                    158.98246624379556,
+                                    105.04234777736924,
+                                    7.056098167565988,
+                                    1.3695808449654496,
+                                    3.8625446169801814,
+                                    1.144954240021904
+                                ],
+                                "distance": 1248.5157783247416,
+                                "sensed_mode": "MotionTypes.BICYCLING",
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68ee6fdd485ce81b5bfe"
+                        }
+                    ]
+                }
+            ],
+            "id": "5f3d68ee6fdd485ce81b5bfc"
+        },
+        {
+            "type": "FeatureCollection",
+            "properties": {
+                "source": "DwellSegmentationTimeFilter",
+                "end_ts": 1440694424.894,
+                "end_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 9,
+                    "minute": 53,
+                    "second": 44,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "end_fmt_time": "2015-08-27T09:53:44.894000-07:00",
+                "end_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.3872605,
+                        37.5995036
+                    ]
+                },
+                "raw_trip": {
+                    "$oid": "5f3d68ec6fdd485ce81b5ba7"
+                },
+                "start_ts": 1440690678.0684743,
+                "start_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 8,
+                    "minute": 51,
+                    "second": 18,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "start_fmt_time": "2015-08-27T08:51:18.068474-07:00",
+                "start_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.0778188,
+                        37.3957356
+                    ]
+                },
+                "duration": 3746.8255257606506,
+                "distance": 38139.68281615126,
+                "start_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e58"
+                },
+                "end_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e59"
+                },
+                "feature_type": "trip"
+            },
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            -122.0778188,
+                            37.3957356
+                        ]
+                    },
+                    "properties": {
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440690076.784,
+                        "enter_local_dt": {
+                            "hour": 8,
+                            "month": 8,
+                            "second": 16,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
+                            "minute": 41
+                        },
+                        "enter_fmt_time": "2015-08-27T08:41:16.784000-07:00",
+                        "raw_places": [
+                            {
+                                "$oid": "5f3d68ec6fdd485ce81b5ba6"
+                            },
+                            {
+                                "$oid": "5f3d68ec6fdd485ce81b5ba6"
+                            }
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68ee6fdd485ce81b5bfc"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c12"
+                        },
+                        "exit_ts": 1440690678.0684743,
+                        "exit_fmt_time": "2015-08-27T08:51:18.068474-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 8,
+                            "minute": 51,
+                            "second": 18,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 601.2844743728638,
+                        "feature_type": "start_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e58"
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [
+                            -122.3872605,
+                            37.5995036
+                        ]
+                    },
+                    "properties": {
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440694424.894,
+                        "enter_local_dt": {
+                            "hour": 9,
+                            "month": 8,
+                            "second": 44,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
+                            "minute": 53
+                        },
+                        "enter_fmt_time": "2015-08-27T09:53:44.894000-07:00",
+                        "raw_places": [
+                            {
+                                "$oid": "5f3d68ec6fdd485ce81b5ba8"
+                            },
+                            {
+                                "$oid": "5f3d68ec6fdd485ce81b5ba8"
+                            }
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c12"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c96"
+                        },
+                        "exit_ts": 1440694936.4705994,
+                        "exit_fmt_time": "2015-08-27T10:02:16.470599-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 10,
+                            "minute": 2,
+                            "second": 16,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 511.57659935951233,
+                        "feature_type": "end_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e59"
+                },
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "LineString",
+                        "coordinates": [
+                            [
+                                -122.3871681,
+                                37.5992489
+                            ],
+                            [
+                                -122.3872958,
+                                37.5992574
+                            ]
+                        ]
+                    },
+                    "properties": {
+                        "trip_id": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c12"
+                        },
+                        "source": "SmoothedHighConfidenceMotion",
+                        "ending_section": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c14"
+                        },
+                        "starting_section": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c90"
+                        },
+                        "enter_ts": 1440694334.783,
+                        "enter_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 9,
+                            "minute": 52,
+                            "second": 14,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "enter_fmt_time": "2015-08-27T09:52:14.783000-07:00",
+                        "enter_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.3871681,
+                                37.5992489
+                            ]
+                        },
+                        "exit_ts": 1440694364.74,
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 9,
+                            "minute": 52,
+                            "second": 44,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "exit_fmt_time": "2015-08-27T09:52:44.740000-07:00",
+                        "exit_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.3872958,
+                                37.5992574
+                            ]
+                        },
+                        "duration": 29.957000017166138,
+                        "distance": 11.289935021388207,
+                        "feature_type": "stop"
+                    },
+                    "id": "5f3d68ef6fdd485ce81b5c95"
+                },
+                {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "geometry": {
+                                "type": "LineString",
+                                "coordinates": [
                                     [
-                                        -122.07660654999759, 
+                                        -122.0778188,
+                                        37.3957356
+                                    ],
+                                    [
+                                        -122.07660654999759,
                                         37.39456072144058
-                                    ], 
+                                    ],
                                     [
-                                        -122.07703128803301, 
+                                        -122.07703128803301,
                                         37.39499901449131
-                                    ], 
+                                    ],
                                     [
-                                        -122.07693977651971, 
+                                        -122.07693977651971,
                                         37.39489713959271
-                                    ], 
+                                    ],
                                     [
-                                        -122.07621276697498, 
+                                        -122.07621276697498,
                                         37.39419027472781
-                                    ], 
+                                    ],
                                     [
-                                        -122.07695012405632, 
+                                        -122.07695012405632,
                                         37.39497735214064
-                                    ], 
+                                    ],
                                     [
-                                        -122.0773244426609, 
+                                        -122.0773244426609,
                                         37.39554575871095
-                                    ], 
+                                    ],
                                     [
-                                        -122.07656070292657, 
+                                        -122.07656070292657,
                                         37.39476671704662
-                                    ], 
+                                    ],
                                     [
-                                        -122.07614654248451, 
+                                        -122.07614654248451,
                                         37.394161568409956
-                                    ], 
+                                    ],
                                     [
-                                        -122.0769821065766, 
+                                        -122.0769821065766,
                                         37.39496173342311
-                                    ], 
+                                    ],
                                     [
-                                        -122.07780373497364, 
+                                        -122.07780373497364,
                                         37.39575002837487
-                                    ], 
+                                    ],
                                     [
-                                        -122.07693511627583, 
+                                        -122.07693511627583,
                                         37.39537516849832
-                                    ], 
+                                    ],
                                     [
-                                        -122.07613277218154, 
+                                        -122.07613277218154,
                                         37.39464493491124
-                                    ], 
+                                    ],
                                     [
-                                        -122.0769465304055, 
+                                        -122.0769465304055,
                                         37.39492254603883
-                                    ], 
+                                    ],
                                     [
-                                        -122.07775580197237, 
+                                        -122.07775580197237,
                                         37.395665812171615
-                                    ], 
+                                    ],
                                     [
-                                        -122.07777708281208, 
+                                        -122.07777708281208,
                                         37.395692959610834
-                                    ], 
+                                    ],
                                     [
-                                        -122.07703167637662, 
+                                        -122.07703167637662,
                                         37.39523580013956
-                                    ], 
+                                    ],
                                     [
-                                        -122.07617844906807, 
+                                        -122.07617844906807,
                                         37.39444732228772
-                                    ], 
+                                    ],
                                     [
-                                        -122.07680636430835, 
+                                        -122.07680636430835,
                                         37.39484276624094
-                                    ], 
+                                    ],
                                     [
-                                        -122.07766097119134, 
+                                        -122.07766097119134,
                                         37.39567411118327
-                                    ], 
+                                    ],
                                     [
-                                        -122.07777873872614, 
+                                        -122.07777873872614,
                                         37.395702045030184
-                                    ], 
+                                    ],
                                     [
-                                        -122.07745676796908, 
+                                        -122.07745676796908,
                                         37.39546895570065
-                                    ], 
+                                    ],
                                     [
-                                        -122.07701558769867, 
+                                        -122.07701558769867,
                                         37.395175167868345
-                                    ], 
+                                    ],
                                     [
-                                        -122.07679038796083, 
+                                        -122.07679038796083,
                                         37.39511906704948
-                                    ], 
+                                    ],
                                     [
-                                        -122.07656518822299, 
+                                        -122.07656518822299,
                                         37.39506296623061
-                                    ], 
+                                    ],
                                     [
-                                        -122.07633998848513, 
+                                        -122.07633998848513,
                                         37.395006865411744
-                                    ], 
+                                    ],
                                     [
-                                        -122.07858774113826, 
+                                        -122.07858774113826,
                                         37.395967641680684
-                                    ], 
+                                    ],
                                     [
-                                        -122.08369123295923, 
+                                        -122.08369123295923,
                                         37.39810269681527
-                                    ], 
+                                    ],
                                     [
-                                        -122.08879472478019, 
+                                        -122.08879472478019,
                                         37.40023775194986
-                                    ], 
+                                    ],
                                     [
-                                        -122.09389821660115, 
+                                        -122.09389821660115,
                                         37.40237280708445
-                                    ], 
+                                    ],
                                     [
-                                        -122.09900170842211, 
+                                        -122.09900170842211,
                                         37.404507862219035
-                                    ], 
+                                    ],
                                     [
-                                        -122.10410520024307, 
+                                        -122.10410520024307,
                                         37.40664291735362
-                                    ], 
+                                    ],
                                     [
-                                        -122.10859855786589, 
+                                        -122.10859855786589,
                                         37.408832669443896
-                                    ], 
+                                    ],
                                     [
-                                        -122.11241198666, 
+                                        -122.11241198666,
                                         37.41108337539829
-                                    ], 
+                                    ],
                                     [
-                                        -122.11622541545414, 
+                                        -122.11622541545414,
                                         37.41333408135269
-                                    ], 
+                                    ],
                                     [
-                                        -122.12003884424827, 
+                                        -122.12003884424827,
                                         37.415584787307075
-                                    ], 
+                                    ],
                                     [
-                                        -122.12385227304239, 
+                                        -122.12385227304239,
                                         37.41783549326147
-                                    ], 
+                                    ],
                                     [
-                                        -122.12766570183652, 
+                                        -122.12766570183652,
                                         37.420086199215866
-                                    ], 
+                                    ],
                                     [
-                                        -122.13147913063065, 
+                                        -122.13147913063065,
                                         37.42233690517026
-                                    ], 
+                                    ],
                                     [
-                                        -122.13598325323161, 
+                                        -122.13598325323161,
                                         37.4255030785857
-                                    ], 
+                                    ],
                                     [
-                                        -122.14003690023162, 
+                                        -122.14003690023162,
                                         37.42842470636199
-                                    ], 
+                                    ],
                                     [
-                                        -122.14147408205909, 
+                                        -122.14147408205909,
                                         37.42922198746185
-                                    ], 
+                                    ],
                                     [
-                                        -122.14148232355679, 
+                                        -122.14148232355679,
                                         37.429231737486006
-                                    ], 
+                                    ],
                                     [
-                                        -122.14145101061618, 
+                                        -122.14145101061618,
                                         37.42919940457275
-                                    ], 
+                                    ],
                                     [
-                                        -122.1414762, 
+                                        -122.1414762,
                                         37.4292348
-                                    ], 
+                                    ],
                                     [
-                                        -122.144099836764, 
+                                        -122.144099836764,
                                         37.43083338198012
-                                    ], 
+                                    ],
                                     [
-                                        -122.1494730313887, 
+                                        -122.1494730313887,
                                         37.43410726966938
-                                    ], 
+                                    ],
                                     [
-                                        -122.15430930456168, 
+                                        -122.15430930456168,
                                         37.43708741828502
-                                    ], 
+                                    ],
                                     [
-                                        -122.15857020612101, 
+                                        -122.15857020612101,
                                         37.43975279250628
-                                    ], 
+                                    ],
                                     [
-                                        -122.16283110768033, 
+                                        -122.16283110768033,
                                         37.44241816672755
-                                    ], 
+                                    ],
                                     [
-                                        -122.16547201379088, 
+                                        -122.16547201379088,
                                         37.44378099413941
-                                    ], 
+                                    ],
                                     [
-                                        -122.16546226792761, 
+                                        -122.16546226792761,
                                         37.44377188743012
-                                    ], 
+                                    ],
                                     [
-                                        -122.16496869608399, 
+                                        -122.16496869608399,
                                         37.4439417226034
-                                    ], 
+                                    ],
                                     [
-                                        -122.16664826743006, 
+                                        -122.16664826743006,
                                         37.44505560790172
-                                    ], 
+                                    ],
                                     [
-                                        -122.16941918415795, 
+                                        -122.16941918415795,
                                         37.446845384407396
-                                    ], 
+                                    ],
                                     [
-                                        -122.17219010088583, 
+                                        -122.17219010088583,
                                         37.44863516091308
-                                    ], 
+                                    ],
                                     [
-                                        -122.1749610176137, 
+                                        -122.1749610176137,
                                         37.45042493741876
-                                    ], 
+                                    ],
                                     [
-                                        -122.17773193434158, 
+                                        -122.17773193434158,
                                         37.452214713924434
-                                    ], 
+                                    ],
                                     [
-                                        -122.18050285106946, 
+                                        -122.18050285106946,
                                         37.454004490430115
-                                    ], 
+                                    ],
                                     [
-                                        -122.18264724551449, 
+                                        -122.18264724551449,
                                         37.455214483163914
-                                    ], 
+                                    ],
                                     [
-                                        -122.18297810964648, 
+                                        -122.18297810964648,
                                         37.455235131383176
-                                    ], 
+                                    ],
                                     [
-                                        -122.18297686525415, 
+                                        -122.18297686525415,
                                         37.45527218076798
-                                    ], 
+                                    ],
                                     [
-                                        -122.18713795096838, 
+                                        -122.18713795096838,
                                         37.45781431746067
-                                    ], 
+                                    ],
                                     [
-                                        -122.1929025658848, 
+                                        -122.1929025658848,
                                         37.46129683612763
-                                    ], 
+                                    ],
                                     [
-                                        -122.19866718080121, 
+                                        -122.19866718080121,
                                         37.464779354794594
-                                    ], 
+                                    ],
                                     [
-                                        -122.20443179571761, 
+                                        -122.20443179571761,
                                         37.46826187346155
-                                    ], 
+                                    ],
                                     [
-                                        -122.21019641063403, 
+                                        -122.21019641063403,
                                         37.471744392128514
-                                    ], 
+                                    ],
                                     [
-                                        -122.21618389438028, 
+                                        -122.21618389438028,
                                         37.47556835878493
-                                    ], 
+                                    ],
                                     [
-                                        -122.22248018426622, 
+                                        -122.22248018426622,
                                         37.47986543437994
-                                    ], 
+                                    ],
                                     [
-                                        -122.22786078088636, 
+                                        -122.22786078088636,
                                         37.4835067943925
-                                    ], 
+                                    ],
                                     [
-                                        -122.23108375004372, 
+                                        -122.23108375004372,
                                         37.485603106514795
-                                    ], 
+                                    ],
                                     [
-                                        -122.23225699253433, 
+                                        -122.23225699253433,
                                         37.48620091911665
-                                    ], 
+                                    ],
                                     [
-                                        -122.2321511775737, 
+                                        -122.2321511775737,
                                         37.48620419495981
-                                    ], 
+                                    ],
                                     [
-                                        -122.23241207404774, 
+                                        -122.23241207404774,
                                         37.48617285760916
-                                    ], 
+                                    ],
                                     [
-                                        -122.23398831876868, 
+                                        -122.23398831876868,
                                         37.487134410005766
-                                    ], 
+                                    ],
                                     [
-                                        -122.23943041317476, 
+                                        -122.23943041317476,
                                         37.49122673417343
-                                    ], 
+                                    ],
                                     [
-                                        -122.2455370842562, 
+                                        -122.2455370842562,
                                         37.495851977453015
-                                    ], 
+                                    ],
                                     [
-                                        -122.25142240778833, 
+                                        -122.25142240778833,
                                         37.500278752753495
-                                    ], 
+                                    ],
                                     [
-                                        -122.2570208754801, 
+                                        -122.2570208754801,
                                         37.504448323042624
-                                    ], 
+                                    ],
                                     [
-                                        -122.26027132095192, 
+                                        -122.26027132095192,
                                         37.507434375975016
-                                    ], 
+                                    ],
                                     [
-                                        -122.26046001994818, 
+                                        -122.26046001994818,
                                         37.50819964006774
-                                    ], 
+                                    ],
                                     [
-                                        -122.26064940266124, 
+                                        -122.26064940266124,
                                         37.5079579447635
-                                    ], 
+                                    ],
                                     [
-                                        -122.26152367315831, 
+                                        -122.26152367315831,
                                         37.508729210441174
-                                    ], 
+                                    ],
                                     [
-                                        -122.2640377644885, 
+                                        -122.2640377644885,
                                         37.51125979406965
-                                    ], 
+                                    ],
                                     [
-                                        -122.26867429569661, 
+                                        -122.26867429569661,
                                         37.51495781847613
-                                    ], 
+                                    ],
                                     [
-                                        -122.27399461371064, 
+                                        -122.27399461371064,
                                         37.51912899219387
-                                    ], 
+                                    ],
                                     [
-                                        -122.27637247894461, 
+                                        -122.27637247894461,
                                         37.52098225263054
-                                    ], 
+                                    ],
                                     [
-                                        -122.2763114592649, 
+                                        -122.2763114592649,
                                         37.52099782324391
-                                    ], 
+                                    ],
                                     [
-                                        -122.27667532843432, 
+                                        -122.27667532843432,
                                         37.52163423648792
-                                    ], 
+                                    ],
                                     [
-                                        -122.27858418130852, 
+                                        -122.27858418130852,
                                         37.5237360923309
-                                    ], 
+                                    ],
                                     [
-                                        -122.28316454924034, 
+                                        -122.28316454924034,
                                         37.52701888766555
-                                    ], 
+                                    ],
                                     [
-                                        -122.28958599148355, 
+                                        -122.28958599148355,
                                         37.53104006173062
-                                    ], 
+                                    ],
                                     [
-                                        -122.29402852309204, 
+                                        -122.29402852309204,
                                         37.53437420727346
-                                    ], 
+                                    ],
                                     [
-                                        -122.2953152362625, 
+                                        -122.2953152362625,
                                         37.53578614727399
-                                    ], 
+                                    ],
                                     [
-                                        -122.29660194943297, 
+                                        -122.29660194943297,
                                         37.53719808727451
-                                    ], 
+                                    ],
                                     [
-                                        -122.29788866260344, 
+                                        -122.29788866260344,
                                         37.53861002727504
-                                    ], 
+                                    ],
                                     [
-                                        -122.29917537577391, 
+                                        -122.29917537577391,
                                         37.54002196727557
-                                    ], 
+                                    ],
                                     [
-                                        -122.30046208894439, 
+                                        -122.30046208894439,
                                         37.541433907276094
-                                    ], 
+                                    ],
                                     [
-                                        -122.3012202, 
+                                        -122.3012202,
                                         37.5422658
-                                    ], 
+                                    ],
                                     [
-                                        -122.3052290479125, 
+                                        -122.3052290479125,
                                         37.54754146562808
-                                    ], 
+                                    ],
                                     [
-                                        -122.31128456477818, 
+                                        -122.31128456477818,
                                         37.55551055871561
-                                    ], 
+                                    ],
                                     [
-                                        -122.31641791047278, 
+                                        -122.31641791047278,
                                         37.56157693508609
-                                    ], 
+                                    ],
                                     [
-                                        -122.32023650050748, 
+                                        -122.32023650050748,
                                         37.564930574763665
-                                    ], 
+                                    ],
                                     [
-                                        -122.32296187030548, 
+                                        -122.32296187030548,
                                         37.56735132173891
-                                    ], 
+                                    ],
                                     [
-                                        -122.32410066495781, 
+                                        -122.32410066495781,
                                         37.568418174663016
-                                    ], 
+                                    ],
                                     [
-                                        -122.32494813303497, 
+                                        -122.32494813303497,
                                         37.56911649122644
-                                    ], 
+                                    ],
                                     [
-                                        -122.325290614839, 
+                                        -122.325290614839,
                                         37.569248328814474
-                                    ], 
+                                    ],
                                     [
-                                        -122.3265090502192, 
+                                        -122.3265090502192,
                                         37.57047125747109
-                                    ], 
+                                    ],
                                     [
-                                        -122.32954718553631, 
+                                        -122.32954718553631,
                                         37.573293981907106
-                                    ], 
+                                    ],
                                     [
-                                        -122.33313459012408, 
+                                        -122.33313459012408,
                                         37.57541392247153
-                                    ], 
+                                    ],
                                     [
-                                        -122.33757778016441, 
+                                        -122.33757778016441,
                                         37.57708148442267
-                                    ], 
+                                    ],
                                     [
-                                        -122.34282387936587, 
+                                        -122.34282387936587,
                                         37.57933179090499
-                                    ], 
+                                    ],
                                     [
-                                        -122.34439244314186, 
+                                        -122.34439244314186,
                                         37.57976284466154
-                                    ], 
+                                    ],
                                     [
-                                        -122.34447976949346, 
+                                        -122.34447976949346,
                                         37.57979139163968
-                                    ], 
+                                    ],
                                     [
-                                        -122.34590809481755, 
+                                        -122.34590809481755,
                                         37.580255662628915
-                                    ], 
+                                    ],
                                     [
-                                        -122.34982977449144, 
+                                        -122.34982977449144,
                                         37.581962860370666
-                                    ], 
+                                    ],
                                     [
-                                        -122.35472086432704, 
+                                        -122.35472086432704,
                                         37.58423058432976
-                                    ], 
+                                    ],
                                     [
-                                        -122.35961195416263, 
+                                        -122.35961195416263,
                                         37.586498308288846
-                                    ], 
+                                    ],
                                     [
-                                        -122.36569387896331, 
+                                        -122.36569387896331,
                                         37.58931658076369
-                                    ], 
+                                    ],
                                     [
-                                        -122.3731212731016, 
+                                        -122.3731212731016,
                                         37.59275689253746
-                                    ], 
+                                    ],
                                     [
-                                        -122.38054866723989, 
+                                        -122.38054866723989,
                                         37.59619720431123
-                                    ], 
+                                    ],
                                     [
-                                        -122.38714456884063, 
+                                        -122.38714456884063,
                                         37.59925076473339
-                                    ], 
+                                    ],
                                     [
-                                        -122.3871681, 
+                                        -122.3871681,
                                         37.5992489
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19341f6858f0a02a4a387", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    168.92426472704878, 
-                                    61.50674138503169, 
-                                    13.916798687232438, 
-                                    101.50257955627998, 
-                                    109.09937793571125, 
-                                    71.33158116013323, 
-                                    109.80013133061675, 
-                                    76.59319377989856, 
-                                    115.60730883034128, 
-                                    113.8049948541516, 
-                                    87.32421554412873, 
-                                    107.78259958236092, 
-                                    78.23560749590261, 
-                                    109.27769970344485, 
-                                    3.5561918249091202, 
-                                    83.18783633084949, 
-                                    115.62109416660469, 
-                                    70.78479927884882, 
-                                    119.35285090261704, 
-                                    10.85736281508804, 
-                                    38.48065393635627, 
-                                    50.85425493485951, 
-                                    20.849377828782753, 
-                                    20.849392037133104, 
-                                    20.849406246664095, 
-                                    225.48215400574873, 
-                                    509.5229688398732, 
-                                    509.511604891406, 
-                                    509.50024045933486, 
-                                    509.4888755436904, 
-                                    509.4775101445037, 
-                                    465.6180290029492, 
-                                    419.61563041106314, 
-                                    419.60750771496845, 
-                                    419.5993846870563, 
-                                    419.59126132877134, 
-                                    419.5831376417531, 
-                                    419.57501362348154, 
-                                    531.1763356074165, 
-                                    483.3926970028211, 
-                                    154.80374109095158, 
-                                    1.305747195417739, 
-                                    4.535503446726655, 
-                                    4.520804338810805, 
-                                    292.00267063320416, 
-                                    598.0077198748444, 
-                                    540.5065297160809, 
-                                    478.9155245225908, 
-                                    478.90499951467484, 
-                                    278.0702869609237, 
-                                    1.3287893311159091, 
-                                    47.490382028262445, 
-                                    193.2015705532464, 
-                                    315.3486501667541, 
-                                    315.3441107272651, 
-                                    315.3395711444095, 
-                                    315.3350314211181, 
-                                    315.33049155597917, 
-                                    232.23226289667326, 
-                                    29.295400642256393, 
-                                    4.121167705370678, 
-                                    463.4726344812118, 
-                                    639.4081740336483, 
-                                    639.3893173318919, 
-                                    639.3704594551043, 
-                                    639.3516004078897, 
-                                    678.2247730510699, 
-                                    732.8040846125862, 
-                                    623.9844982806363, 
-                                    367.70464950689546, 
-                                    123.02440819269749, 
-                                    9.343491851795617, 
-                                    23.28196510597105, 
-                                    175.42527642198888, 
-                                    661.5243811555102, 
-                                    744.8277361761103, 
-                                    715.4453681491283, 
-                                    677.3911492517191, 
-                                    438.6976602591421, 
-                                    86.70609482321359, 
-                                    31.643899562036005, 
-                                    115.33394360505284, 
-                                    358.2663444356864, 
-                                    579.9358074510931, 
-                                    659.7756976014618, 
-                                    294.0153823877059, 
-                                    5.653111731426852, 
-                                    77.70198839853164, 
-                                    288.03126341937576, 
-                                    544.4310238623791, 
-                                    721.5112214828997, 
-                                    539.3552708630775, 
-                                    193.70478701797444, 
-                                    193.70352882615745, 
-                                    193.70227061018318, 
-                                    193.701012368867, 
-                                    193.6997541022115, 
-                                    114.12424342069181, 
-                                    684.8707820478421, 
-                                    1034.4988237503694, 
-                                    812.2606919728466, 
-                                    502.3397635147115, 
-                                    360.77157377084126, 
-                                    155.3923662566552, 
-                                    107.74188202645576, 
-                                    33.55621358039076, 
-                                    173.27214223029367, 
-                                    412.5646669182797, 
-                                    394.3609005251167, 
-                                    433.2486057891365, 
-                                    525.6817050360011, 
-                                    146.30062117948447, 
-                                    8.32439317321614, 
-                                    136.04284329265397, 
-                                    394.2881015235877, 
-                                    499.34147308347576, 
-                                    499.3301409937256, 
-                                    620.7979667825371, 
-                                    758.0294768332428, 
-                                    758.003359576214, 
-                                    673.0330676376088, 
-                                    2.0834265056587395
-                                ], 
-                                "end_ts": 1440694334.783, 
-                                "feature_type": "section", 
-                                "distance": 38070.43688294189, 
-                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
-                                "start_ts": 1440690678.0684743, 
-                                "start_fmt_time": "2015-08-27T08:51:18.068474-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T09:52:14.783000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 9, 
-                                    "month": 8, 
-                                    "second": 14, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 52
-                                }, 
-                                "duration": 3656.7145256996155, 
-                                "end_stop": {
-                                    "$oid": "57e19341f6858f0a02a4a408"
-                                }, 
+                                "times": [
+                                    1440690678.0684743,
+                                    1440690708.0684743,
+                                    1440690738.0684743,
+                                    1440690768.0684743,
+                                    1440690798.0684743,
+                                    1440690828.0684743,
+                                    1440690858.0684743,
+                                    1440690888.0684743,
+                                    1440690918.0684743,
+                                    1440690948.0684743,
+                                    1440690978.0684743,
+                                    1440691008.0684743,
+                                    1440691038.0684743,
+                                    1440691068.0684743,
+                                    1440691098.0684743,
+                                    1440691128.0684743,
+                                    1440691158.0684743,
+                                    1440691188.0684743,
+                                    1440691218.0684743,
+                                    1440691248.0684743,
+                                    1440691278.0684743,
+                                    1440691308.0684743,
+                                    1440691338.0684743,
+                                    1440691368.0684743,
+                                    1440691398.0684743,
+                                    1440691428.0684743,
+                                    1440691458.0684743,
+                                    1440691488.0684743,
+                                    1440691518.0684743,
+                                    1440691548.0684743,
+                                    1440691578.0684743,
+                                    1440691608.0684743,
+                                    1440691638.0684743,
+                                    1440691668.0684743,
+                                    1440691698.0684743,
+                                    1440691728.0684743,
+                                    1440691758.0684743,
+                                    1440691788.0684743,
+                                    1440691818.0684743,
+                                    1440691848.0684743,
+                                    1440691878.0684743,
+                                    1440691908.0684743,
+                                    1440691938.0684743,
+                                    1440691968.0684743,
+                                    1440691998.0684743,
+                                    1440692028.0684743,
+                                    1440692058.0684743,
+                                    1440692088.0684743,
+                                    1440692118.0684743,
+                                    1440692148.0684743,
+                                    1440692178.0684743,
+                                    1440692208.0684743,
+                                    1440692238.0684743,
+                                    1440692268.0684743,
+                                    1440692298.0684743,
+                                    1440692328.0684743,
+                                    1440692358.0684743,
+                                    1440692388.0684743,
+                                    1440692418.0684743,
+                                    1440692448.0684743,
+                                    1440692478.0684743,
+                                    1440692508.0684743,
+                                    1440692538.0684743,
+                                    1440692568.0684743,
+                                    1440692598.0684743,
+                                    1440692628.0684743,
+                                    1440692658.0684743,
+                                    1440692688.0684743,
+                                    1440692718.0684743,
+                                    1440692748.0684743,
+                                    1440692778.0684743,
+                                    1440692808.0684743,
+                                    1440692838.0684743,
+                                    1440692868.0684743,
+                                    1440692898.0684743,
+                                    1440692928.0684743,
+                                    1440692958.0684743,
+                                    1440692988.0684743,
+                                    1440693018.0684743,
+                                    1440693048.0684743,
+                                    1440693078.0684743,
+                                    1440693108.0684743,
+                                    1440693138.0684743,
+                                    1440693168.0684743,
+                                    1440693198.0684743,
+                                    1440693228.0684743,
+                                    1440693258.0684743,
+                                    1440693288.0684743,
+                                    1440693318.0684743,
+                                    1440693348.0684743,
+                                    1440693378.0684743,
+                                    1440693408.0684743,
+                                    1440693438.0684743,
+                                    1440693468.0684743,
+                                    1440693498.0684743,
+                                    1440693528.0684743,
+                                    1440693558.0684743,
+                                    1440693588.0684743,
+                                    1440693618.0684743,
+                                    1440693648.0684743,
+                                    1440693678.0684743,
+                                    1440693708.0684743,
+                                    1440693738.0684743,
+                                    1440693768.0684743,
+                                    1440693798.0684743,
+                                    1440693828.0684743,
+                                    1440693858.0684743,
+                                    1440693888.0684743,
+                                    1440693918.0684743,
+                                    1440693948.0684743,
+                                    1440693978.0684743,
+                                    1440694008.0684743,
+                                    1440694038.0684743,
+                                    1440694068.0684743,
+                                    1440694098.0684743,
+                                    1440694128.0684743,
+                                    1440694158.0684743,
+                                    1440694188.0684743,
+                                    1440694218.0684743,
+                                    1440694248.0684743,
+                                    1440694278.0684743,
+                                    1440694308.0684743,
+                                    1440694334.783
+                                ],
+                                "timestamps": [
+                                    1440690678068,
+                                    1440690708068,
+                                    1440690738068,
+                                    1440690768068,
+                                    1440690798068,
+                                    1440690828068,
+                                    1440690858068,
+                                    1440690888068,
+                                    1440690918068,
+                                    1440690948068,
+                                    1440690978068,
+                                    1440691008068,
+                                    1440691038068,
+                                    1440691068068,
+                                    1440691098068,
+                                    1440691128068,
+                                    1440691158068,
+                                    1440691188068,
+                                    1440691218068,
+                                    1440691248068,
+                                    1440691278068,
+                                    1440691308068,
+                                    1440691338068,
+                                    1440691368068,
+                                    1440691398068,
+                                    1440691428068,
+                                    1440691458068,
+                                    1440691488068,
+                                    1440691518068,
+                                    1440691548068,
+                                    1440691578068,
+                                    1440691608068,
+                                    1440691638068,
+                                    1440691668068,
+                                    1440691698068,
+                                    1440691728068,
+                                    1440691758068,
+                                    1440691788068,
+                                    1440691818068,
+                                    1440691848068,
+                                    1440691878068,
+                                    1440691908068,
+                                    1440691938068,
+                                    1440691968068,
+                                    1440691998068,
+                                    1440692028068,
+                                    1440692058068,
+                                    1440692088068,
+                                    1440692118068,
+                                    1440692148068,
+                                    1440692178068,
+                                    1440692208068,
+                                    1440692238068,
+                                    1440692268068,
+                                    1440692298068,
+                                    1440692328068,
+                                    1440692358068,
+                                    1440692388068,
+                                    1440692418068,
+                                    1440692448068,
+                                    1440692478068,
+                                    1440692508068,
+                                    1440692538068,
+                                    1440692568068,
+                                    1440692598068,
+                                    1440692628068,
+                                    1440692658068,
+                                    1440692688068,
+                                    1440692718068,
+                                    1440692748068,
+                                    1440692778068,
+                                    1440692808068,
+                                    1440692838068,
+                                    1440692868068,
+                                    1440692898068,
+                                    1440692928068,
+                                    1440692958068,
+                                    1440692988068,
+                                    1440693018068,
+                                    1440693048068,
+                                    1440693078068,
+                                    1440693108068,
+                                    1440693138068,
+                                    1440693168068,
+                                    1440693198068,
+                                    1440693228068,
+                                    1440693258068,
+                                    1440693288068,
+                                    1440693318068,
+                                    1440693348068,
+                                    1440693378068,
+                                    1440693408068,
+                                    1440693438068,
+                                    1440693468068,
+                                    1440693498068,
+                                    1440693528068,
+                                    1440693558068,
+                                    1440693588068,
+                                    1440693618068,
+                                    1440693648068,
+                                    1440693678068,
+                                    1440693708068,
+                                    1440693738068,
+                                    1440693768068,
+                                    1440693798068,
+                                    1440693828068,
+                                    1440693858068,
+                                    1440693888068,
+                                    1440693918068,
+                                    1440693948068,
+                                    1440693978068,
+                                    1440694008068,
+                                    1440694038068,
+                                    1440694068068,
+                                    1440694098068,
+                                    1440694128068,
+                                    1440694158068,
+                                    1440694188068,
+                                    1440694218068,
+                                    1440694248068,
+                                    1440694278068,
+                                    1440694308068,
+                                    1440694334783
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19341f6858f0a02a4a385"
-                                }, 
+                                    "$oid": "5f3d68ef6fdd485ce81b5c12"
+                                },
+                                "start_ts": 1440690678.0684743,
                                 "start_local_dt": {
-                                    "hour": 8, 
-                                    "month": 8, 
-                                    "second": 18, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 51
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 8,
+                                    "minute": 51,
+                                    "second": 18,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T08:51:18.068474-07:00",
+                                "end_ts": 1440694334.783,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 9,
+                                    "minute": 52,
+                                    "second": 14,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T09:52:14.783000-07:00",
+                                "duration": 3656.7145256996155,
                                 "speeds": [
-                                    0.0, 
-                                    5.630808824234959, 
-                                    2.05022471283439, 
-                                    0.4638932895744146, 
-                                    3.383419318542666, 
-                                    3.6366459311903747, 
-                                    2.377719372004441, 
-                                    3.660004377687225, 
-                                    2.553106459329952, 
-                                    3.853576961011376, 
-                                    3.79349982847172, 
-                                    2.910807184804291, 
-                                    3.5927533194120307, 
-                                    2.607853583196754, 
-                                    3.6425899901148284, 
-                                    0.11853972749697067, 
-                                    2.772927877694983, 
-                                    3.8540364722201566, 
-                                    2.359493309294961, 
-                                    3.978428363420568, 
-                                    0.361912093836268, 
-                                    1.282688464545209, 
-                                    1.6951418311619837, 
-                                    0.6949792609594251, 
-                                    0.6949797345711034, 
-                                    0.6949802082221365, 
-                                    7.516071800191624, 
-                                    16.984098961329106, 
-                                    16.98372016304687, 
-                                    16.983341348644494, 
-                                    16.982962518123013, 
-                                    16.982583671483457, 
-                                    15.520600966764972, 
-                                    13.987187680368772, 
-                                    13.98691692383228, 
-                                    13.986646156235208, 
-                                    13.986375377625711, 
-                                    13.986104588058437, 
-                                    13.985833787449385, 
-                                    17.70587785358055, 
-                                    16.113089900094035, 
-                                    5.160124703031719, 
-                                    0.043524906513924634, 
-                                    0.15118344822422183, 
-                                    0.15069347796036017, 
-                                    9.733422354440139, 
-                                    19.93359066249481, 
-                                    18.016884323869363, 
-                                    15.963850817419692, 
-                                    15.963499983822494, 
-                                    9.269009565364122, 
-                                    0.04429297770386364, 
-                                    1.5830127342754148, 
-                                    6.44005235177488, 
-                                    10.511621672225138, 
-                                    10.511470357575503, 
-                                    10.511319038146983, 
-                                    10.51116771403727, 
-                                    10.511016385199305, 
-                                    7.741075429889109, 
-                                    0.9765133547418797, 
-                                    0.13737225684568927, 
-                                    15.449087816040393, 
-                                    21.313605801121607, 
-                                    21.312977244396397, 
-                                    21.312348648503477, 
-                                    21.31172001359632, 
-                                    22.607492435035663, 
-                                    24.42680282041954, 
-                                    20.79948327602121, 
-                                    12.256821650229849, 
-                                    4.10081360642325, 
-                                    0.31144972839318724, 
-                                    0.7760655035323684, 
-                                    5.847509214066296, 
-                                    22.050812705183674, 
-                                    24.827591205870345, 
-                                    23.848178938304276, 
-                                    22.579704975057304, 
-                                    14.623255341971403, 
-                                    2.8902031607737864, 
-                                    1.0547966520678669, 
-                                    3.8444647868350947, 
-                                    11.942211481189547, 
-                                    19.3311935817031, 
-                                    21.99252325338206, 
-                                    9.800512746256864, 
-                                    0.18843705771422842, 
-                                    2.5900662799510545, 
-                                    9.601042113979192, 
-                                    18.147700795412636, 
-                                    24.05037404942999, 
-                                    17.97850902876925, 
-                                    6.456826233932481, 
-                                    6.4567842942052485, 
-                                    6.456742353672772, 
-                                    6.456700412295566, 
-                                    6.456658470073717, 
-                                    3.8041414473563937, 
-                                    22.829026068261403, 
-                                    34.483294125012314, 
-                                    27.07535639909489, 
-                                    16.744658783823716, 
-                                    12.025719125694708, 
-                                    5.179745541888507, 
-                                    3.591396067548525, 
-                                    1.118540452679692, 
-                                    5.775738074343122, 
-                                    13.752155563942658, 
-                                    13.145363350837222, 
-                                    14.441620192971216, 
-                                    17.522723501200037, 
-                                    4.876687372649482, 
-                                    0.277479772440538, 
-                                    4.534761443088466, 
-                                    13.142936717452924, 
-                                    16.644715769449192, 
-                                    16.644338033124185, 
-                                    20.693265559417902, 
-                                    25.26764922777476, 
-                                    25.26677865254047, 
-                                    22.434435587920294, 
+                                    0.0,
+                                    5.630808824234959,
+                                    2.05022471283439,
+                                    0.4638932895744146,
+                                    3.383419318542666,
+                                    3.6366459311903747,
+                                    2.377719372004441,
+                                    3.660004377687225,
+                                    2.553106459329952,
+                                    3.853576961011376,
+                                    3.79349982847172,
+                                    2.910807184804291,
+                                    3.5927533194120307,
+                                    2.607853583196754,
+                                    3.6425899901148284,
+                                    0.11853972749697067,
+                                    2.772927877694983,
+                                    3.8540364722201566,
+                                    2.359493309294961,
+                                    3.978428363420568,
+                                    0.361912093836268,
+                                    1.282688464545209,
+                                    1.6951418311619837,
+                                    0.6949792609594251,
+                                    0.6949797345711034,
+                                    0.6949802082221365,
+                                    7.516071800191624,
+                                    16.984098961329106,
+                                    16.98372016304687,
+                                    16.983341348644494,
+                                    16.982962518123013,
+                                    16.982583671483457,
+                                    15.520600966764972,
+                                    13.987187680368772,
+                                    13.98691692383228,
+                                    13.986646156235208,
+                                    13.986375377625711,
+                                    13.986104588058437,
+                                    13.985833787449385,
+                                    17.70587785358055,
+                                    16.113089900094035,
+                                    5.160124703031719,
+                                    0.043524906513924634,
+                                    0.15118344822422183,
+                                    0.15069347796036017,
+                                    9.733422354440139,
+                                    19.93359066249481,
+                                    18.016884323869363,
+                                    15.963850817419692,
+                                    15.963499983822494,
+                                    9.269009565364122,
+                                    0.04429297770386364,
+                                    1.5830127342754148,
+                                    6.44005235177488,
+                                    10.511621672225138,
+                                    10.511470357575503,
+                                    10.511319038146983,
+                                    10.51116771403727,
+                                    10.511016385199305,
+                                    7.741075429889109,
+                                    0.9765133547418797,
+                                    0.13737225684568927,
+                                    15.449087816040393,
+                                    21.313605801121607,
+                                    21.312977244396397,
+                                    21.312348648503477,
+                                    21.31172001359632,
+                                    22.607492435035663,
+                                    24.42680282041954,
+                                    20.79948327602121,
+                                    12.256821650229849,
+                                    4.10081360642325,
+                                    0.31144972839318724,
+                                    0.7760655035323684,
+                                    5.847509214066296,
+                                    22.050812705183674,
+                                    24.827591205870345,
+                                    23.848178938304276,
+                                    22.579704975057304,
+                                    14.623255341971403,
+                                    2.8902031607737864,
+                                    1.0547966520678669,
+                                    3.8444647868350947,
+                                    11.942211481189547,
+                                    19.3311935817031,
+                                    21.99252325338206,
+                                    9.800512746256864,
+                                    0.18843705771422842,
+                                    2.5900662799510545,
+                                    9.601042113979192,
+                                    18.147700795412636,
+                                    24.05037404942999,
+                                    17.97850902876925,
+                                    6.456826233932481,
+                                    6.4567842942052485,
+                                    6.456742353672772,
+                                    6.456700412295566,
+                                    6.456658470073717,
+                                    3.8041414473563937,
+                                    22.829026068261403,
+                                    34.483294125012314,
+                                    27.07535639909489,
+                                    16.744658783823716,
+                                    12.025719125694708,
+                                    5.179745541888507,
+                                    3.591396067548525,
+                                    1.118540452679692,
+                                    5.775738074343122,
+                                    13.752155563942658,
+                                    13.145363350837222,
+                                    14.441620192971216,
+                                    17.522723501200037,
+                                    4.876687372649482,
+                                    0.277479772440538,
+                                    4.534761443088466,
+                                    13.142936717452924,
+                                    16.644715769449192,
+                                    16.644338033124185,
+                                    20.693265559417902,
+                                    25.26764922777476,
+                                    25.26677865254047,
+                                    22.434435587920294,
                                     0.0779885268817903
-                                ]
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    168.92426472704878,
+                                    61.50674138503169,
+                                    13.916798687232438,
+                                    101.50257955627998,
+                                    109.09937793571125,
+                                    71.33158116013323,
+                                    109.80013133061675,
+                                    76.59319377989856,
+                                    115.60730883034128,
+                                    113.8049948541516,
+                                    87.32421554412873,
+                                    107.78259958236092,
+                                    78.23560749590261,
+                                    109.27769970344485,
+                                    3.5561918249091202,
+                                    83.18783633084949,
+                                    115.62109416660469,
+                                    70.78479927884882,
+                                    119.35285090261704,
+                                    10.85736281508804,
+                                    38.48065393635627,
+                                    50.85425493485951,
+                                    20.849377828782753,
+                                    20.849392037133104,
+                                    20.849406246664095,
+                                    225.48215400574873,
+                                    509.5229688398732,
+                                    509.511604891406,
+                                    509.50024045933486,
+                                    509.4888755436904,
+                                    509.4775101445037,
+                                    465.6180290029492,
+                                    419.61563041106314,
+                                    419.60750771496845,
+                                    419.5993846870563,
+                                    419.59126132877134,
+                                    419.5831376417531,
+                                    419.57501362348154,
+                                    531.1763356074165,
+                                    483.3926970028211,
+                                    154.80374109095158,
+                                    1.305747195417739,
+                                    4.535503446726655,
+                                    4.520804338810805,
+                                    292.00267063320416,
+                                    598.0077198748444,
+                                    540.5065297160809,
+                                    478.9155245225908,
+                                    478.90499951467484,
+                                    278.0702869609237,
+                                    1.3287893311159091,
+                                    47.490382028262445,
+                                    193.2015705532464,
+                                    315.3486501667541,
+                                    315.3441107272651,
+                                    315.3395711444095,
+                                    315.3350314211181,
+                                    315.33049155597917,
+                                    232.23226289667326,
+                                    29.295400642256393,
+                                    4.121167705370678,
+                                    463.4726344812118,
+                                    639.4081740336483,
+                                    639.3893173318919,
+                                    639.3704594551043,
+                                    639.3516004078897,
+                                    678.2247730510699,
+                                    732.8040846125862,
+                                    623.9844982806363,
+                                    367.70464950689546,
+                                    123.02440819269749,
+                                    9.343491851795617,
+                                    23.28196510597105,
+                                    175.42527642198888,
+                                    661.5243811555102,
+                                    744.8277361761103,
+                                    715.4453681491283,
+                                    677.3911492517191,
+                                    438.6976602591421,
+                                    86.70609482321359,
+                                    31.643899562036005,
+                                    115.33394360505284,
+                                    358.2663444356864,
+                                    579.9358074510931,
+                                    659.7756976014618,
+                                    294.0153823877059,
+                                    5.653111731426852,
+                                    77.70198839853164,
+                                    288.03126341937576,
+                                    544.4310238623791,
+                                    721.5112214828997,
+                                    539.3552708630775,
+                                    193.70478701797444,
+                                    193.70352882615745,
+                                    193.70227061018318,
+                                    193.701012368867,
+                                    193.6997541022115,
+                                    114.12424342069181,
+                                    684.8707820478421,
+                                    1034.4988237503694,
+                                    812.2606919728466,
+                                    502.3397635147115,
+                                    360.77157377084126,
+                                    155.3923662566552,
+                                    107.74188202645576,
+                                    33.55621358039076,
+                                    173.27214223029367,
+                                    412.5646669182797,
+                                    394.3609005251167,
+                                    433.2486057891365,
+                                    525.6817050360011,
+                                    146.30062117948447,
+                                    8.32439317321614,
+                                    136.04284329265397,
+                                    394.2881015235877,
+                                    499.34147308347576,
+                                    499.3301409937256,
+                                    620.7979667825371,
+                                    758.0294768332428,
+                                    758.003359576214,
+                                    673.0330676376088,
+                                    2.0834265056587395
+                                ],
+                                "distance": 38070.43688294189,
+                                "sensed_mode": "MotionTypes.IN_VEHICLE",
+                                "end_stop": {
+                                    "$oid": "5f3d68ef6fdd485ce81b5c95"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68ef6fdd485ce81b5c14"
                         }
                     ]
-                }, 
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.3872958, 
+                                        -122.3872958,
                                         37.5992574
-                                    ], 
+                                    ],
                                     [
-                                        -122.38706284639784, 
+                                        -122.38706284639784,
                                         37.59921186544218
-                                    ], 
+                                    ],
                                     [
-                                        -122.3872594825592, 
+                                        -122.3872594825592,
                                         37.59950210382384
-                                    ], 
+                                    ],
                                     [
-                                        -122.3872605, 
+                                        -122.3872605,
                                         37.5995036
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19341f6858f0a02a4a403", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    21.138437284785873, 
-                                    36.62858311901798, 
-                                    0.18897778418604586
-                                ], 
-                                "feature_type": "section", 
-                                "sensed_mode": "MotionTypes.ON_FOOT", 
-                                "end_ts": 1440694424.894, 
-                                "start_ts": 1440694364.74, 
-                                "start_fmt_time": "2015-08-27T09:52:44.740000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T09:53:44.894000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 9, 
-                                    "month": 8, 
-                                    "second": 44, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 53
-                                }, 
-                                "duration": 60.15400004386902, 
-                                "start_stop": {
-                                    "$oid": "57e19341f6858f0a02a4a408"
-                                }, 
+                                "times": [
+                                    1440694364.74,
+                                    1440694394.74,
+                                    1440694424.74,
+                                    1440694424.894
+                                ],
+                                "timestamps": [
+                                    1440694364740,
+                                    1440694394740,
+                                    1440694424740,
+                                    1440694424894
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19341f6858f0a02a4a385"
-                                }, 
+                                    "$oid": "5f3d68ef6fdd485ce81b5c12"
+                                },
+                                "start_ts": 1440694364.74,
                                 "start_local_dt": {
-                                    "hour": 9, 
-                                    "month": 8, 
-                                    "second": 44, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 52
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 9,
+                                    "minute": 52,
+                                    "second": 44,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T09:52:44.740000-07:00",
+                                "end_ts": 1440694424.894,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 9,
+                                    "minute": 53,
+                                    "second": 44,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T09:53:44.894000-07:00",
+                                "duration": 60.15400004386902,
                                 "speeds": [
-                                    0.0, 
-                                    0.704614576159529, 
-                                    1.2209527706339327, 
+                                    0.0,
+                                    0.704614576159529,
+                                    1.2209527706339327,
                                     1.2271281191762313
-                                ], 
-                                "distance": 57.9559981879899
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    21.138437284785873,
+                                    36.62858311901798,
+                                    0.18897778418604586
+                                ],
+                                "distance": 57.9559981879899,
+                                "sensed_mode": "MotionTypes.ON_FOOT",
+                                "start_stop": {
+                                    "$oid": "5f3d68ef6fdd485ce81b5c95"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68ef6fdd485ce81b5c90"
                         }
                     ]
                 }
-            ], 
-            "type": "FeatureCollection", 
-            "id": "57e19341f6858f0a02a4a385", 
+            ],
+            "id": "5f3d68ef6fdd485ce81b5c12"
+        },
+        {
+            "type": "FeatureCollection",
             "properties": {
-                "distance": 38139.68281615126, 
-                "end_place": {
-                    "$oid": "57e19345f6858f0a02a4a5cc"
-                }, 
-                "raw_trip": {
-                    "$oid": "57e1933df6858f0a02a4a31a"
-                }, 
-                "feature_type": "trip", 
-                "start_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.0778188, 
-                        37.3957356
-                    ]
-                }, 
-                "end_ts": 1440694424.894, 
-                "start_ts": 1440690678.0684743, 
-                "start_fmt_time": "2015-08-27T08:51:18.068474-07:00", 
+                "source": "DwellSegmentationTimeFilter",
+                "end_ts": 1440699266.669,
+                "end_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 11,
+                    "minute": 14,
+                    "second": 26,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "end_fmt_time": "2015-08-27T11:14:26.669000-07:00",
                 "end_loc": {
-                    "type": "Point", 
+                    "type": "Point",
                     "coordinates": [
-                        -122.3872605, 
+                        -122.2603947,
+                        37.875023
+                    ]
+                },
+                "raw_trip": {
+                    "$oid": "5f3d68ec6fdd485ce81b5ba9"
+                },
+                "start_ts": 1440694936.4705994,
+                "start_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 10,
+                    "minute": 2,
+                    "second": 16,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "start_fmt_time": "2015-08-27T10:02:16.470599-07:00",
+                "start_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.3872605,
                         37.5995036
                     ]
-                }, 
-                "source": "DwellSegmentationTimeFilter", 
+                },
+                "duration": 4330.1984004974365,
+                "distance": 44122.97498643092,
                 "start_place": {
-                    "$oid": "57e19345f6858f0a02a4a5cb"
-                }, 
-                "end_fmt_time": "2015-08-27T09:53:44.894000-07:00", 
-                "end_local_dt": {
-                    "hour": 9, 
-                    "month": 8, 
-                    "second": 44, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 53
-                }, 
-                "duration": 3746.8255257606506, 
-                "start_local_dt": {
-                    "hour": 8, 
-                    "month": 8, 
-                    "second": 18, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 51
-                }
-            }
-        }, 
-        {
+                    "$oid": "5f3d68f16fdd485ce81b5e59"
+                },
+                "end_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e5a"
+                },
+                "feature_type": "trip"
+            },
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.3872605, 
+                            -122.3872605,
                             37.5995036
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19345f6858f0a02a4a5cc", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T09:53:44.894000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 10, 
-                            "month": 8, 
-                            "second": 16, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 2
-                        }, 
-                        "display_name": "El Camino Real, Millbrae", 
-                        "feature_type": "start_place", 
-                        "exit_fmt_time": "2015-08-27T10:02:16.470599-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440694424.894,
                         "enter_local_dt": {
-                            "hour": 9, 
-                            "month": 8, 
-                            "second": 44, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 9,
+                            "month": 8,
+                            "second": 44,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 53
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19341f6858f0a02a4a385"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19341f6858f0a02a4a409"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440694424.894, 
-                        "duration": 511.57659935951233, 
+                        },
+                        "enter_fmt_time": "2015-08-27T09:53:44.894000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a31b"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5ba8"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a31b"
+                                "$oid": "5f3d68ec6fdd485ce81b5ba8"
                             }
-                        ], 
-                        "exit_ts": 1440694936.4705994
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c12"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c96"
+                        },
+                        "exit_ts": 1440694936.4705994,
+                        "exit_fmt_time": "2015-08-27T10:02:16.470599-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 10,
+                            "minute": 2,
+                            "second": 16,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 511.57659935951233,
+                        "feature_type": "start_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e59"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.2603947, 
+                            -122.2603947,
                             37.875023
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19346f6858f0a02a4a5cd", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T11:14:26.669000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 11, 
-                            "month": 8, 
-                            "second": 58, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 14
-                        }, 
-                        "display_name": "Hearst Avenue, Berkeley", 
-                        "feature_type": "end_place", 
-                        "exit_fmt_time": "2015-08-27T11:14:58.737183-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440699266.669,
                         "enter_local_dt": {
-                            "hour": 11, 
-                            "month": 8, 
-                            "second": 26, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 11,
+                            "month": 8,
+                            "second": 26,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 14
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19341f6858f0a02a4a409"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19342f6858f0a02a4a499"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440699266.669, 
-                        "duration": 32.068182706832886, 
+                        },
+                        "enter_fmt_time": "2015-08-27T11:14:26.669000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a31d"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5baa"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a31d"
+                                "$oid": "5f3d68ec6fdd485ce81b5baa"
                             }
-                        ], 
-                        "exit_ts": 1440699298.7371826
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c96"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5d26"
+                        },
+                        "exit_ts": 1440699298.7371826,
+                        "exit_fmt_time": "2015-08-27T11:14:58.737183-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 11,
+                            "minute": 14,
+                            "second": 58,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 32.068182706832886,
+                        "feature_type": "end_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5a"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "LineString", 
+                        "type": "LineString",
                         "coordinates": [
                             [
-                                -122.2705638, 
+                                -122.2705638,
                                 37.8440278
-                            ], 
+                            ],
                             [
-                                -122.2682605, 
+                                -122.2682605,
                                 37.8700849
                             ]
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19342f6858f0a02a4a498", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T10:54:26.704000-07:00", 
-                        "distance": 2904.4651460936093, 
-                        "exit_local_dt": {
-                            "hour": 10, 
-                            "month": 8, 
-                            "second": 26, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 58
-                        }, 
-                        "feature_type": "stop", 
+                        "trip_id": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c96"
+                        },
+                        "source": "SmoothedHighConfidenceMotion",
                         "ending_section": {
-                            "$oid": "57e19342f6858f0a02a4a40b"
-                        }, 
+                            "$oid": "5f3d68ef6fdd485ce81b5c98"
+                        },
                         "starting_section": {
-                            "$oid": "57e19342f6858f0a02a4a476"
-                        }, 
-                        "exit_fmt_time": "2015-08-27T10:58:26.892000-07:00", 
+                            "$oid": "5f3d68ef6fdd485ce81b5d03"
+                        },
+                        "enter_ts": 1440698066.704,
                         "enter_local_dt": {
-                            "hour": 10, 
-                            "month": 8, 
-                            "second": 26, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 54
-                        }, 
-                        "exit_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.2682605, 
-                                37.8700849
-                            ]
-                        }, 
-                        "source": "SmoothedHighConfidenceMotion", 
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 10,
+                            "minute": 54,
+                            "second": 26,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "enter_fmt_time": "2015-08-27T10:54:26.704000-07:00",
                         "enter_loc": {
-                            "type": "Point", 
+                            "type": "Point",
                             "coordinates": [
-                                -122.2705638, 
+                                -122.2705638,
                                 37.8440278
                             ]
-                        }, 
-                        "enter_ts": 1440698066.704, 
-                        "duration": 240.18799996376038, 
-                        "trip_id": {
-                            "$oid": "57e19341f6858f0a02a4a409"
-                        }, 
-                        "exit_ts": 1440698306.892
-                    }
-                }, 
+                        },
+                        "exit_ts": 1440698306.892,
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 10,
+                            "minute": 58,
+                            "second": 26,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "exit_fmt_time": "2015-08-27T10:58:26.892000-07:00",
+                        "exit_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.2682605,
+                                37.8700849
+                            ]
+                        },
+                        "duration": 240.18799996376038,
+                        "distance": 2904.4651460936093,
+                        "feature_type": "stop"
+                    },
+                    "id": "5f3d68ef6fdd485ce81b5d25"
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.3872605, 
+                                        -122.3872605,
                                         37.5995036
-                                    ], 
+                                    ],
                                     [
-                                        -122.38943533594255, 
+                                        -122.38943533594255,
                                         37.60181732483102
-                                    ], 
+                                    ],
                                     [
-                                        -122.3916101718851, 
+                                        -122.3916101718851,
                                         37.60413104966203
-                                    ], 
+                                    ],
                                     [
-                                        -122.39378500782767, 
+                                        -122.39378500782767,
                                         37.60644477449305
-                                    ], 
+                                    ],
                                     [
-                                        -122.39595984377023, 
+                                        -122.39595984377023,
                                         37.60875849932406
-                                    ], 
+                                    ],
                                     [
-                                        -122.39813467971278, 
+                                        -122.39813467971278,
                                         37.61107222415508
-                                    ], 
+                                    ],
                                     [
-                                        -122.40030951565534, 
+                                        -122.40030951565534,
                                         37.61338594898609
-                                    ], 
+                                    ],
                                     [
-                                        -122.4024843515979, 
+                                        -122.4024843515979,
                                         37.61569967381711
-                                    ], 
+                                    ],
                                     [
-                                        -122.40331094109018, 
+                                        -122.40331094109018,
                                         37.616812007175135
-                                    ], 
+                                    ],
                                     [
-                                        -122.40570766227482, 
+                                        -122.40570766227482,
                                         37.6199361687232
-                                    ], 
+                                    ],
                                     [
-                                        -122.40864891099417, 
+                                        -122.40864891099417,
                                         37.62371713795991
-                                    ], 
+                                    ],
                                     [
-                                        -122.41159015971351, 
+                                        -122.41159015971351,
                                         37.627498107196615
-                                    ], 
+                                    ],
                                     [
-                                        -122.41453140843286, 
+                                        -122.41453140843286,
                                         37.63127907643332
-                                    ], 
+                                    ],
                                     [
-                                        -122.4174726571522, 
+                                        -122.4174726571522,
                                         37.63506004567003
-                                    ], 
+                                    ],
                                     [
-                                        -122.42041390587156, 
+                                        -122.42041390587156,
                                         37.63884101490673
-                                    ], 
+                                    ],
                                     [
-                                        -122.4233551545909, 
+                                        -122.4233551545909,
                                         37.64262198414344
-                                    ], 
+                                    ],
                                     [
-                                        -122.42629640331025, 
+                                        -122.42629640331025,
                                         37.64640295338015
-                                    ], 
+                                    ],
                                     [
-                                        -122.4292376520296, 
+                                        -122.4292376520296,
                                         37.650183922616854
-                                    ], 
+                                    ],
                                     [
-                                        -122.43217890074894, 
+                                        -122.43217890074894,
                                         37.65396489185356
-                                    ], 
+                                    ],
                                     [
-                                        -122.43512014946829, 
+                                        -122.43512014946829,
                                         37.65774586109026
-                                    ], 
+                                    ],
                                     [
-                                        -122.43806139818763, 
+                                        -122.43806139818763,
                                         37.66152683032697
-                                    ], 
+                                    ],
                                     [
-                                        -122.44100264690698, 
+                                        -122.44100264690698,
                                         37.66530779956368
-                                    ], 
+                                    ],
                                     [
-                                        -122.44394389562632, 
+                                        -122.44394389562632,
                                         37.669088768800385
-                                    ], 
+                                    ],
                                     [
-                                        -122.44688514434567, 
+                                        -122.44688514434567,
                                         37.67286973803709
-                                    ], 
+                                    ],
                                     [
-                                        -122.44982639306501, 
+                                        -122.44982639306501,
                                         37.6766507072738
-                                    ], 
+                                    ],
                                     [
-                                        -122.45276764178436, 
+                                        -122.45276764178436,
                                         37.6804316765105
-                                    ], 
+                                    ],
                                     [
-                                        -122.45570889050371, 
+                                        -122.45570889050371,
                                         37.68421264574721
-                                    ], 
+                                    ],
                                     [
-                                        -122.45865013922305, 
+                                        -122.45865013922305,
                                         37.68799361498392
-                                    ], 
+                                    ],
                                     [
-                                        -122.4615913879424, 
+                                        -122.4615913879424,
                                         37.691774584220624
-                                    ], 
+                                    ],
                                     [
-                                        -122.46453263666174, 
+                                        -122.46453263666174,
                                         37.69555555345733
-                                    ], 
+                                    ],
                                     [
-                                        -122.4674738853811, 
+                                        -122.4674738853811,
                                         37.69933652269403
-                                    ], 
+                                    ],
                                     [
-                                        -122.47041513410043, 
+                                        -122.47041513410043,
                                         37.70311749193074
-                                    ], 
+                                    ],
                                     [
-                                        -122.46988285724983, 
+                                        -122.46988285724983,
                                         37.705054130998384
-                                    ], 
+                                    ],
                                     [
-                                        -122.46899244325444, 
+                                        -122.46899244325444,
                                         37.70585630401584
-                                    ], 
+                                    ],
                                     [
-                                        -122.46876146114758, 
+                                        -122.46876146114758,
                                         37.70591455518281
-                                    ], 
+                                    ],
                                     [
-                                        -122.46658232620851, 
+                                        -122.46658232620851,
                                         37.709378060124166
-                                    ], 
+                                    ],
                                     [
-                                        -122.46053254893589, 
+                                        -122.46053254893589,
                                         37.7104573330376
-                                    ], 
+                                    ],
                                     [
-                                        -122.455106031357, 
+                                        -122.455106031357,
                                         37.71116024632176
-                                    ], 
+                                    ],
                                     [
-                                        -122.45065720092147, 
+                                        -122.45065720092147,
                                         37.714107179215546
-                                    ], 
+                                    ],
                                     [
-                                        -122.44684381666558, 
+                                        -122.44684381666558,
                                         37.71665440785618
-                                    ], 
+                                    ],
                                     [
-                                        -122.44318181304111, 
+                                        -122.44318181304111,
                                         37.71888092335173
-                                    ], 
+                                    ],
                                     [
-                                        -122.43951980941664, 
+                                        -122.43951980941664,
                                         37.72110743884728
-                                    ], 
+                                    ],
                                     [
-                                        -122.43585780579217, 
+                                        -122.43585780579217,
                                         37.72333395434282
-                                    ], 
+                                    ],
                                     [
-                                        -122.43219580216768, 
+                                        -122.43219580216768,
                                         37.72556046983837
-                                    ], 
+                                    ],
                                     [
-                                        -122.42853379854321, 
+                                        -122.42853379854321,
                                         37.727786985333914
-                                    ], 
+                                    ],
                                     [
-                                        -122.42487179491874, 
+                                        -122.42487179491874,
                                         37.73001350082946
-                                    ], 
+                                    ],
                                     [
-                                        -122.42120979129427, 
+                                        -122.42120979129427,
                                         37.73224001632501
-                                    ], 
+                                    ],
                                     [
-                                        -122.4175477876698, 
+                                        -122.4175477876698,
                                         37.73446653182055
-                                    ], 
+                                    ],
                                     [
-                                        -122.41388578404533, 
+                                        -122.41388578404533,
                                         37.736693047316095
-                                    ], 
+                                    ],
                                     [
-                                        -122.41022378042086, 
+                                        -122.41022378042086,
                                         37.738919562811645
-                                    ], 
+                                    ],
                                     [
-                                        -122.40656177679638, 
+                                        -122.40656177679638,
                                         37.74114607830719
-                                    ], 
+                                    ],
                                     [
-                                        -122.40289977317191, 
+                                        -122.40289977317191,
                                         37.74337259380273
-                                    ], 
+                                    ],
                                     [
-                                        -122.39923776954744, 
+                                        -122.39923776954744,
                                         37.74559910929828
-                                    ], 
+                                    ],
                                     [
-                                        -122.39557576592297, 
+                                        -122.39557576592297,
                                         37.747825624793826
-                                    ], 
+                                    ],
                                     [
-                                        -122.3919137622985, 
+                                        -122.3919137622985,
                                         37.75005214028937
-                                    ], 
+                                    ],
                                     [
-                                        -122.38825175867403, 
+                                        -122.38825175867403,
                                         37.75227865578492
-                                    ], 
+                                    ],
                                     [
-                                        -122.38458975504955, 
+                                        -122.38458975504955,
                                         37.754505171280464
-                                    ], 
+                                    ],
                                     [
-                                        -122.38092775142508, 
+                                        -122.38092775142508,
                                         37.75673168677601
-                                    ], 
+                                    ],
                                     [
-                                        -122.3772657478006, 
+                                        -122.3772657478006,
                                         37.75895820227156
-                                    ], 
+                                    ],
                                     [
-                                        -122.37360374417614, 
+                                        -122.37360374417614,
                                         37.7611847177671
-                                    ], 
+                                    ],
                                     [
-                                        -122.36994174055167, 
+                                        -122.36994174055167,
                                         37.763411233262644
-                                    ], 
+                                    ],
                                     [
-                                        -122.3662797369272, 
+                                        -122.3662797369272,
                                         37.765637748758195
-                                    ], 
+                                    ],
                                     [
-                                        -122.36261773330273, 
+                                        -122.36261773330273,
                                         37.76786426425374
-                                    ], 
+                                    ],
                                     [
-                                        -122.35895572967824, 
+                                        -122.35895572967824,
                                         37.77009077974928
-                                    ], 
+                                    ],
                                     [
-                                        -122.35529372605377, 
+                                        -122.35529372605377,
                                         37.772317295244825
-                                    ], 
+                                    ],
                                     [
-                                        -122.3516317224293, 
+                                        -122.3516317224293,
                                         37.774543810740376
-                                    ], 
+                                    ],
                                     [
-                                        -122.34796971880483, 
+                                        -122.34796971880483,
                                         37.77677032623592
-                                    ], 
+                                    ],
                                     [
-                                        -122.34430771518036, 
+                                        -122.34430771518036,
                                         37.77899684173146
-                                    ], 
+                                    ],
                                     [
-                                        -122.3406457115559, 
+                                        -122.3406457115559,
                                         37.78122335722701
-                                    ], 
+                                    ],
                                     [
-                                        -122.33698370793142, 
+                                        -122.33698370793142,
                                         37.78344987272256
-                                    ], 
+                                    ],
                                     [
-                                        -122.33332170430694, 
+                                        -122.33332170430694,
                                         37.7856763882181
-                                    ], 
+                                    ],
                                     [
-                                        -122.32965970068247, 
+                                        -122.32965970068247,
                                         37.78790290371365
-                                    ], 
+                                    ],
                                     [
-                                        -122.325997697058, 
+                                        -122.325997697058,
                                         37.790129419209194
-                                    ], 
+                                    ],
                                     [
-                                        -122.32233569343353, 
+                                        -122.32233569343353,
                                         37.79235593470474
-                                    ], 
+                                    ],
                                     [
-                                        -122.31867368980906, 
+                                        -122.31867368980906,
                                         37.79458245020029
-                                    ], 
+                                    ],
                                     [
-                                        -122.31501168618459, 
+                                        -122.31501168618459,
                                         37.79680896569583
-                                    ], 
+                                    ],
                                     [
-                                        -122.31134968256012, 
+                                        -122.31134968256012,
                                         37.799035481191375
-                                    ], 
+                                    ],
                                     [
-                                        -122.30768767893564, 
+                                        -122.30768767893564,
                                         37.801261996686925
-                                    ], 
+                                    ],
                                     [
-                                        -122.30402567531117, 
+                                        -122.30402567531117,
                                         37.80348851218247
-                                    ], 
+                                    ],
                                     [
-                                        -122.3003636716867, 
+                                        -122.3003636716867,
                                         37.80571502767801
-                                    ], 
+                                    ],
                                     [
-                                        -122.29597842061877, 
+                                        -122.29597842061877,
                                         37.80514412592476
-                                    ], 
+                                    ],
                                     [
-                                        -122.29439563243965, 
+                                        -122.29439563243965,
                                         37.804597291353716
-                                    ], 
+                                    ],
                                     [
-                                        -122.29182482779107, 
+                                        -122.29182482779107,
                                         37.803846995704056
-                                    ], 
+                                    ],
                                     [
-                                        -122.28839774168254, 
+                                        -122.28839774168254,
                                         37.80285221098052
-                                    ], 
+                                    ],
                                     [
-                                        -122.28303842241617, 
+                                        -122.28303842241617,
                                         37.80095777802297
-                                    ], 
+                                    ],
                                     [
-                                        -122.2795278210576, 
+                                        -122.2795278210576,
                                         37.79952285061273
-                                    ], 
+                                    ],
                                     [
-                                        -122.27804294114121, 
+                                        -122.27804294114121,
                                         37.80045905348325
-                                    ], 
+                                    ],
                                     [
-                                        -122.2769538873445, 
+                                        -122.2769538873445,
                                         37.80222882974804
-                                    ], 
+                                    ],
                                     [
-                                        -122.2758648335478, 
+                                        -122.2758648335478,
                                         37.803998606012826
-                                    ], 
+                                    ],
                                     [
-                                        -122.2747757797511, 
+                                        -122.2747757797511,
                                         37.80576838227761
-                                    ], 
+                                    ],
                                     [
-                                        -122.27368672595439, 
+                                        -122.27368672595439,
                                         37.8075381585424
-                                    ], 
+                                    ],
                                     [
-                                        -122.27259767215769, 
+                                        -122.27259767215769,
                                         37.80930793480719
-                                    ], 
+                                    ],
                                     [
-                                        -122.27150861836098, 
+                                        -122.27150861836098,
                                         37.81107771107197
-                                    ], 
+                                    ],
                                     [
-                                        -122.27041956456428, 
+                                        -122.27041956456428,
                                         37.812847487336754
-                                    ], 
+                                    ],
                                     [
-                                        -122.26933051076757, 
+                                        -122.26933051076757,
                                         37.81461726360154
-                                    ], 
+                                    ],
                                     [
-                                        -122.27011423274739, 
+                                        -122.27011423274739,
                                         37.81493704552863
-                                    ], 
+                                    ],
                                     [
-                                        -122.271685548239, 
+                                        -122.271685548239,
                                         37.81464703414952
-                                    ], 
+                                    ],
                                     [
-                                        -122.27148344702869, 
+                                        -122.27148344702869,
                                         37.81745342519405
-                                    ], 
+                                    ],
                                     [
-                                        -122.27045693334298, 
+                                        -122.27045693334298,
                                         37.82169924825931
-                                    ], 
+                                    ],
                                     [
-                                        -122.26943041965728, 
+                                        -122.26943041965728,
                                         37.825945071324554
-                                    ], 
+                                    ],
                                     [
-                                        -122.26912589543251, 
+                                        -122.26912589543251,
                                         37.82924899416199
-                                    ], 
+                                    ],
                                     [
-                                        -122.26918657340711, 
+                                        -122.26918657340711,
                                         37.83207647786365
-                                    ], 
+                                    ],
                                     [
-                                        -122.26924725138171, 
+                                        -122.26924725138171,
                                         37.83490396156531
-                                    ], 
+                                    ],
                                     [
-                                        -122.26930792935632, 
+                                        -122.26930792935632,
                                         37.83773144526697
-                                    ], 
+                                    ],
                                     [
-                                        -122.27014330571282, 
+                                        -122.27014330571282,
                                         37.84221082079968
-                                    ], 
+                                    ],
                                     [
-                                        -122.2705638, 
+                                        -122.2705638,
                                         37.8440278
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19342f6858f0a02a4a40b", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    320.78037466966975, 
-                                    320.7768156437519, 
-                                    320.7732565044456, 
-                                    320.7696972469924, 
-                                    320.7661378761896, 
-                                    320.76257838877405, 
-                                    320.7590187880474, 
-                                    143.52288218962568, 
-                                    406.49944461902413, 
-                                    493.8223819091249, 
-                                    493.8154706327788, 
-                                    493.80855902087734, 
-                                    493.80164707090114, 
-                                    493.7947347849095, 
-                                    493.7878221624011, 
-                                    493.78090920408926, 
-                                    493.77399590878446, 
-                                    493.76708227659293, 
-                                    493.76016830891666, 
-                                    493.7532540052559, 
-                                    493.74633936632273, 
-                                    493.7394243902724, 
-                                    493.732509079835, 
-                                    493.72559343249327, 
-                                    493.7186774503041, 
-                                    493.71176113342494, 
-                                    493.70484447994403, 
-                                    493.69792749260716, 
-                                    493.6910101688985, 
-                                    493.68409251087377, 
-                                    493.67717451803617, 
-                                    220.37697303752472, 
-                                    118.71077917888171, 
-                                    21.327568512609602, 
-                                    430.19734497982296, 
-                                    545.5518897526107, 
-                                    483.71214921437246, 
-                                    510.4165217284997, 
-                                    439.020456596289, 
-                                    406.2594722352683, 
-                                    406.25179684403207, 
-                                    406.2441211533155, 
-                                    406.2364451641393, 
-                                    406.2287688721151, 
-                                    406.22109228168983, 
-                                    406.213415391902, 
-                                    406.20573820133615, 
-                                    406.1980607114664, 
-                                    406.1903829223221, 
-                                    406.1827048334788, 
-                                    406.17502644343836, 
-                                    406.1673477552021, 
-                                    406.15966876636435, 
-                                    406.15198947839883, 
-                                    406.1443098913353, 
-                                    406.13663000474855, 
-                                    406.12894981714163, 
-                                    406.1212693315152, 
-                                    406.11358854546336, 
-                                    406.1059074604604, 
-                                    406.0982260765357, 
-                                    406.0905443922738, 
-                                    406.08286241013906, 
-                                    406.07518012670914, 
-                                    406.0674975454652, 
-                                    406.0598146640017, 
-                                    406.05213148379295, 
-                                    406.0444480048686, 
-                                    406.03676422581276, 
-                                    406.0290801490898, 
-                                    406.0213957717599, 
-                                    406.0137110953766, 
-                                    406.00602612042474, 
-                                    405.99834084693384, 
-                                    405.990655273488, 
-                                    405.9829694015622, 
-                                    405.97528323217506, 
-                                    405.9675967609423, 
-                                    405.9599099923072, 
-                                    390.46021278333865, 
-                                    151.7695565532854, 
-                                    240.77721191964739, 
-                                    320.77014146564096, 
-                                    515.8363194934051, 
-                                    347.2700458252823, 
-                                    166.90630983364224, 
-                                    218.81901591627837, 
-                                    218.81801338975063, 
-                                    218.81701084273502, 
-                                    218.81600827523513, 
-                                    218.8150056872544, 
-                                    218.81400307808585, 
-                                    218.8130004498647, 
-                                    218.81199780046288, 
-                                    77.48557438226604, 
-                                    141.74701811064563, 
-                                    312.5610256599072, 
-                                    480.6471409948956, 
-                                    480.6461680138889, 
-                                    368.35174433601503, 
-                                    314.4470023504811, 
-                                    314.4469988895449, 
-                                    314.44699542852135, 
-                                    503.4568720449231, 
-                                    205.38513667072613
-                                ], 
-                                "end_ts": 1440698066.704, 
-                                "feature_type": "section", 
-                                "distance": 40069.54392210929, 
-                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
-                                "start_ts": 1440694936.4705994, 
-                                "start_fmt_time": "2015-08-27T10:02:16.470599-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T10:54:26.704000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 10, 
-                                    "month": 8, 
-                                    "second": 26, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 54
-                                }, 
-                                "duration": 3130.233400583267, 
-                                "end_stop": {
-                                    "$oid": "57e19342f6858f0a02a4a498"
-                                }, 
+                                "times": [
+                                    1440694936.4705994,
+                                    1440694966.4705994,
+                                    1440694996.4705994,
+                                    1440695026.4705994,
+                                    1440695056.4705994,
+                                    1440695086.4705994,
+                                    1440695116.4705994,
+                                    1440695146.4705994,
+                                    1440695176.4705994,
+                                    1440695206.4705994,
+                                    1440695236.4705994,
+                                    1440695266.4705994,
+                                    1440695296.4705994,
+                                    1440695326.4705994,
+                                    1440695356.4705994,
+                                    1440695386.4705994,
+                                    1440695416.4705994,
+                                    1440695446.4705994,
+                                    1440695476.4705994,
+                                    1440695506.4705994,
+                                    1440695536.4705994,
+                                    1440695566.4705994,
+                                    1440695596.4705994,
+                                    1440695626.4705994,
+                                    1440695656.4705994,
+                                    1440695686.4705994,
+                                    1440695716.4705994,
+                                    1440695746.4705994,
+                                    1440695776.4705994,
+                                    1440695806.4705994,
+                                    1440695836.4705994,
+                                    1440695866.4705994,
+                                    1440695896.4705994,
+                                    1440695926.4705994,
+                                    1440695956.4705994,
+                                    1440695986.4705994,
+                                    1440696016.4705994,
+                                    1440696046.4705994,
+                                    1440696076.4705994,
+                                    1440696106.4705994,
+                                    1440696136.4705994,
+                                    1440696166.4705994,
+                                    1440696196.4705994,
+                                    1440696226.4705994,
+                                    1440696256.4705994,
+                                    1440696286.4705994,
+                                    1440696316.4705994,
+                                    1440696346.4705994,
+                                    1440696376.4705994,
+                                    1440696406.4705994,
+                                    1440696436.4705994,
+                                    1440696466.4705994,
+                                    1440696496.4705994,
+                                    1440696526.4705994,
+                                    1440696556.4705994,
+                                    1440696586.4705994,
+                                    1440696616.4705994,
+                                    1440696646.4705994,
+                                    1440696676.4705994,
+                                    1440696706.4705994,
+                                    1440696736.4705994,
+                                    1440696766.4705994,
+                                    1440696796.4705994,
+                                    1440696826.4705994,
+                                    1440696856.4705994,
+                                    1440696886.4705994,
+                                    1440696916.4705994,
+                                    1440696946.4705994,
+                                    1440696976.4705994,
+                                    1440697006.4705994,
+                                    1440697036.4705994,
+                                    1440697066.4705994,
+                                    1440697096.4705994,
+                                    1440697126.4705994,
+                                    1440697156.4705994,
+                                    1440697186.4705994,
+                                    1440697216.4705994,
+                                    1440697246.4705994,
+                                    1440697276.4705994,
+                                    1440697306.4705994,
+                                    1440697336.4705994,
+                                    1440697366.4705994,
+                                    1440697396.4705994,
+                                    1440697426.4705994,
+                                    1440697456.4705994,
+                                    1440697486.4705994,
+                                    1440697516.4705994,
+                                    1440697546.4705994,
+                                    1440697576.4705994,
+                                    1440697606.4705994,
+                                    1440697636.4705994,
+                                    1440697666.4705994,
+                                    1440697696.4705994,
+                                    1440697726.4705994,
+                                    1440697756.4705994,
+                                    1440697786.4705994,
+                                    1440697816.4705994,
+                                    1440697846.4705994,
+                                    1440697876.4705994,
+                                    1440697906.4705994,
+                                    1440697936.4705994,
+                                    1440697966.4705994,
+                                    1440697996.4705994,
+                                    1440698026.4705994,
+                                    1440698056.4705994,
+                                    1440698066.704
+                                ],
+                                "timestamps": [
+                                    1440694936471,
+                                    1440694966471,
+                                    1440694996471,
+                                    1440695026471,
+                                    1440695056471,
+                                    1440695086471,
+                                    1440695116471,
+                                    1440695146471,
+                                    1440695176471,
+                                    1440695206471,
+                                    1440695236471,
+                                    1440695266471,
+                                    1440695296471,
+                                    1440695326471,
+                                    1440695356471,
+                                    1440695386471,
+                                    1440695416471,
+                                    1440695446471,
+                                    1440695476471,
+                                    1440695506471,
+                                    1440695536471,
+                                    1440695566471,
+                                    1440695596471,
+                                    1440695626471,
+                                    1440695656471,
+                                    1440695686471,
+                                    1440695716471,
+                                    1440695746471,
+                                    1440695776471,
+                                    1440695806471,
+                                    1440695836471,
+                                    1440695866471,
+                                    1440695896471,
+                                    1440695926471,
+                                    1440695956471,
+                                    1440695986471,
+                                    1440696016471,
+                                    1440696046471,
+                                    1440696076471,
+                                    1440696106471,
+                                    1440696136471,
+                                    1440696166471,
+                                    1440696196471,
+                                    1440696226471,
+                                    1440696256471,
+                                    1440696286471,
+                                    1440696316471,
+                                    1440696346471,
+                                    1440696376471,
+                                    1440696406471,
+                                    1440696436471,
+                                    1440696466471,
+                                    1440696496471,
+                                    1440696526471,
+                                    1440696556471,
+                                    1440696586471,
+                                    1440696616471,
+                                    1440696646471,
+                                    1440696676471,
+                                    1440696706471,
+                                    1440696736471,
+                                    1440696766471,
+                                    1440696796471,
+                                    1440696826471,
+                                    1440696856471,
+                                    1440696886471,
+                                    1440696916471,
+                                    1440696946471,
+                                    1440696976471,
+                                    1440697006471,
+                                    1440697036471,
+                                    1440697066471,
+                                    1440697096471,
+                                    1440697126471,
+                                    1440697156471,
+                                    1440697186471,
+                                    1440697216471,
+                                    1440697246471,
+                                    1440697276471,
+                                    1440697306471,
+                                    1440697336471,
+                                    1440697366471,
+                                    1440697396471,
+                                    1440697426471,
+                                    1440697456471,
+                                    1440697486471,
+                                    1440697516471,
+                                    1440697546471,
+                                    1440697576471,
+                                    1440697606471,
+                                    1440697636471,
+                                    1440697666471,
+                                    1440697696471,
+                                    1440697726471,
+                                    1440697756471,
+                                    1440697786471,
+                                    1440697816471,
+                                    1440697846471,
+                                    1440697876471,
+                                    1440697906471,
+                                    1440697936471,
+                                    1440697966471,
+                                    1440697996471,
+                                    1440698026471,
+                                    1440698056471,
+                                    1440698066704
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19341f6858f0a02a4a409"
-                                }, 
+                                    "$oid": "5f3d68ef6fdd485ce81b5c96"
+                                },
+                                "start_ts": 1440694936.4705994,
                                 "start_local_dt": {
-                                    "hour": 10, 
-                                    "month": 8, 
-                                    "second": 16, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 2
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 10,
+                                    "minute": 2,
+                                    "second": 16,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T10:02:16.470599-07:00",
+                                "end_ts": 1440698066.704,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 10,
+                                    "minute": 54,
+                                    "second": 26,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T10:54:26.704000-07:00",
+                                "duration": 3130.233400583267,
                                 "speeds": [
-                                    0.0, 
-                                    10.692679155655659, 
-                                    10.692560521458397, 
-                                    10.69244188348152, 
-                                    10.692323241566413, 
-                                    10.692204595872987, 
-                                    10.692085946292469, 
-                                    10.691967292934914, 
-                                    4.784096072987523, 
-                                    13.549981487300805, 
-                                    16.460746063637497, 
-                                    16.460515687759294, 
-                                    16.46028530069591, 
-                                    16.46005490236337, 
-                                    16.459824492830318, 
-                                    16.459594072080037, 
-                                    16.45936364013631, 
-                                    16.45913319695948, 
-                                    16.458902742553096, 
-                                    16.45867227696389, 
-                                    16.458441800175198, 
-                                    16.458211312210757, 
-                                    16.45798081300908, 
-                                    16.457750302661164, 
-                                    16.45751978108311, 
-                                    16.457289248343468, 
-                                    16.457058704447498, 
-                                    16.456828149331468, 
-                                    16.456597583086907, 
-                                    16.45636700562995, 
-                                    16.456136417029125, 
-                                    16.455905817267872, 
-                                    7.345899101250824, 
-                                    3.95702597262939, 
-                                    0.71091895042032, 
-                                    14.339911499327432, 
-                                    18.18506299175369, 
-                                    16.12373830714575, 
-                                    17.013884057616657, 
-                                    14.6340152198763, 
-                                    13.541982407842276, 
-                                    13.541726561467735, 
-                                    13.541470705110518, 
-                                    13.541214838804644, 
-                                    13.540958962403836, 
-                                    13.540703076056328, 
-                                    13.540447179730068, 
-                                    13.540191273377872, 
-                                    13.53993535704888, 
-                                    13.53967943074407, 
-                                    13.539423494449293, 
-                                    13.539167548114612, 
-                                    13.53891159184007, 
-                                    13.538655625545479, 
-                                    13.538399649279961, 
-                                    13.53814366304451, 
-                                    13.537887666824952, 
-                                    13.537631660571387, 
-                                    13.53737564438384, 
-                                    13.537119618182112, 
-                                    13.536863582015346, 
-                                    13.536607535884523, 
-                                    13.536351479742459, 
-                                    13.536095413671301, 
-                                    13.535839337556972, 
-                                    13.535583251515506, 
-                                    13.535327155466723, 
-                                    13.535071049459765, 
-                                    13.534814933495621, 
-                                    13.534558807527093, 
-                                    13.534302671636327, 
-                                    13.53404652572533, 
-                                    13.533790369845887, 
-                                    13.533534204014158, 
-                                    13.533278028231129, 
-                                    13.533021842449601, 
-                                    13.532765646718738, 
-                                    13.532509441072502, 
-                                    13.532253225364743, 
-                                    13.531996999743573, 
-                                    13.015340426111289, 
-                                    5.058985218442847, 
-                                    8.025907063988246, 
-                                    10.6923380488547, 
-                                    17.1945439831135, 
-                                    11.575668194176076, 
-                                    5.563543661121408, 
-                                    7.293967197209279, 
-                                    7.293933779658355, 
-                                    7.293900361424501, 
-                                    7.2938669425078375, 
-                                    7.29383352290848, 
-                                    7.293800102602861, 
-                                    7.293766681662157, 
-                                    7.293733260015429, 
-                                    2.582852479408868, 
-                                    4.724900603688187, 
-                                    10.41870085533024, 
-                                    16.02157136649652, 
-                                    16.021538933796297, 
-                                    12.278391477867167, 
-                                    10.481566745016037, 
-                                    10.481566629651496, 
-                                    10.481566514284046, 
-                                    16.78189573483077, 
+                                    0.0,
+                                    10.692679155655659,
+                                    10.692560521458397,
+                                    10.69244188348152,
+                                    10.692323241566413,
+                                    10.692204595872987,
+                                    10.692085946292469,
+                                    10.691967292934914,
+                                    4.784096072987523,
+                                    13.549981487300805,
+                                    16.460746063637497,
+                                    16.460515687759294,
+                                    16.46028530069591,
+                                    16.46005490236337,
+                                    16.459824492830318,
+                                    16.459594072080037,
+                                    16.45936364013631,
+                                    16.45913319695948,
+                                    16.458902742553096,
+                                    16.45867227696389,
+                                    16.458441800175198,
+                                    16.458211312210757,
+                                    16.45798081300908,
+                                    16.457750302661164,
+                                    16.45751978108311,
+                                    16.457289248343468,
+                                    16.457058704447498,
+                                    16.456828149331468,
+                                    16.456597583086907,
+                                    16.45636700562995,
+                                    16.456136417029125,
+                                    16.455905817267872,
+                                    7.345899101250824,
+                                    3.95702597262939,
+                                    0.71091895042032,
+                                    14.339911499327432,
+                                    18.18506299175369,
+                                    16.12373830714575,
+                                    17.013884057616657,
+                                    14.6340152198763,
+                                    13.541982407842276,
+                                    13.541726561467735,
+                                    13.541470705110518,
+                                    13.541214838804644,
+                                    13.540958962403836,
+                                    13.540703076056328,
+                                    13.540447179730068,
+                                    13.540191273377872,
+                                    13.53993535704888,
+                                    13.53967943074407,
+                                    13.539423494449293,
+                                    13.539167548114612,
+                                    13.53891159184007,
+                                    13.538655625545479,
+                                    13.538399649279961,
+                                    13.53814366304451,
+                                    13.537887666824952,
+                                    13.537631660571387,
+                                    13.53737564438384,
+                                    13.537119618182112,
+                                    13.536863582015346,
+                                    13.536607535884523,
+                                    13.536351479742459,
+                                    13.536095413671301,
+                                    13.535839337556972,
+                                    13.535583251515506,
+                                    13.535327155466723,
+                                    13.535071049459765,
+                                    13.534814933495621,
+                                    13.534558807527093,
+                                    13.534302671636327,
+                                    13.53404652572533,
+                                    13.533790369845887,
+                                    13.533534204014158,
+                                    13.533278028231129,
+                                    13.533021842449601,
+                                    13.532765646718738,
+                                    13.532509441072502,
+                                    13.532253225364743,
+                                    13.531996999743573,
+                                    13.015340426111289,
+                                    5.058985218442847,
+                                    8.025907063988246,
+                                    10.6923380488547,
+                                    17.1945439831135,
+                                    11.575668194176076,
+                                    5.563543661121408,
+                                    7.293967197209279,
+                                    7.293933779658355,
+                                    7.293900361424501,
+                                    7.2938669425078375,
+                                    7.29383352290848,
+                                    7.293800102602861,
+                                    7.293766681662157,
+                                    7.293733260015429,
+                                    2.582852479408868,
+                                    4.724900603688187,
+                                    10.41870085533024,
+                                    16.02157136649652,
+                                    16.021538933796297,
+                                    12.278391477867167,
+                                    10.481566745016037,
+                                    10.481566629651496,
+                                    10.481566514284046,
+                                    16.78189573483077,
                                     20.070076901568232
-                                ]
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    320.78037466966975,
+                                    320.7768156437519,
+                                    320.7732565044456,
+                                    320.7696972469924,
+                                    320.7661378761896,
+                                    320.76257838877405,
+                                    320.7590187880474,
+                                    143.52288218962568,
+                                    406.49944461902413,
+                                    493.8223819091249,
+                                    493.8154706327788,
+                                    493.80855902087734,
+                                    493.80164707090114,
+                                    493.7947347849095,
+                                    493.7878221624011,
+                                    493.78090920408926,
+                                    493.77399590878446,
+                                    493.76708227659293,
+                                    493.76016830891666,
+                                    493.7532540052559,
+                                    493.74633936632273,
+                                    493.7394243902724,
+                                    493.732509079835,
+                                    493.72559343249327,
+                                    493.7186774503041,
+                                    493.71176113342494,
+                                    493.70484447994403,
+                                    493.69792749260716,
+                                    493.6910101688985,
+                                    493.68409251087377,
+                                    493.67717451803617,
+                                    220.37697303752472,
+                                    118.71077917888171,
+                                    21.327568512609602,
+                                    430.19734497982296,
+                                    545.5518897526107,
+                                    483.71214921437246,
+                                    510.4165217284997,
+                                    439.020456596289,
+                                    406.2594722352683,
+                                    406.25179684403207,
+                                    406.2441211533155,
+                                    406.2364451641393,
+                                    406.2287688721151,
+                                    406.22109228168983,
+                                    406.213415391902,
+                                    406.20573820133615,
+                                    406.1980607114664,
+                                    406.1903829223221,
+                                    406.1827048334788,
+                                    406.17502644343836,
+                                    406.1673477552021,
+                                    406.15966876636435,
+                                    406.15198947839883,
+                                    406.1443098913353,
+                                    406.13663000474855,
+                                    406.12894981714163,
+                                    406.1212693315152,
+                                    406.11358854546336,
+                                    406.1059074604604,
+                                    406.0982260765357,
+                                    406.0905443922738,
+                                    406.08286241013906,
+                                    406.07518012670914,
+                                    406.0674975454652,
+                                    406.0598146640017,
+                                    406.05213148379295,
+                                    406.0444480048686,
+                                    406.03676422581276,
+                                    406.0290801490898,
+                                    406.0213957717599,
+                                    406.0137110953766,
+                                    406.00602612042474,
+                                    405.99834084693384,
+                                    405.990655273488,
+                                    405.9829694015622,
+                                    405.97528323217506,
+                                    405.9675967609423,
+                                    405.9599099923072,
+                                    390.46021278333865,
+                                    151.7695565532854,
+                                    240.77721191964739,
+                                    320.77014146564096,
+                                    515.8363194934051,
+                                    347.2700458252823,
+                                    166.90630983364224,
+                                    218.81901591627837,
+                                    218.81801338975063,
+                                    218.81701084273502,
+                                    218.81600827523513,
+                                    218.8150056872544,
+                                    218.81400307808585,
+                                    218.8130004498647,
+                                    218.81199780046288,
+                                    77.48557438226604,
+                                    141.74701811064563,
+                                    312.5610256599072,
+                                    480.6471409948956,
+                                    480.6461680138889,
+                                    368.35174433601503,
+                                    314.4470023504811,
+                                    314.4469988895449,
+                                    314.44699542852135,
+                                    503.4568720449231,
+                                    205.38513667072613
+                                ],
+                                "distance": 40069.54392210929,
+                                "sensed_mode": "MotionTypes.IN_VEHICLE",
+                                "end_stop": {
+                                    "$oid": "5f3d68ef6fdd485ce81b5d25"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68ef6fdd485ce81b5c98"
                         }
                     ]
-                }, 
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.2682605, 
+                                        -122.2682605,
                                         37.8700849
-                                    ], 
+                                    ],
                                     [
-                                        -122.26819713283284, 
+                                        -122.26819713283284,
                                         37.87040193716121
-                                    ], 
+                                    ],
                                     [
-                                        -122.26813583015814, 
+                                        -122.26813583015814,
                                         37.87072068746613
-                                    ], 
+                                    ],
                                     [
-                                        -122.26822581879796, 
+                                        -122.26822581879796,
                                         37.871164182922286
-                                    ], 
+                                    ],
                                     [
-                                        -122.2678958443703, 
+                                        -122.2678958443703,
                                         37.871162158361095
-                                    ], 
+                                    ],
                                     [
-                                        -122.26752496394688, 
+                                        -122.26752496394688,
                                         37.871170518780445
-                                    ], 
+                                    ],
                                     [
-                                        -122.2669616471382, 
+                                        -122.2669616471382,
                                         37.87132428027256
-                                    ], 
+                                    ],
                                     [
-                                        -122.26657931456204, 
+                                        -122.26657931456204,
                                         37.871792773695766
-                                    ], 
+                                    ],
                                     [
-                                        -122.2664828, 
+                                        -122.2664828,
                                         37.8716111
-                                    ], 
+                                    ],
                                     [
-                                        -122.2664828, 
+                                        -122.2664828,
                                         37.8716111
-                                    ], 
+                                    ],
                                     [
-                                        -122.26619605942552, 
+                                        -122.26619605942552,
                                         37.871492407385894
-                                    ], 
+                                    ],
                                     [
-                                        -122.2661958, 
+                                        -122.2661958,
                                         37.8714923
-                                    ], 
+                                    ],
                                     [
-                                        -122.2661958, 
+                                        -122.2661958,
                                         37.8714923
-                                    ], 
+                                    ],
                                     [
-                                        -122.26409632726971, 
+                                        -122.26409632726971,
                                         37.871776108026324
-                                    ], 
+                                    ],
                                     [
-                                        -122.2641226811183, 
+                                        -122.2641226811183,
                                         37.87187549738821
-                                    ], 
+                                    ],
                                     [
-                                        -122.26394716215142, 
+                                        -122.26394716215142,
                                         37.87200684391983
-                                    ], 
+                                    ],
                                     [
-                                        -122.26372716993468, 
+                                        -122.26372716993468,
                                         37.87218280433579
-                                    ], 
+                                    ],
                                     [
-                                        -122.26348596700898, 
+                                        -122.26348596700898,
                                         37.87218426858689
-                                    ], 
+                                    ],
                                     [
-                                        -122.26296046716568, 
+                                        -122.26296046716568,
                                         37.87245086295697
-                                    ], 
+                                    ],
                                     [
-                                        -122.26268984968807, 
+                                        -122.26268984968807,
                                         37.87243670371433
-                                    ], 
+                                    ],
                                     [
-                                        -122.2623930020699, 
+                                        -122.2623930020699,
                                         37.872318311399944
-                                    ], 
+                                    ],
                                     [
-                                        -122.26245328889898, 
+                                        -122.26245328889898,
                                         37.87233859482948
-                                    ], 
+                                    ],
                                     [
-                                        -122.26216949578131, 
+                                        -122.26216949578131,
                                         37.87320924283683
-                                    ], 
+                                    ],
                                     [
-                                        -122.26160711654842, 
+                                        -122.26160711654842,
                                         37.873411856018265
-                                    ], 
+                                    ],
                                     [
-                                        -122.26155910696049, 
+                                        -122.26155910696049,
                                         37.87337117829105
-                                    ], 
+                                    ],
                                     [
-                                        -122.2616393, 
+                                        -122.2616393,
                                         37.8734842
-                                    ], 
+                                    ],
                                     [
-                                        -122.2616393, 
+                                        -122.2616393,
                                         37.8734842
-                                    ], 
+                                    ],
                                     [
-                                        -122.2616393, 
+                                        -122.2616393,
                                         37.8734842
-                                    ], 
+                                    ],
                                     [
-                                        -122.26014501737879, 
+                                        -122.26014501737879,
                                         37.87502184101186
-                                    ], 
+                                    ],
                                     [
-                                        -122.26029657300413, 
+                                        -122.26029657300413,
                                         37.87508383032673
-                                    ], 
+                                    ],
                                     [
-                                        -122.26032112597528, 
+                                        -122.26032112597528,
                                         37.87506468030227
-                                    ], 
+                                    ],
                                     [
-                                        -122.2603292252078, 
+                                        -122.2603292252078,
                                         37.87501589130828
-                                    ], 
+                                    ],
                                     [
-                                        -122.2603947, 
+                                        -122.2603947,
                                         37.875023
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19342f6858f0a02a4a476", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    35.68903075935187, 
-                                    35.84955687109811, 
-                                    49.94304035632598, 
-                                    28.964879745489064, 
-                                    32.56785993557204, 
-                                    52.31848941633157, 
-                                    61.96808756733756, 
-                                    21.905639925456928, 
-                                    0.0, 
-                                    28.41942905117402, 
-                                    0.025712195801050677, 
-                                    0.0, 
-                                    186.9658067554721, 
-                                    11.291090645740372, 
-                                    21.228789016482626, 
-                                    27.489945730117572, 
-                                    21.172284757276913, 
-                                    54.83023500327235, 
-                                    23.805567390137107, 
-                                    29.192688767792855, 
-                                    5.752287699973198, 
-                                    99.96496045507438, 
-                                    54.260599607708755, 
-                                    6.181960287587016, 
-                                    14.40437296303708, 
-                                    0.0, 
-                                    0.0, 
-                                    215.48945127443346, 
-                                    14.982116212565153, 
-                                    3.0296147639092896, 
-                                    5.471466335730012, 
-                                    5.800954737773264
-                                ], 
-                                "feature_type": "section", 
-                                "sensed_mode": "MotionTypes.ON_FOOT", 
-                                "end_ts": 1440699266.669, 
-                                "start_ts": 1440698306.892, 
-                                "start_fmt_time": "2015-08-27T10:58:26.892000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T11:14:26.669000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 11, 
-                                    "month": 8, 
-                                    "second": 26, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 14
-                                }, 
-                                "duration": 959.7769999504089, 
-                                "start_stop": {
-                                    "$oid": "57e19342f6858f0a02a4a498"
-                                }, 
+                                "times": [
+                                    1440698306.892,
+                                    1440698336.892,
+                                    1440698366.892,
+                                    1440698396.892,
+                                    1440698426.892,
+                                    1440698456.892,
+                                    1440698486.892,
+                                    1440698516.892,
+                                    1440698546.892,
+                                    1440698576.892,
+                                    1440698606.892,
+                                    1440698636.892,
+                                    1440698666.892,
+                                    1440698696.892,
+                                    1440698726.892,
+                                    1440698756.892,
+                                    1440698786.892,
+                                    1440698816.892,
+                                    1440698846.892,
+                                    1440698876.892,
+                                    1440698906.892,
+                                    1440698936.892,
+                                    1440698966.892,
+                                    1440698996.892,
+                                    1440699026.892,
+                                    1440699056.892,
+                                    1440699086.892,
+                                    1440699116.892,
+                                    1440699146.892,
+                                    1440699176.892,
+                                    1440699206.892,
+                                    1440699236.892,
+                                    1440699266.669
+                                ],
+                                "timestamps": [
+                                    1440698306892,
+                                    1440698336892,
+                                    1440698366892,
+                                    1440698396892,
+                                    1440698426892,
+                                    1440698456892,
+                                    1440698486892,
+                                    1440698516892,
+                                    1440698546892,
+                                    1440698576892,
+                                    1440698606892,
+                                    1440698636892,
+                                    1440698666892,
+                                    1440698696892,
+                                    1440698726892,
+                                    1440698756892,
+                                    1440698786892,
+                                    1440698816892,
+                                    1440698846892,
+                                    1440698876892,
+                                    1440698906892,
+                                    1440698936892,
+                                    1440698966892,
+                                    1440698996892,
+                                    1440699026892,
+                                    1440699056892,
+                                    1440699086892,
+                                    1440699116892,
+                                    1440699146892,
+                                    1440699176892,
+                                    1440699206892,
+                                    1440699236892,
+                                    1440699266669
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19341f6858f0a02a4a409"
-                                }, 
+                                    "$oid": "5f3d68ef6fdd485ce81b5c96"
+                                },
+                                "start_ts": 1440698306.892,
                                 "start_local_dt": {
-                                    "hour": 10, 
-                                    "month": 8, 
-                                    "second": 26, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 58
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 10,
+                                    "minute": 58,
+                                    "second": 26,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T10:58:26.892000-07:00",
+                                "end_ts": 1440699266.669,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 11,
+                                    "minute": 14,
+                                    "second": 26,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T11:14:26.669000-07:00",
+                                "duration": 959.7769999504089,
                                 "speeds": [
-                                    0.0, 
-                                    1.1896343586450624, 
-                                    1.1949852290366036, 
-                                    1.6647680118775328, 
-                                    0.9654959915163022, 
-                                    1.0855953311857347, 
-                                    1.7439496472110525, 
-                                    2.065602918911252, 
-                                    0.7301879975152309, 
-                                    0.0, 
-                                    0.9473143017058007, 
-                                    0.0008570731933683559, 
-                                    0.0, 
-                                    6.232193558515736, 
-                                    0.37636968819134575, 
-                                    0.7076263005494209, 
-                                    0.9163315243372524, 
-                                    0.7057428252425637, 
-                                    1.8276745001090784, 
-                                    0.7935189130045702, 
-                                    0.9730896255930952, 
-                                    0.19174292333243995, 
-                                    3.332165348502479, 
-                                    1.808686653590292, 
-                                    0.20606534291956718, 
-                                    0.4801457654345693, 
-                                    0.0, 
-                                    0.0, 
-                                    7.182981709147782, 
-                                    0.49940387375217177, 
-                                    0.10098715879697633, 
-                                    0.1823822111910004, 
+                                    0.0,
+                                    1.1896343586450624,
+                                    1.1949852290366036,
+                                    1.6647680118775328,
+                                    0.9654959915163022,
+                                    1.0855953311857347,
+                                    1.7439496472110525,
+                                    2.065602918911252,
+                                    0.7301879975152309,
+                                    0.0,
+                                    0.9473143017058007,
+                                    0.0008570731933683559,
+                                    0.0,
+                                    6.232193558515736,
+                                    0.37636968819134575,
+                                    0.7076263005494209,
+                                    0.9163315243372524,
+                                    0.7057428252425637,
+                                    1.8276745001090784,
+                                    0.7935189130045702,
+                                    0.9730896255930952,
+                                    0.19174292333243995,
+                                    3.332165348502479,
+                                    1.808686653590292,
+                                    0.20606534291956718,
+                                    0.4801457654345693,
+                                    0.0,
+                                    0.0,
+                                    7.182981709147782,
+                                    0.49940387375217177,
+                                    0.10098715879697633,
+                                    0.1823822111910004,
                                     0.194813270223134
-                                ], 
-                                "distance": 1148.9659182280216
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    35.68903075935187,
+                                    35.84955687109811,
+                                    49.94304035632598,
+                                    28.964879745489064,
+                                    32.56785993557204,
+                                    52.31848941633157,
+                                    61.96808756733756,
+                                    21.905639925456928,
+                                    0.0,
+                                    28.41942905117402,
+                                    0.025712195801050677,
+                                    0.0,
+                                    186.9658067554721,
+                                    11.291090645740372,
+                                    21.228789016482626,
+                                    27.489945730117572,
+                                    21.172284757276913,
+                                    54.83023500327235,
+                                    23.805567390137107,
+                                    29.192688767792855,
+                                    5.752287699973198,
+                                    99.96496045507438,
+                                    54.260599607708755,
+                                    6.181960287587016,
+                                    14.40437296303708,
+                                    0.0,
+                                    0.0,
+                                    215.48945127443346,
+                                    14.982116212565153,
+                                    3.0296147639092896,
+                                    5.471466335730012,
+                                    5.800954737773264
+                                ],
+                                "distance": 1148.9659182280216,
+                                "sensed_mode": "MotionTypes.ON_FOOT",
+                                "start_stop": {
+                                    "$oid": "5f3d68ef6fdd485ce81b5d25"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68ef6fdd485ce81b5d03"
                         }
                     ]
                 }
-            ], 
-            "type": "FeatureCollection", 
-            "id": "57e19341f6858f0a02a4a409", 
+            ],
+            "id": "5f3d68ef6fdd485ce81b5c96"
+        },
+        {
+            "type": "FeatureCollection",
             "properties": {
-                "distance": 44122.97498643092, 
-                "end_place": {
-                    "$oid": "57e19346f6858f0a02a4a5cd"
-                }, 
-                "raw_trip": {
-                    "$oid": "57e1933df6858f0a02a4a31c"
-                }, 
-                "feature_type": "trip", 
-                "start_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.3872605, 
-                        37.5995036
-                    ]
-                }, 
-                "end_ts": 1440699266.669, 
-                "start_ts": 1440694936.4705994, 
-                "start_fmt_time": "2015-08-27T10:02:16.470599-07:00", 
+                "source": "DwellSegmentationTimeFilter",
+                "end_ts": 1440700070.129,
+                "end_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 11,
+                    "minute": 27,
+                    "second": 50,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "end_fmt_time": "2015-08-27T11:27:50.129000-07:00",
                 "end_loc": {
-                    "type": "Point", 
+                    "type": "Point",
                     "coordinates": [
-                        -122.2603947, 
+                        -122.2589186,
+                        37.8752735
+                    ]
+                },
+                "raw_trip": {
+                    "$oid": "5f3d68ec6fdd485ce81b5bab"
+                },
+                "start_ts": 1440699298.7371826,
+                "start_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 11,
+                    "minute": 14,
+                    "second": 58,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "start_fmt_time": "2015-08-27T11:14:58.737183-07:00",
+                "start_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.2603947,
                         37.875023
                     ]
-                }, 
-                "source": "DwellSegmentationTimeFilter", 
+                },
+                "duration": 771.3918173313141,
+                "distance": 179.4320067990865,
                 "start_place": {
-                    "$oid": "57e19345f6858f0a02a4a5cc"
-                }, 
-                "end_fmt_time": "2015-08-27T11:14:26.669000-07:00", 
-                "end_local_dt": {
-                    "hour": 11, 
-                    "month": 8, 
-                    "second": 26, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 14
-                }, 
-                "duration": 4330.1984004974365, 
-                "start_local_dt": {
-                    "hour": 10, 
-                    "month": 8, 
-                    "second": 16, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 2
-                }
-            }
-        }, 
-        {
+                    "$oid": "5f3d68f16fdd485ce81b5e5a"
+                },
+                "end_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e5b"
+                },
+                "feature_type": "trip"
+            },
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.2603947, 
+                            -122.2603947,
                             37.875023
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19346f6858f0a02a4a5cd", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T11:14:26.669000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 11, 
-                            "month": 8, 
-                            "second": 58, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 14
-                        }, 
-                        "display_name": "Hearst Avenue, Berkeley", 
-                        "feature_type": "start_place", 
-                        "exit_fmt_time": "2015-08-27T11:14:58.737183-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440699266.669,
                         "enter_local_dt": {
-                            "hour": 11, 
-                            "month": 8, 
-                            "second": 26, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 11,
+                            "month": 8,
+                            "second": 26,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 14
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19341f6858f0a02a4a409"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19342f6858f0a02a4a499"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440699266.669, 
-                        "duration": 32.068182706832886, 
+                        },
+                        "enter_fmt_time": "2015-08-27T11:14:26.669000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a31d"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5baa"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a31d"
+                                "$oid": "5f3d68ec6fdd485ce81b5baa"
                             }
-                        ], 
-                        "exit_ts": 1440699298.7371826
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68ef6fdd485ce81b5c96"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5d26"
+                        },
+                        "exit_ts": 1440699298.7371826,
+                        "exit_fmt_time": "2015-08-27T11:14:58.737183-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 11,
+                            "minute": 14,
+                            "second": 58,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 32.068182706832886,
+                        "feature_type": "start_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5a"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.2589186, 
+                            -122.2589186,
                             37.8752735
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19346f6858f0a02a4a5ce", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T11:27:50.129000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 11, 
-                            "month": 8, 
-                            "second": 50, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 27
-                        }, 
-                        "display_name": "Le Roy Avenue, Berkeley", 
-                        "feature_type": "end_place", 
-                        "exit_fmt_time": "2015-08-27T11:27:50.129000-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440700070.129,
                         "enter_local_dt": {
-                            "hour": 11, 
-                            "month": 8, 
-                            "second": 50, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 11,
+                            "month": 8,
+                            "second": 50,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 27
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19342f6858f0a02a4a499"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19342f6858f0a02a4a4b7"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440700070.129, 
-                        "duration": 5.0, 
+                        },
+                        "enter_fmt_time": "2015-08-27T11:27:50.129000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a31f"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5bac"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a31f"
+                                "$oid": "5f3d68ec6fdd485ce81b5bac"
                             }
-                        ], 
-                        "exit_ts": 1440700075.129
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5d26"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5d44"
+                        },
+                        "exit_ts": 1440700075.129,
+                        "exit_fmt_time": "2015-08-27T11:27:50.129000-07:00",
+                        "exit_local_dt": {
+                            "hour": 11,
+                            "month": 8,
+                            "second": 50,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
+                            "minute": 27
+                        },
+                        "duration": 5.0,
+                        "feature_type": "end_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5b"
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.2603947, 
+                                        -122.2603947,
                                         37.875023
-                                    ], 
+                                    ],
                                     [
-                                        -122.26031600874185, 
+                                        -122.26031600874185,
                                         37.87502772950762
-                                    ], 
+                                    ],
                                     [
-                                        -122.26023731748369, 
+                                        -122.26023731748369,
                                         37.87503245901524
-                                    ], 
+                                    ],
                                     [
-                                        -122.26015862622553, 
+                                        -122.26015862622553,
                                         37.87503718852286
-                                    ], 
+                                    ],
                                     [
-                                        -122.26007993496738, 
+                                        -122.26007993496738,
                                         37.87504191803048
-                                    ], 
+                                    ],
                                     [
-                                        -122.26000124370921, 
+                                        -122.26000124370921,
                                         37.8750466475381
-                                    ], 
+                                    ],
                                     [
-                                        -122.25992255245106, 
+                                        -122.25992255245106,
                                         37.87505137704572
-                                    ], 
+                                    ],
                                     [
-                                        -122.2598438611929, 
+                                        -122.2598438611929,
                                         37.875056106553345
-                                    ], 
+                                    ],
                                     [
-                                        -122.25976516993474, 
+                                        -122.25976516993474,
                                         37.87506083606096
-                                    ], 
+                                    ],
                                     [
-                                        -122.25968647867658, 
+                                        -122.25968647867658,
                                         37.87506556556858
-                                    ], 
+                                    ],
                                     [
-                                        -122.25960778741842, 
+                                        -122.25960778741842,
                                         37.875070295076206
-                                    ], 
+                                    ],
                                     [
-                                        -122.25952909616026, 
+                                        -122.25952909616026,
                                         37.87507502458382
-                                    ], 
+                                    ],
                                     [
-                                        -122.25945040490211, 
+                                        -122.25945040490211,
                                         37.875079754091445
-                                    ], 
+                                    ],
                                     [
-                                        -122.25937171364394, 
+                                        -122.25937171364394,
                                         37.87508448359907
-                                    ], 
+                                    ],
                                     [
-                                        -122.25929302238579, 
+                                        -122.25929302238579,
                                         37.87508921310668
-                                    ], 
+                                    ],
                                     [
-                                        -122.25921433112764, 
+                                        -122.25921433112764,
                                         37.875093942614306
-                                    ], 
+                                    ],
                                     [
-                                        -122.25913563986947, 
+                                        -122.25913563986947,
                                         37.87509867212193
-                                    ], 
+                                    ],
                                     [
-                                        -122.25905694861132, 
+                                        -122.25905694861132,
                                         37.875103401629545
-                                    ], 
+                                    ],
                                     [
-                                        -122.25897825735316, 
+                                        -122.25897825735316,
                                         37.87510813113717
-                                    ], 
+                                    ],
                                     [
-                                        -122.258899566095, 
+                                        -122.258899566095,
                                         37.87511286064479
-                                    ], 
+                                    ],
                                     [
-                                        -122.25882087483684, 
+                                        -122.25882087483684,
                                         37.875117590152406
-                                    ], 
+                                    ],
                                     [
-                                        -122.25874218357869, 
+                                        -122.25874218357869,
                                         37.87512231966003
-                                    ], 
+                                    ],
                                     [
-                                        -122.25881128125309, 
+                                        -122.25881128125309,
                                         37.87521723136464
-                                    ], 
+                                    ],
                                     [
-                                        -122.25888467126879, 
+                                        -122.25888467126879,
                                         37.8752794722262
-                                    ], 
+                                    ],
                                     [
-                                        -122.25890971865765, 
+                                        -122.25890971865765,
                                         37.87525413217614
-                                    ], 
+                                    ],
                                     [
-                                        -122.25894276787676, 
+                                        -122.25894276787676,
                                         37.8752960085897
-                                    ], 
+                                    ],
                                     [
-                                        -122.2589186, 
+                                        -122.2589186,
                                         37.8752735
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19342f6858f0a02a4a49b", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    6.926874452011729, 
-                                    6.926874011038682, 
-                                    6.92687356769813, 
-                                    6.926873125541259, 
-                                    6.926872684568072, 
-                                    6.92687224122738, 
-                                    6.92687179907037, 
-                                    6.926871358097041, 
-                                    6.9268709147562095, 
-                                    6.926870473842772, 
-                                    6.926870030381877, 
-                                    6.926869588284618, 
-                                    6.92686914737104, 
-                                    6.926868703910006, 
-                                    6.926868261812606, 
-                                    6.926867820898888, 
-                                    6.926867377437712, 
-                                    6.926866935340172, 
-                                    6.926866494426314, 
-                                    6.926866050964999, 
-                                    6.926865608867319, 
-                                    12.172208667873306, 
-                                    9.454741774005255, 
-                                    3.5738678277396985, 
-                                    5.486075233166488, 
-                                    3.2808426487546134
-                                ], 
-                                "feature_type": "section", 
-                                "distance": 179.4320067990865, 
-                                "end_ts": 1440700070.129, 
-                                "start_ts": 1440699298.7371826, 
-                                "start_fmt_time": "2015-08-27T11:14:58.737183-07:00", 
-                                "sensed_mode": "MotionTypes.UNKNOWN", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T11:27:50.129000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 11, 
-                                    "month": 8, 
-                                    "second": 50, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 27
-                                }, 
-                                "duration": 771.3918173313141, 
+                                "times": [
+                                    1440699298.7371826,
+                                    1440699328.7371826,
+                                    1440699358.7371826,
+                                    1440699388.7371826,
+                                    1440699418.7371826,
+                                    1440699448.7371826,
+                                    1440699478.7371826,
+                                    1440699508.7371826,
+                                    1440699538.7371826,
+                                    1440699568.7371826,
+                                    1440699598.7371826,
+                                    1440699628.7371826,
+                                    1440699658.7371826,
+                                    1440699688.7371826,
+                                    1440699718.7371826,
+                                    1440699748.7371826,
+                                    1440699778.7371826,
+                                    1440699808.7371826,
+                                    1440699838.7371826,
+                                    1440699868.7371826,
+                                    1440699898.7371826,
+                                    1440699928.7371826,
+                                    1440699958.7371826,
+                                    1440699988.7371826,
+                                    1440700018.7371826,
+                                    1440700048.7371826,
+                                    1440700070.129
+                                ],
+                                "timestamps": [
+                                    1440699298737,
+                                    1440699328737,
+                                    1440699358737,
+                                    1440699388737,
+                                    1440699418737,
+                                    1440699448737,
+                                    1440699478737,
+                                    1440699508737,
+                                    1440699538737,
+                                    1440699568737,
+                                    1440699598737,
+                                    1440699628737,
+                                    1440699658737,
+                                    1440699688737,
+                                    1440699718737,
+                                    1440699748737,
+                                    1440699778737,
+                                    1440699808737,
+                                    1440699838737,
+                                    1440699868737,
+                                    1440699898737,
+                                    1440699928737,
+                                    1440699958737,
+                                    1440699988737,
+                                    1440700018737,
+                                    1440700048737,
+                                    1440700070129
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19342f6858f0a02a4a499"
-                                }, 
+                                    "$oid": "5f3d68f06fdd485ce81b5d26"
+                                },
+                                "start_ts": 1440699298.7371826,
                                 "start_local_dt": {
-                                    "hour": 11, 
-                                    "month": 8, 
-                                    "second": 58, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 14
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 11,
+                                    "minute": 14,
+                                    "second": 58,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T11:14:58.737183-07:00",
+                                "end_ts": 1440700070.129,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 11,
+                                    "minute": 27,
+                                    "second": 50,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T11:27:50.129000-07:00",
+                                "duration": 771.3918173313141,
                                 "speeds": [
-                                    0.0, 
-                                    0.23089581506705764, 
-                                    0.23089580036795607, 
-                                    0.23089578558993767, 
-                                    0.2308957708513753, 
-                                    0.23089575615226907, 
-                                    0.23089574137424598, 
-                                    0.230895726635679, 
-                                    0.23089571193656805, 
-                                    0.23089569715854033, 
-                                    0.23089568246142575, 
-                                    0.2308956676793959, 
-                                    0.2308956529428206, 
-                                    0.23089563824570133, 
-                                    0.23089562346366685, 
-                                    0.23089560872708687, 
-                                    0.23089559402996293, 
-                                    0.23089557924792373, 
-                                    0.23089556451133905, 
-                                    0.23089554981421045, 
-                                    0.23089553503216662, 
-                                    0.23089552029557728, 
-                                    0.40574028892911024, 
-                                    0.3151580591335085, 
-                                    0.11912892759132328, 
-                                    0.18286917443888295, 
+                                    0.0,
+                                    0.23089581506705764,
+                                    0.23089580036795607,
+                                    0.23089578558993767,
+                                    0.2308957708513753,
+                                    0.23089575615226907,
+                                    0.23089574137424598,
+                                    0.230895726635679,
+                                    0.23089571193656805,
+                                    0.23089569715854033,
+                                    0.23089568246142575,
+                                    0.2308956676793959,
+                                    0.2308956529428206,
+                                    0.23089563824570133,
+                                    0.23089562346366685,
+                                    0.23089560872708687,
+                                    0.23089559402996293,
+                                    0.23089557924792373,
+                                    0.23089556451133905,
+                                    0.23089554981421045,
+                                    0.23089553503216662,
+                                    0.23089552029557728,
+                                    0.40574028892911024,
+                                    0.3151580591335085,
+                                    0.11912892759132328,
+                                    0.18286917443888295,
                                     0.1533690475166877
-                                ]
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    6.926874452011729,
+                                    6.926874011038682,
+                                    6.92687356769813,
+                                    6.926873125541259,
+                                    6.926872684568072,
+                                    6.92687224122738,
+                                    6.92687179907037,
+                                    6.926871358097041,
+                                    6.9268709147562095,
+                                    6.926870473842772,
+                                    6.926870030381877,
+                                    6.926869588284618,
+                                    6.92686914737104,
+                                    6.926868703910006,
+                                    6.926868261812606,
+                                    6.926867820898888,
+                                    6.926867377437712,
+                                    6.926866935340172,
+                                    6.926866494426314,
+                                    6.926866050964999,
+                                    6.926865608867319,
+                                    12.172208667873306,
+                                    9.454741774005255,
+                                    3.5738678277396985,
+                                    5.486075233166488,
+                                    3.2808426487546134
+                                ],
+                                "distance": 179.4320067990865,
+                                "sensed_mode": "MotionTypes.UNKNOWN",
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f06fdd485ce81b5d28"
                         }
                     ]
                 }
-            ], 
-            "type": "FeatureCollection", 
-            "id": "57e19342f6858f0a02a4a499", 
-            "properties": {
-                "distance": 179.4320067990865, 
-                "end_place": {
-                    "$oid": "57e19346f6858f0a02a4a5ce"
-                }, 
-                "raw_trip": {
-                    "$oid": "57e1933df6858f0a02a4a31e"
-                }, 
-                "feature_type": "trip", 
-                "start_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.2603947, 
-                        37.875023
-                    ]
-                }, 
-                "end_ts": 1440700070.129, 
-                "start_ts": 1440699298.7371826, 
-                "start_fmt_time": "2015-08-27T11:14:58.737183-07:00", 
-                "end_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.2589186, 
-                        37.8752735
-                    ]
-                }, 
-                "source": "DwellSegmentationTimeFilter", 
-                "start_place": {
-                    "$oid": "57e19346f6858f0a02a4a5cd"
-                }, 
-                "end_fmt_time": "2015-08-27T11:27:50.129000-07:00", 
-                "end_local_dt": {
-                    "hour": 11, 
-                    "month": 8, 
-                    "second": 50, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 27
-                }, 
-                "duration": 771.3918173313141, 
-                "start_local_dt": {
-                    "hour": 11, 
-                    "month": 8, 
-                    "second": 58, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 14
-                }
-            }
-        }, 
+            ],
+            "id": "5f3d68f06fdd485ce81b5d26"
+        },
         {
+            "type": "FeatureCollection",
+            "properties": {
+                "source": "DwellSegmentationTimeFilter",
+                "end_ts": 1440719699.47,
+                "end_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 16,
+                    "minute": 54,
+                    "second": 59,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "end_fmt_time": "2015-08-27T16:54:59.470000-07:00",
+                "end_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.3871046,
+                        37.5993148
+                    ]
+                },
+                "raw_trip": {
+                    "$oid": "5f3d68ec6fdd485ce81b5bad"
+                },
+                "start_ts": 1440716367.376,
+                "start_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 15,
+                    "minute": 59,
+                    "second": 27,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "start_fmt_time": "2015-08-27T15:59:27.376000-07:00",
+                "start_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.2714736,
+                        37.8471355
+                    ]
+                },
+                "duration": 3332.0940001010895,
+                "distance": 39163.534997241404,
+                "start_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e5c"
+                },
+                "end_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e5d"
+                },
+                "feature_type": "trip"
+            },
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.2714736, 
+                            -122.2714736,
                             37.8471355
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19346f6858f0a02a4a5cf", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T15:59:27.376000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 15, 
-                            "month": 8, 
-                            "second": 27, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 59
-                        }, 
-                        "display_name": "Adeline Street, Berkeley", 
-                        "feature_type": "start_place", 
-                        "exit_fmt_time": "2015-08-27T15:59:27.376000-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440716367.376,
                         "enter_local_dt": {
-                            "hour": 15, 
-                            "month": 8, 
-                            "second": 27, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 15,
+                            "month": 8,
+                            "second": 27,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 59
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19342f6858f0a02a4a4b7"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19343f6858f0a02a4a4b8"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440716367.376, 
-                        "duration": 0.0, 
+                        },
+                        "enter_fmt_time": "2015-08-27T15:59:27.376000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a323"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5bb0"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a323"
+                                "$oid": "5f3d68ec6fdd485ce81b5bb0"
                             }
-                        ], 
-                        "exit_ts": 1440716367.376
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5d44"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5d45"
+                        },
+                        "exit_ts": 1440716367.376,
+                        "exit_fmt_time": "2015-08-27T15:59:27.376000-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 15,
+                            "minute": 59,
+                            "second": 27,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 0.0,
+                        "feature_type": "start_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5c"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.3871046, 
+                            -122.3871046,
                             37.5993148
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19346f6858f0a02a4a5d0", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T16:54:59.470000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 16, 
-                            "month": 8, 
-                            "second": 59, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 57
-                        }, 
-                        "display_name": "El Camino Real, Millbrae", 
-                        "feature_type": "end_place", 
-                        "exit_fmt_time": "2015-08-27T16:57:59.470000-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440719699.47,
                         "enter_local_dt": {
-                            "hour": 16, 
-                            "month": 8, 
-                            "second": 59, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 16,
+                            "month": 8,
+                            "second": 59,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 54
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19343f6858f0a02a4a4b8"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19343f6858f0a02a4a52d"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440719699.47, 
-                        "duration": 180.0, 
+                        },
+                        "enter_fmt_time": "2015-08-27T16:54:59.470000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a321"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5bae"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a321"
+                                "$oid": "5f3d68ec6fdd485ce81b5bae"
                             }
-                        ], 
-                        "exit_ts": 1440719879.47
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5d45"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5dba"
+                        },
+                        "exit_ts": 1440719879.47,
+                        "exit_fmt_time": "2015-08-27T16:57:59.470000-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 16,
+                            "minute": 57,
+                            "second": 59,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 180.0,
+                        "feature_type": "end_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5d"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "LineString", 
+                        "type": "LineString",
                         "coordinates": [
                             [
-                                -122.3872753, 
+                                -122.3872753,
                                 37.5992646
-                            ], 
+                            ],
                             [
-                                -122.3872511, 
+                                -122.3872511,
                                 37.5992711
                             ]
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19343f6858f0a02a4a52c", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T16:51:59.226000-07:00", 
-                        "distance": 2.251187528064414, 
-                        "exit_local_dt": {
-                            "hour": 16, 
-                            "month": 8, 
-                            "second": 59, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 52
-                        }, 
-                        "feature_type": "stop", 
+                        "trip_id": {
+                            "$oid": "5f3d68f06fdd485ce81b5d45"
+                        },
+                        "source": "SmoothedHighConfidenceMotion",
                         "ending_section": {
-                            "$oid": "57e19343f6858f0a02a4a4b9"
-                        }, 
+                            "$oid": "5f3d68f06fdd485ce81b5d46"
+                        },
                         "starting_section": {
-                            "$oid": "57e19343f6858f0a02a4a525"
-                        }, 
-                        "exit_fmt_time": "2015-08-27T16:52:59.435000-07:00", 
+                            "$oid": "5f3d68f06fdd485ce81b5db2"
+                        },
+                        "enter_ts": 1440719519.226,
                         "enter_local_dt": {
-                            "hour": 16, 
-                            "month": 8, 
-                            "second": 59, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 51
-                        }, 
-                        "exit_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.3872511, 
-                                37.5992711
-                            ]
-                        }, 
-                        "source": "SmoothedHighConfidenceMotion", 
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 16,
+                            "minute": 51,
+                            "second": 59,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "enter_fmt_time": "2015-08-27T16:51:59.226000-07:00",
                         "enter_loc": {
-                            "type": "Point", 
+                            "type": "Point",
                             "coordinates": [
-                                -122.3872753, 
+                                -122.3872753,
                                 37.5992646
                             ]
-                        }, 
-                        "enter_ts": 1440719519.226, 
-                        "duration": 60.20899987220764, 
-                        "trip_id": {
-                            "$oid": "57e19343f6858f0a02a4a4b8"
-                        }, 
-                        "exit_ts": 1440719579.435
-                    }
-                }, 
+                        },
+                        "exit_ts": 1440719579.435,
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 16,
+                            "minute": 52,
+                            "second": 59,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "exit_fmt_time": "2015-08-27T16:52:59.435000-07:00",
+                        "exit_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.3872511,
+                                37.5992711
+                            ]
+                        },
+                        "duration": 60.20899987220764,
+                        "distance": 2.251187528064414,
+                        "feature_type": "stop"
+                    },
+                    "id": "5f3d68f06fdd485ce81b5db9"
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.2714736, 
+                                        -122.2714736,
                                         37.8471355
-                                    ], 
+                                    ],
                                     [
-                                        -122.27009181563555, 
+                                        -122.27009181563555,
                                         37.841423836603525
-                                    ], 
+                                    ],
                                     [
-                                        -122.26786632623609, 
+                                        -122.26786632623609,
                                         37.83616163476735
-                                    ], 
+                                    ],
                                     [
-                                        -122.2675080224559, 
+                                        -122.2675080224559,
                                         37.83247665018014
-                                    ], 
+                                    ],
                                     [
-                                        -122.26755544321314, 
+                                        -122.26755544321314,
                                         37.8290787955205
-                                    ], 
+                                    ],
                                     [
-                                        -122.2675635, 
+                                        -122.2675635,
                                         37.8285015
-                                    ], 
+                                    ],
                                     [
-                                        -122.26760443194355, 
+                                        -122.26760443194355,
                                         37.82810911792033
-                                    ], 
+                                    ],
                                     [
-                                        -122.26858367466076, 
+                                        -122.26858367466076,
                                         37.82350724449178
-                                    ], 
+                                    ],
                                     [
-                                        -122.26944815465468, 
+                                        -122.26944815465468,
                                         37.818994679273544
-                                    ], 
+                                    ],
                                     [
-                                        -122.27024789808634, 
+                                        -122.27024789808634,
                                         37.81468138270404
-                                    ], 
+                                    ],
                                     [
-                                        -122.27108281999597, 
+                                        -122.27108281999597,
                                         37.8127154858414
-                                    ], 
+                                    ],
                                     [
-                                        -122.27192517473868, 
+                                        -122.27192517473868,
                                         37.81124556922586
-                                    ], 
+                                    ],
                                     [
-                                        -122.2727675294814, 
+                                        -122.2727675294814,
                                         37.80977565261033
-                                    ], 
+                                    ],
                                     [
-                                        -122.27360988422411, 
+                                        -122.27360988422411,
                                         37.80830573599479
-                                    ], 
+                                    ],
                                     [
-                                        -122.27445223896682, 
+                                        -122.27445223896682,
                                         37.80683581937926
-                                    ], 
+                                    ],
                                     [
-                                        -122.27529459370953, 
+                                        -122.27529459370953,
                                         37.805365902763725
-                                    ], 
+                                    ],
                                     [
-                                        -122.27613694845225, 
+                                        -122.27613694845225,
                                         37.803895986148184
-                                    ], 
+                                    ],
                                     [
-                                        -122.27697930319496, 
+                                        -122.27697930319496,
                                         37.80242606953265
-                                    ], 
+                                    ],
                                     [
-                                        -122.27782165793766, 
+                                        -122.27782165793766,
                                         37.80095615291712
-                                    ], 
+                                    ],
                                     [
-                                        -122.27866401268038, 
+                                        -122.27866401268038,
                                         37.79948623630158
-                                    ], 
+                                    ],
                                     [
-                                        -122.28164793791302, 
+                                        -122.28164793791302,
                                         37.80026624513196
-                                    ], 
+                                    ],
                                     [
-                                        -122.28624065032594, 
+                                        -122.28624065032594,
                                         37.80201657433343
-                                    ], 
+                                    ],
                                     [
-                                        -122.29109331975565, 
+                                        -122.29109331975565,
                                         37.803871740891715
-                                    ], 
+                                    ],
                                     [
-                                        -122.2936441887295, 
+                                        -122.2936441887295,
                                         37.80468146507711
-                                    ], 
+                                    ],
                                     [
-                                        -122.29427078705407, 
+                                        -122.29427078705407,
                                         37.804670765971565
-                                    ], 
+                                    ],
                                     [
-                                        -122.2990713418114, 
+                                        -122.2990713418114,
                                         37.8061544933156
-                                    ], 
+                                    ],
                                     [
-                                        -122.30571109965662, 
+                                        -122.30571109965662,
                                         37.80780690783083
-                                    ], 
+                                    ],
                                     [
-                                        -122.30986702322102, 
+                                        -122.30986702322102,
                                         37.80625795616244
-                                    ], 
+                                    ],
                                     [
-                                        -122.31337645322813, 
+                                        -122.31337645322813,
                                         37.80394596596371
-                                    ], 
+                                    ],
                                     [
-                                        -122.31688588323524, 
+                                        -122.31688588323524,
                                         37.801633975764986
-                                    ], 
+                                    ],
                                     [
-                                        -122.32039531324237, 
+                                        -122.32039531324237,
                                         37.79932198556626
-                                    ], 
+                                    ],
                                     [
-                                        -122.32390474324949, 
+                                        -122.32390474324949,
                                         37.797009995367524
-                                    ], 
+                                    ],
                                     [
-                                        -122.3274141732566, 
+                                        -122.3274141732566,
                                         37.7946980051688
-                                    ], 
+                                    ],
                                     [
-                                        -122.33092360326371, 
+                                        -122.33092360326371,
                                         37.79238601497007
-                                    ], 
+                                    ],
                                     [
-                                        -122.33443303327083, 
+                                        -122.33443303327083,
                                         37.79007402477134
-                                    ], 
+                                    ],
                                     [
-                                        -122.33794246327795, 
+                                        -122.33794246327795,
                                         37.78776203457261
-                                    ], 
+                                    ],
                                     [
-                                        -122.34145189328507, 
+                                        -122.34145189328507,
                                         37.78545004437388
-                                    ], 
+                                    ],
                                     [
-                                        -122.34496132329218, 
+                                        -122.34496132329218,
                                         37.783138054175154
-                                    ], 
+                                    ],
                                     [
-                                        -122.3484707532993, 
+                                        -122.3484707532993,
                                         37.78082606397643
-                                    ], 
+                                    ],
                                     [
-                                        -122.35198018330641, 
+                                        -122.35198018330641,
                                         37.7785140737777
-                                    ], 
+                                    ],
                                     [
-                                        -122.35548961331354, 
+                                        -122.35548961331354,
                                         37.776202083578966
-                                    ], 
+                                    ],
                                     [
-                                        -122.35899904332065, 
+                                        -122.35899904332065,
                                         37.77389009338024
-                                    ], 
+                                    ],
                                     [
-                                        -122.36250847332776, 
+                                        -122.36250847332776,
                                         37.77157810318151
-                                    ], 
+                                    ],
                                     [
-                                        -122.36601790333488, 
+                                        -122.36601790333488,
                                         37.769266112982784
-                                    ], 
+                                    ],
                                     [
-                                        -122.36952733334199, 
+                                        -122.36952733334199,
                                         37.76695412278406
-                                    ], 
+                                    ],
                                     [
-                                        -122.37303676334912, 
+                                        -122.37303676334912,
                                         37.76464213258532
-                                    ], 
+                                    ],
                                     [
-                                        -122.37654619335623, 
+                                        -122.37654619335623,
                                         37.762330142386595
-                                    ], 
+                                    ],
                                     [
-                                        -122.38005562336335, 
+                                        -122.38005562336335,
                                         37.76001815218787
-                                    ], 
+                                    ],
                                     [
-                                        -122.38356505337046, 
+                                        -122.38356505337046,
                                         37.75770616198914
-                                    ], 
+                                    ],
                                     [
-                                        -122.38707448337757, 
+                                        -122.38707448337757,
                                         37.755394171790414
-                                    ], 
+                                    ],
                                     [
-                                        -122.3905839133847, 
+                                        -122.3905839133847,
                                         37.75308218159168
-                                    ], 
+                                    ],
                                     [
-                                        -122.39409334339182, 
+                                        -122.39409334339182,
                                         37.75077019139295
-                                    ], 
+                                    ],
                                     [
-                                        -122.39760277339893, 
+                                        -122.39760277339893,
                                         37.748458201194225
-                                    ], 
+                                    ],
                                     [
-                                        -122.40111220340604, 
+                                        -122.40111220340604,
                                         37.7461462109955
-                                    ], 
+                                    ],
                                     [
-                                        -122.40462163341316, 
+                                        -122.40462163341316,
                                         37.743834220796764
-                                    ], 
+                                    ],
                                     [
-                                        -122.40813106342029, 
+                                        -122.40813106342029,
                                         37.74152223059804
-                                    ], 
+                                    ],
                                     [
-                                        -122.4116404934274, 
+                                        -122.4116404934274,
                                         37.73921024039931
-                                    ], 
+                                    ],
                                     [
-                                        -122.41514992343451, 
+                                        -122.41514992343451,
                                         37.73689825020058
-                                    ], 
+                                    ],
                                     [
-                                        -122.41865935344163, 
+                                        -122.41865935344163,
                                         37.734586260001855
-                                    ], 
+                                    ],
                                     [
-                                        -122.42216878344874, 
+                                        -122.42216878344874,
                                         37.73227426980312
-                                    ], 
+                                    ],
                                     [
-                                        -122.42567821345587, 
+                                        -122.42567821345587,
                                         37.72996227960439
-                                    ], 
+                                    ],
                                     [
-                                        -122.42918764346298, 
+                                        -122.42918764346298,
                                         37.727650289405666
-                                    ], 
+                                    ],
                                     [
-                                        -122.4326970734701, 
+                                        -122.4326970734701,
                                         37.72533829920694
-                                    ], 
+                                    ],
                                     [
-                                        -122.43620650347721, 
+                                        -122.43620650347721,
                                         37.72302630900821
-                                    ], 
+                                    ],
                                     [
-                                        -122.43971593348432, 
+                                        -122.43971593348432,
                                         37.72071431880948
-                                    ], 
+                                    ],
                                     [
-                                        -122.44322536349145, 
+                                        -122.44322536349145,
                                         37.71840232861075
-                                    ], 
+                                    ],
                                     [
-                                        -122.44673479349856, 
+                                        -122.44673479349856,
                                         37.71609033841202
-                                    ], 
+                                    ],
                                     [
-                                        -122.45024422350568, 
+                                        -122.45024422350568,
                                         37.713778348213296
-                                    ], 
+                                    ],
                                     [
-                                        -122.45375365351279, 
+                                        -122.45375365351279,
                                         37.71146635801457
-                                    ], 
+                                    ],
                                     [
-                                        -122.45578716957253, 
+                                        -122.45578716957253,
                                         37.71072368402514
-                                    ], 
+                                    ],
                                     [
-                                        -122.45750464447623, 
+                                        -122.45750464447623,
                                         37.7103170516524
-                                    ], 
+                                    ],
                                     [
-                                        -122.4578115, 
+                                        -122.4578115,
                                         37.7102444
-                                    ], 
+                                    ],
                                     [
-                                        -122.4578115, 
+                                        -122.4578115,
                                         37.7102444
-                                    ], 
+                                    ],
                                     [
-                                        -122.4578115, 
+                                        -122.4578115,
                                         37.7102444
-                                    ], 
+                                    ],
                                     [
-                                        -122.4559282497936, 
+                                        -122.4559282497936,
                                         37.70728134370753
-                                    ], 
+                                    ],
                                     [
-                                        -122.45371803517376, 
+                                        -122.45371803517376,
                                         37.7038038502153
-                                    ], 
+                                    ],
                                     [
-                                        -122.45150782055393, 
+                                        -122.45150782055393,
                                         37.70032635672308
-                                    ], 
+                                    ],
                                     [
-                                        -122.44929760593409, 
+                                        -122.44929760593409,
                                         37.696848863230855
-                                    ], 
+                                    ],
                                     [
-                                        -122.44708739131426, 
+                                        -122.44708739131426,
                                         37.693371369738635
-                                    ], 
+                                    ],
                                     [
-                                        -122.44487717669443, 
+                                        -122.44487717669443,
                                         37.68989387624641
-                                    ], 
+                                    ],
                                     [
-                                        -122.4426669620746, 
+                                        -122.4426669620746,
                                         37.68641638275419
-                                    ], 
+                                    ],
                                     [
-                                        -122.44045674745476, 
+                                        -122.44045674745476,
                                         37.68293888926196
-                                    ], 
+                                    ],
                                     [
-                                        -122.43824653283492, 
+                                        -122.43824653283492,
                                         37.67946139576974
-                                    ], 
+                                    ],
                                     [
-                                        -122.4360363182151, 
+                                        -122.4360363182151,
                                         37.675983902277515
-                                    ], 
+                                    ],
                                     [
-                                        -122.43382610359527, 
+                                        -122.43382610359527,
                                         37.67250640878529
-                                    ], 
+                                    ],
                                     [
-                                        -122.43161588897543, 
+                                        -122.43161588897543,
                                         37.66902891529307
-                                    ], 
+                                    ],
                                     [
-                                        -122.42940567435559, 
+                                        -122.42940567435559,
                                         37.66555142180084
-                                    ], 
+                                    ],
                                     [
-                                        -122.42719545973576, 
+                                        -122.42719545973576,
                                         37.66207392830862
-                                    ], 
+                                    ],
                                     [
-                                        -122.42498524511593, 
+                                        -122.42498524511593,
                                         37.658596434816396
-                                    ], 
+                                    ],
                                     [
-                                        -122.4227750304961, 
+                                        -122.4227750304961,
                                         37.655118941324176
-                                    ], 
+                                    ],
                                     [
-                                        -122.42056481587626, 
+                                        -122.42056481587626,
                                         37.65164144783195
-                                    ], 
+                                    ],
                                     [
-                                        -122.41835460125642, 
+                                        -122.41835460125642,
                                         37.64816395433973
-                                    ], 
+                                    ],
                                     [
-                                        -122.41614438663659, 
+                                        -122.41614438663659,
                                         37.6446864608475
-                                    ], 
+                                    ],
                                     [
-                                        -122.41393417201677, 
+                                        -122.41393417201677,
                                         37.64120896735528
-                                    ], 
+                                    ],
                                     [
-                                        -122.41172395739693, 
+                                        -122.41172395739693,
                                         37.637731473863056
-                                    ], 
+                                    ],
                                     [
-                                        -122.4095137427771, 
+                                        -122.4095137427771,
                                         37.634253980370836
-                                    ], 
+                                    ],
                                     [
-                                        -122.40730352815726, 
+                                        -122.40730352815726,
                                         37.63077648687861
-                                    ], 
+                                    ],
                                     [
-                                        -122.40509331353744, 
+                                        -122.40509331353744,
                                         37.62729899338639
-                                    ], 
+                                    ],
                                     [
-                                        -122.4028830989176, 
+                                        -122.4028830989176,
                                         37.62382149989416
-                                    ], 
+                                    ],
                                     [
-                                        -122.40067288429776, 
+                                        -122.40067288429776,
                                         37.62034400640194
-                                    ], 
+                                    ],
                                     [
-                                        -122.39846266967793, 
+                                        -122.39846266967793,
                                         37.616866512909716
-                                    ], 
+                                    ],
                                     [
-                                        -122.39625245505809, 
+                                        -122.39625245505809,
                                         37.6133890194175
-                                    ], 
+                                    ],
                                     [
-                                        -122.39404224043827, 
+                                        -122.39404224043827,
                                         37.60991152592527
-                                    ], 
+                                    ],
                                     [
-                                        -122.39183202581843, 
+                                        -122.39183202581843,
                                         37.60643403243305
-                                    ], 
+                                    ],
                                     [
-                                        -122.3896218111986, 
+                                        -122.3896218111986,
                                         37.60295653894082
-                                    ], 
+                                    ],
                                     [
-                                        -122.38741159657876, 
+                                        -122.38741159657876,
                                         37.599479045448604
-                                    ], 
+                                    ],
                                     [
-                                        -122.3872753, 
+                                        -122.3872753,
                                         37.5992646
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19343f6858f0a02a4a4b9", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    646.5939430587197, 
-                                    616.904173329822, 
-                                    410.95802603243146, 
-                                    377.8471524677576, 
-                                    64.19623295203787, 
-                                    43.77874846473474, 
-                                    518.882701012275, 
-                                    507.487180865965, 
-                                    484.7342531905478, 
-                                    230.57378817099993, 
-                                    179.41783930949697, 
-                                    179.41844690401348, 
-                                    179.41905448919997, 
-                                    179.4196620638202, 
-                                    179.42026962941745, 
-                                    179.42087718516515, 
-                                    179.42148472941756, 
-                                    179.42209226381738, 
-                                    179.42269978918839, 
-                                    276.14608069647124, 
-                                    448.0004509626269, 
-                                    473.62768288938776, 
-                                    241.51971275853097, 
-                                    55.06306685887056, 
-                                    452.8729366468228, 
-                                    611.5759586912512, 
-                                    403.69573284082264, 
-                                    401.43879606223294, 
-                                    401.44620925671995, 
-                                    401.45362216173265, 
-                                    401.4610347748677, 
-                                    401.46844709745216, 
-                                    401.4758591300125, 
-                                    401.4832708720108, 
-                                    401.4906823248798, 
-                                    401.4980934841922, 
-                                    401.50550435431114, 
-                                    401.512914933739, 
-                                    401.520325222444, 
-                                    401.52773522185913, 
-                                    401.53514492755636, 
-                                    401.5425543438994, 
-                                    401.5499634693907, 
-                                    401.5573723039983, 
-                                    401.5647808491553, 
-                                    401.5721891004334, 
-                                    401.5795970621965, 
-                                    401.5870047329475, 
-                                    401.59441211265374, 
-                                    401.60181920274897, 
-                                    401.6092259988041, 
-                                    401.61663250518393, 
-                                    401.62403872039084, 
-                                    401.631444644898, 
-                                    401.6388502781166, 
-                                    401.6462556186513, 
-                                    401.6536606688445, 
-                                    401.661065427704, 
-                                    401.6684698957033, 
-                                    401.6758740722537, 
-                                    401.6832779559591, 
-                                    401.69068154916283, 
-                                    401.69808485087214, 
-                                    401.70548786156087, 
-                                    401.7128905806403, 
-                                    401.7202930067139, 
-                                    401.7276951421253, 
-                                    401.735096985882, 
-                                    197.02412315205953, 
-                                    157.70297763960681, 
-                                    28.176349668486797, 
-                                    0.0, 
-                                    0.0, 
-                                    368.7833323045045, 
-                                    432.81421524582737, 
-                                    432.8183135931796, 
-                                    432.8224117735929, 
-                                    432.8265097841885, 
-                                    432.8306076271722, 
-                                    432.8347053013505, 
-                                    432.83880280780573, 
-                                    432.84290014422083, 
-                                    432.8469973128014, 
-                                    432.8510943130607, 
-                                    432.8551911432568, 
-                                    432.8592878060137, 
-                                    432.8633842984527, 
-                                    432.86748062277894, 
-                                    432.8715767778007, 
-                                    432.8756727645987, 
-                                    432.87976858085653, 
-                                    432.8838642293418, 
-                                    432.8879597066131, 
-                                    432.8920550171259, 
-                                    432.89615015631375, 
-                                    432.90024512750676, 
-                                    432.9043399272639, 
-                                    432.90843456004035, 
-                                    432.9125290212698, 
-                                    432.91662331428216, 
-                                    432.92071743619925, 
-                                    432.9248113892254, 
-                                    432.9289051721709, 
-                                    432.9329987861145, 
-                                    432.9370922287407, 
-                                    26.69792341463841
-                                ], 
-                                "end_ts": 1440719519.226, 
-                                "feature_type": "section", 
-                                "distance": 39141.83695916698, 
-                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
-                                "start_ts": 1440716367.376, 
-                                "start_fmt_time": "2015-08-27T15:59:27.376000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T16:51:59.226000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 16, 
-                                    "month": 8, 
-                                    "second": 59, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 51
-                                }, 
-                                "duration": 3151.850000143051, 
-                                "end_stop": {
-                                    "$oid": "57e19343f6858f0a02a4a52c"
-                                }, 
+                                "times": [
+                                    1440716367.376,
+                                    1440716397.376,
+                                    1440716427.376,
+                                    1440716457.376,
+                                    1440716487.376,
+                                    1440716517.376,
+                                    1440716547.376,
+                                    1440716577.376,
+                                    1440716607.376,
+                                    1440716637.376,
+                                    1440716667.376,
+                                    1440716697.376,
+                                    1440716727.376,
+                                    1440716757.376,
+                                    1440716787.376,
+                                    1440716817.376,
+                                    1440716847.376,
+                                    1440716877.376,
+                                    1440716907.376,
+                                    1440716937.376,
+                                    1440716967.376,
+                                    1440716997.376,
+                                    1440717027.376,
+                                    1440717057.376,
+                                    1440717087.376,
+                                    1440717117.376,
+                                    1440717147.376,
+                                    1440717177.376,
+                                    1440717207.376,
+                                    1440717237.376,
+                                    1440717267.376,
+                                    1440717297.376,
+                                    1440717327.376,
+                                    1440717357.376,
+                                    1440717387.376,
+                                    1440717417.376,
+                                    1440717447.376,
+                                    1440717477.376,
+                                    1440717507.376,
+                                    1440717537.376,
+                                    1440717567.376,
+                                    1440717597.376,
+                                    1440717627.376,
+                                    1440717657.376,
+                                    1440717687.376,
+                                    1440717717.376,
+                                    1440717747.376,
+                                    1440717777.376,
+                                    1440717807.376,
+                                    1440717837.376,
+                                    1440717867.376,
+                                    1440717897.376,
+                                    1440717927.376,
+                                    1440717957.376,
+                                    1440717987.376,
+                                    1440718017.376,
+                                    1440718047.376,
+                                    1440718077.376,
+                                    1440718107.376,
+                                    1440718137.376,
+                                    1440718167.376,
+                                    1440718197.376,
+                                    1440718227.376,
+                                    1440718257.376,
+                                    1440718287.376,
+                                    1440718317.376,
+                                    1440718347.376,
+                                    1440718377.376,
+                                    1440718407.376,
+                                    1440718437.376,
+                                    1440718467.376,
+                                    1440718497.376,
+                                    1440718527.376,
+                                    1440718557.376,
+                                    1440718587.376,
+                                    1440718617.376,
+                                    1440718647.376,
+                                    1440718677.376,
+                                    1440718707.376,
+                                    1440718737.376,
+                                    1440718767.376,
+                                    1440718797.376,
+                                    1440718827.376,
+                                    1440718857.376,
+                                    1440718887.376,
+                                    1440718917.376,
+                                    1440718947.376,
+                                    1440718977.376,
+                                    1440719007.376,
+                                    1440719037.376,
+                                    1440719067.376,
+                                    1440719097.376,
+                                    1440719127.376,
+                                    1440719157.376,
+                                    1440719187.376,
+                                    1440719217.376,
+                                    1440719247.376,
+                                    1440719277.376,
+                                    1440719307.376,
+                                    1440719337.376,
+                                    1440719367.376,
+                                    1440719397.376,
+                                    1440719427.376,
+                                    1440719457.376,
+                                    1440719487.376,
+                                    1440719517.376,
+                                    1440719519.226
+                                ],
+                                "timestamps": [
+                                    1440716367376,
+                                    1440716397376,
+                                    1440716427376,
+                                    1440716457376,
+                                    1440716487376,
+                                    1440716517376,
+                                    1440716547376,
+                                    1440716577376,
+                                    1440716607376,
+                                    1440716637376,
+                                    1440716667376,
+                                    1440716697376,
+                                    1440716727376,
+                                    1440716757376,
+                                    1440716787376,
+                                    1440716817376,
+                                    1440716847376,
+                                    1440716877376,
+                                    1440716907376,
+                                    1440716937376,
+                                    1440716967376,
+                                    1440716997376,
+                                    1440717027376,
+                                    1440717057376,
+                                    1440717087376,
+                                    1440717117376,
+                                    1440717147376,
+                                    1440717177376,
+                                    1440717207376,
+                                    1440717237376,
+                                    1440717267376,
+                                    1440717297376,
+                                    1440717327376,
+                                    1440717357376,
+                                    1440717387376,
+                                    1440717417376,
+                                    1440717447376,
+                                    1440717477376,
+                                    1440717507376,
+                                    1440717537376,
+                                    1440717567376,
+                                    1440717597376,
+                                    1440717627376,
+                                    1440717657376,
+                                    1440717687376,
+                                    1440717717376,
+                                    1440717747376,
+                                    1440717777376,
+                                    1440717807376,
+                                    1440717837376,
+                                    1440717867376,
+                                    1440717897376,
+                                    1440717927376,
+                                    1440717957376,
+                                    1440717987376,
+                                    1440718017376,
+                                    1440718047376,
+                                    1440718077376,
+                                    1440718107376,
+                                    1440718137376,
+                                    1440718167376,
+                                    1440718197376,
+                                    1440718227376,
+                                    1440718257376,
+                                    1440718287376,
+                                    1440718317376,
+                                    1440718347376,
+                                    1440718377376,
+                                    1440718407376,
+                                    1440718437376,
+                                    1440718467376,
+                                    1440718497376,
+                                    1440718527376,
+                                    1440718557376,
+                                    1440718587376,
+                                    1440718617376,
+                                    1440718647376,
+                                    1440718677376,
+                                    1440718707376,
+                                    1440718737376,
+                                    1440718767376,
+                                    1440718797376,
+                                    1440718827376,
+                                    1440718857376,
+                                    1440718887376,
+                                    1440718917376,
+                                    1440718947376,
+                                    1440718977376,
+                                    1440719007376,
+                                    1440719037376,
+                                    1440719067376,
+                                    1440719097376,
+                                    1440719127376,
+                                    1440719157376,
+                                    1440719187376,
+                                    1440719217376,
+                                    1440719247376,
+                                    1440719277376,
+                                    1440719307376,
+                                    1440719337376,
+                                    1440719367376,
+                                    1440719397376,
+                                    1440719427376,
+                                    1440719457376,
+                                    1440719487376,
+                                    1440719517376,
+                                    1440719519226
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19343f6858f0a02a4a4b8"
-                                }, 
+                                    "$oid": "5f3d68f06fdd485ce81b5d45"
+                                },
+                                "start_ts": 1440716367.376,
                                 "start_local_dt": {
-                                    "hour": 15, 
-                                    "month": 8, 
-                                    "second": 27, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 59
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 15,
+                                    "minute": 59,
+                                    "second": 27,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T15:59:27.376000-07:00",
+                                "end_ts": 1440719519.226,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 16,
+                                    "minute": 51,
+                                    "second": 59,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T16:51:59.226000-07:00",
+                                "duration": 3151.850000143051,
                                 "speeds": [
-                                    0.0, 
-                                    21.553131435290656, 
-                                    20.5634724443274, 
-                                    13.698600867747716, 
-                                    12.594905082258586, 
-                                    2.139874431734596, 
-                                    1.459291615491158, 
-                                    17.296090033742498, 
-                                    16.916239362198834, 
-                                    16.157808439684928, 
-                                    7.685792939033331, 
-                                    5.980594643649899, 
-                                    5.980614896800449, 
-                                    5.9806351496399985, 
-                                    5.98065540212734, 
-                                    5.980675654313915, 
-                                    5.980695906172172, 
-                                    5.980716157647252, 
-                                    5.980736408793913, 
-                                    5.980756659639613, 
-                                    9.204869356549041, 
-                                    14.933348365420898, 
-                                    15.787589429646259, 
-                                    8.050657091951033, 
-                                    1.8354355619623521, 
-                                    15.095764554894092, 
-                                    20.385865289708374, 
-                                    13.456524428027421, 
-                                    13.381293202074431, 
-                                    13.381540308557332, 
-                                    13.381787405391089, 
-                                    13.38203449249559, 
-                                    13.382281569915072, 
-                                    13.382528637667084, 
-                                    13.382775695733693, 
-                                    13.38302274416266, 
-                                    13.383269782806407, 
-                                    13.383516811810372, 
-                                    13.383763831124634, 
-                                    13.384010840748134, 
-                                    13.384257840728639, 
-                                    13.384504830918546, 
-                                    13.384751811463312, 
-                                    13.384998782313025, 
-                                    13.38524574346661, 
-                                    13.385492694971843, 
-                                    13.385739636681112, 
-                                    13.385986568739884, 
-                                    13.386233491098249, 
-                                    13.386480403755124, 
-                                    13.3867273067583, 
-                                    13.386974199960138, 
-                                    13.38722108350613, 
-                                    13.387467957346361, 
-                                    13.3877148214966, 
-                                    13.38796167593722, 
-                                    13.38820852062171, 
-                                    13.38845535562815, 
-                                    13.388702180923467, 
-                                    13.388948996523444, 
-                                    13.389195802408457, 
-                                    13.38944259853197, 
-                                    13.389689384972094, 
-                                    13.389936161695738, 
-                                    13.390182928718696, 
-                                    13.390429686021344, 
-                                    13.39067643355713, 
-                                    13.390923171404177, 
-                                    13.3911698995294, 
-                                    6.567470771735318, 
-                                    5.256765921320227, 
-                                    0.9392116556162265, 
-                                    0.0, 
-                                    0.0, 
-                                    12.292777743483482, 
-                                    14.427140508194245, 
-                                    14.427277119772652, 
-                                    14.42741372578643, 
-                                    14.427550326139617, 
-                                    14.427686920905739, 
-                                    14.427823510045016, 
-                                    14.427960093593525, 
-                                    14.428096671474028, 
-                                    14.428233243760047, 
-                                    14.428369810435356, 
-                                    14.428506371441893, 
-                                    14.428642926867123, 
-                                    14.42877947661509, 
-                                    14.428916020759297, 
-                                    14.429052559260024, 
-                                    14.429189092153289, 
-                                    14.429325619361885, 
-                                    14.429462140978059, 
-                                    14.429598656887103, 
-                                    14.429735167237531, 
-                                    14.429871671877125, 
-                                    14.430008170916892, 
-                                    14.43014466424213, 
-                                    14.430281152001346, 
-                                    14.430417634042326, 
-                                    14.430554110476072, 
-                                    14.430690581206642, 
-                                    14.430827046307513, 
-                                    14.430963505739031, 
-                                    14.431099959537152, 
-                                    14.43123640762469, 
+                                    0.0,
+                                    21.553131435290656,
+                                    20.5634724443274,
+                                    13.698600867747716,
+                                    12.594905082258586,
+                                    2.139874431734596,
+                                    1.459291615491158,
+                                    17.296090033742498,
+                                    16.916239362198834,
+                                    16.157808439684928,
+                                    7.685792939033331,
+                                    5.980594643649899,
+                                    5.980614896800449,
+                                    5.9806351496399985,
+                                    5.98065540212734,
+                                    5.980675654313915,
+                                    5.980695906172172,
+                                    5.980716157647252,
+                                    5.980736408793913,
+                                    5.980756659639613,
+                                    9.204869356549041,
+                                    14.933348365420898,
+                                    15.787589429646259,
+                                    8.050657091951033,
+                                    1.8354355619623521,
+                                    15.095764554894092,
+                                    20.385865289708374,
+                                    13.456524428027421,
+                                    13.381293202074431,
+                                    13.381540308557332,
+                                    13.381787405391089,
+                                    13.38203449249559,
+                                    13.382281569915072,
+                                    13.382528637667084,
+                                    13.382775695733693,
+                                    13.38302274416266,
+                                    13.383269782806407,
+                                    13.383516811810372,
+                                    13.383763831124634,
+                                    13.384010840748134,
+                                    13.384257840728639,
+                                    13.384504830918546,
+                                    13.384751811463312,
+                                    13.384998782313025,
+                                    13.38524574346661,
+                                    13.385492694971843,
+                                    13.385739636681112,
+                                    13.385986568739884,
+                                    13.386233491098249,
+                                    13.386480403755124,
+                                    13.3867273067583,
+                                    13.386974199960138,
+                                    13.38722108350613,
+                                    13.387467957346361,
+                                    13.3877148214966,
+                                    13.38796167593722,
+                                    13.38820852062171,
+                                    13.38845535562815,
+                                    13.388702180923467,
+                                    13.388948996523444,
+                                    13.389195802408457,
+                                    13.38944259853197,
+                                    13.389689384972094,
+                                    13.389936161695738,
+                                    13.390182928718696,
+                                    13.390429686021344,
+                                    13.39067643355713,
+                                    13.390923171404177,
+                                    13.3911698995294,
+                                    6.567470771735318,
+                                    5.256765921320227,
+                                    0.9392116556162265,
+                                    0.0,
+                                    0.0,
+                                    12.292777743483482,
+                                    14.427140508194245,
+                                    14.427277119772652,
+                                    14.42741372578643,
+                                    14.427550326139617,
+                                    14.427686920905739,
+                                    14.427823510045016,
+                                    14.427960093593525,
+                                    14.428096671474028,
+                                    14.428233243760047,
+                                    14.428369810435356,
+                                    14.428506371441893,
+                                    14.428642926867123,
+                                    14.42877947661509,
+                                    14.428916020759297,
+                                    14.429052559260024,
+                                    14.429189092153289,
+                                    14.429325619361885,
+                                    14.429462140978059,
+                                    14.429598656887103,
+                                    14.429735167237531,
+                                    14.429871671877125,
+                                    14.430008170916892,
+                                    14.43014466424213,
+                                    14.430281152001346,
+                                    14.430417634042326,
+                                    14.430554110476072,
+                                    14.430690581206642,
+                                    14.430827046307513,
+                                    14.430963505739031,
+                                    14.431099959537152,
+                                    14.43123640762469,
                                     14.431308837958444
-                                ]
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    646.5939430587197,
+                                    616.904173329822,
+                                    410.95802603243146,
+                                    377.8471524677576,
+                                    64.19623295203787,
+                                    43.77874846473474,
+                                    518.882701012275,
+                                    507.487180865965,
+                                    484.7342531905478,
+                                    230.57378817099993,
+                                    179.41783930949697,
+                                    179.41844690401348,
+                                    179.41905448919997,
+                                    179.4196620638202,
+                                    179.42026962941745,
+                                    179.42087718516515,
+                                    179.42148472941756,
+                                    179.42209226381738,
+                                    179.42269978918839,
+                                    276.14608069647124,
+                                    448.0004509626269,
+                                    473.62768288938776,
+                                    241.51971275853097,
+                                    55.06306685887056,
+                                    452.8729366468228,
+                                    611.5759586912512,
+                                    403.69573284082264,
+                                    401.43879606223294,
+                                    401.44620925671995,
+                                    401.45362216173265,
+                                    401.4610347748677,
+                                    401.46844709745216,
+                                    401.4758591300125,
+                                    401.4832708720108,
+                                    401.4906823248798,
+                                    401.4980934841922,
+                                    401.50550435431114,
+                                    401.512914933739,
+                                    401.520325222444,
+                                    401.52773522185913,
+                                    401.53514492755636,
+                                    401.5425543438994,
+                                    401.5499634693907,
+                                    401.5573723039983,
+                                    401.5647808491553,
+                                    401.5721891004334,
+                                    401.5795970621965,
+                                    401.5870047329475,
+                                    401.59441211265374,
+                                    401.60181920274897,
+                                    401.6092259988041,
+                                    401.61663250518393,
+                                    401.62403872039084,
+                                    401.631444644898,
+                                    401.6388502781166,
+                                    401.6462556186513,
+                                    401.6536606688445,
+                                    401.661065427704,
+                                    401.6684698957033,
+                                    401.6758740722537,
+                                    401.6832779559591,
+                                    401.69068154916283,
+                                    401.69808485087214,
+                                    401.70548786156087,
+                                    401.7128905806403,
+                                    401.7202930067139,
+                                    401.7276951421253,
+                                    401.735096985882,
+                                    197.02412315205953,
+                                    157.70297763960681,
+                                    28.176349668486797,
+                                    0.0,
+                                    0.0,
+                                    368.7833323045045,
+                                    432.81421524582737,
+                                    432.8183135931796,
+                                    432.8224117735929,
+                                    432.8265097841885,
+                                    432.8306076271722,
+                                    432.8347053013505,
+                                    432.83880280780573,
+                                    432.84290014422083,
+                                    432.8469973128014,
+                                    432.8510943130607,
+                                    432.8551911432568,
+                                    432.8592878060137,
+                                    432.8633842984527,
+                                    432.86748062277894,
+                                    432.8715767778007,
+                                    432.8756727645987,
+                                    432.87976858085653,
+                                    432.8838642293418,
+                                    432.8879597066131,
+                                    432.8920550171259,
+                                    432.89615015631375,
+                                    432.90024512750676,
+                                    432.9043399272639,
+                                    432.90843456004035,
+                                    432.9125290212698,
+                                    432.91662331428216,
+                                    432.92071743619925,
+                                    432.9248113892254,
+                                    432.9289051721709,
+                                    432.9329987861145,
+                                    432.9370922287407,
+                                    26.69792341463841
+                                ],
+                                "distance": 39141.83695916698,
+                                "sensed_mode": "MotionTypes.IN_VEHICLE",
+                                "end_stop": {
+                                    "$oid": "5f3d68f06fdd485ce81b5db9"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f06fdd485ce81b5d46"
                         }
                     ]
-                }, 
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.3872511, 
+                                        -122.3872511,
                                         37.5992711
-                                    ], 
+                                    ],
                                     [
-                                        -122.38714270190331, 
+                                        -122.38714270190331,
                                         37.599294846561044
-                                    ], 
+                                    ],
                                     [
-                                        -122.387077826848, 
+                                        -122.387077826848,
                                         37.59928960783066
-                                    ], 
+                                    ],
                                     [
-                                        -122.3870880172632, 
+                                        -122.3870880172632,
                                         37.59929320387766
-                                    ], 
+                                    ],
                                     [
-                                        -122.38710458067597, 
+                                        -122.38710458067597,
                                         37.59931477483382
-                                    ], 
+                                    ],
                                     [
-                                        -122.3871046, 
+                                        -122.3871046,
                                         37.5993148
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19343f6858f0a02a4a525", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    9.908134151186015, 
-                                    5.745063782479622, 
-                                    0.982792086356484, 
-                                    2.8075850020833313, 
-                                    0.0032755242536713644
-                                ], 
-                                "feature_type": "section", 
-                                "sensed_mode": "MotionTypes.ON_FOOT", 
-                                "end_ts": 1440719699.47, 
-                                "start_ts": 1440719579.435, 
-                                "start_fmt_time": "2015-08-27T16:52:59.435000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T16:54:59.470000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 16, 
-                                    "month": 8, 
-                                    "second": 59, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 54
-                                }, 
-                                "duration": 120.03500008583069, 
-                                "start_stop": {
-                                    "$oid": "57e19343f6858f0a02a4a52c"
-                                }, 
+                                "times": [
+                                    1440719579.435,
+                                    1440719609.435,
+                                    1440719639.435,
+                                    1440719669.435,
+                                    1440719699.435,
+                                    1440719699.47
+                                ],
+                                "timestamps": [
+                                    1440719579435,
+                                    1440719609435,
+                                    1440719639435,
+                                    1440719669435,
+                                    1440719699435,
+                                    1440719699470
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19343f6858f0a02a4a4b8"
-                                }, 
+                                    "$oid": "5f3d68f06fdd485ce81b5d45"
+                                },
+                                "start_ts": 1440719579.435,
                                 "start_local_dt": {
-                                    "hour": 16, 
-                                    "month": 8, 
-                                    "second": 59, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 52
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 16,
+                                    "minute": 52,
+                                    "second": 59,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T16:52:59.435000-07:00",
+                                "end_ts": 1440719699.47,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 16,
+                                    "minute": 54,
+                                    "second": 59,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T16:54:59.470000-07:00",
+                                "duration": 120.03500008583069,
                                 "speeds": [
-                                    0.0, 
-                                    0.3302711383728672, 
-                                    0.19150212608265405, 
-                                    0.0327597362118828, 
-                                    0.09358616673611105, 
+                                    0.0,
+                                    0.3302711383728672,
+                                    0.19150212608265405,
+                                    0.0327597362118828,
+                                    0.09358616673611105,
                                     0.09358617774586561
-                                ], 
-                                "distance": 19.446850546359123
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    9.908134151186015,
+                                    5.745063782479622,
+                                    0.982792086356484,
+                                    2.8075850020833313,
+                                    0.0032755242536713644
+                                ],
+                                "distance": 19.446850546359123,
+                                "sensed_mode": "MotionTypes.ON_FOOT",
+                                "start_stop": {
+                                    "$oid": "5f3d68f06fdd485ce81b5db9"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f06fdd485ce81b5db2"
                         }
                     ]
                 }
-            ], 
-            "type": "FeatureCollection", 
-            "id": "57e19343f6858f0a02a4a4b8", 
+            ],
+            "id": "5f3d68f06fdd485ce81b5d45"
+        },
+        {
+            "type": "FeatureCollection",
             "properties": {
-                "distance": 39163.534997241404, 
-                "end_place": {
-                    "$oid": "57e19346f6858f0a02a4a5d0"
-                }, 
-                "raw_trip": {
-                    "$oid": "57e1933df6858f0a02a4a320"
-                }, 
-                "feature_type": "trip", 
-                "start_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.2714736, 
-                        37.8471355
-                    ]
-                }, 
-                "end_ts": 1440719699.47, 
-                "start_ts": 1440716367.376, 
-                "start_fmt_time": "2015-08-27T15:59:27.376000-07:00", 
+                "source": "DwellSegmentationTimeFilter",
+                "end_ts": 1440723334.898,
+                "end_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 17,
+                    "minute": 55,
+                    "second": 34,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "end_fmt_time": "2015-08-27T17:55:34.898000-07:00",
                 "end_loc": {
-                    "type": "Point", 
+                    "type": "Point",
                     "coordinates": [
-                        -122.3871046, 
+                        -122.083702,
+                        37.4036219
+                    ]
+                },
+                "raw_trip": {
+                    "$oid": "5f3d68ec6fdd485ce81b5bb1"
+                },
+                "start_ts": 1440719879.47,
+                "start_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 16,
+                    "minute": 57,
+                    "second": 59,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "start_fmt_time": "2015-08-27T16:57:59.470000-07:00",
+                "start_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.3871046,
                         37.5993148
                     ]
-                }, 
-                "source": "DwellSegmentationTimeFilter", 
+                },
+                "duration": 3455.427999973297,
+                "distance": 37830.496342360595,
                 "start_place": {
-                    "$oid": "57e19346f6858f0a02a4a5cf"
-                }, 
-                "end_fmt_time": "2015-08-27T16:54:59.470000-07:00", 
-                "end_local_dt": {
-                    "hour": 16, 
-                    "month": 8, 
-                    "second": 59, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 54
-                }, 
-                "duration": 3332.0940001010895, 
-                "start_local_dt": {
-                    "hour": 15, 
-                    "month": 8, 
-                    "second": 27, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 59
-                }
-            }
-        }, 
-        {
+                    "$oid": "5f3d68f16fdd485ce81b5e5d"
+                },
+                "end_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e5e"
+                },
+                "feature_type": "trip"
+            },
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.3871046, 
+                            -122.3871046,
                             37.5993148
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19346f6858f0a02a4a5d0", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T16:54:59.470000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 16, 
-                            "month": 8, 
-                            "second": 59, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 57
-                        }, 
-                        "display_name": "El Camino Real, Millbrae", 
-                        "feature_type": "start_place", 
-                        "exit_fmt_time": "2015-08-27T16:57:59.470000-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440719699.47,
                         "enter_local_dt": {
-                            "hour": 16, 
-                            "month": 8, 
-                            "second": 59, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 16,
+                            "month": 8,
+                            "second": 59,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 54
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19343f6858f0a02a4a4b8"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19343f6858f0a02a4a52d"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440719699.47, 
-                        "duration": 180.0, 
+                        },
+                        "enter_fmt_time": "2015-08-27T16:54:59.470000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a321"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5bae"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a321"
+                                "$oid": "5f3d68ec6fdd485ce81b5bae"
                             }
-                        ], 
-                        "exit_ts": 1440719879.47
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5d45"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5dba"
+                        },
+                        "exit_ts": 1440719879.47,
+                        "exit_fmt_time": "2015-08-27T16:57:59.470000-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 16,
+                            "minute": 57,
+                            "second": 59,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 180.0,
+                        "feature_type": "start_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5d"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.083702, 
+                            -122.083702,
                             37.4036219
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19346f6858f0a02a4a5d1", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T17:55:34.898000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 19, 
-                            "month": 8, 
-                            "second": 57, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 20
-                        }, 
-                        "display_name": "San Pierre Way, Mountain View", 
-                        "feature_type": "end_place", 
-                        "exit_fmt_time": "2015-08-27T19:20:57.489561-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440723334.898,
                         "enter_local_dt": {
-                            "hour": 17, 
-                            "month": 8, 
-                            "second": 34, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 17,
+                            "month": 8,
+                            "second": 34,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 55
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19343f6858f0a02a4a52d"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19344f6858f0a02a4a5ac"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440723334.898, 
-                        "duration": 5122.591560602188, 
+                        },
+                        "enter_fmt_time": "2015-08-27T17:55:34.898000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a325"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5bb2"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a325"
+                                "$oid": "5f3d68ec6fdd485ce81b5bb2"
                             }
-                        ], 
-                        "exit_ts": 1440728457.4895606
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5dba"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68f16fdd485ce81b5e39"
+                        },
+                        "exit_ts": 1440728457.4895606,
+                        "exit_fmt_time": "2015-08-27T19:20:57.489561-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 19,
+                            "minute": 20,
+                            "second": 57,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 5122.591560602188,
+                        "feature_type": "end_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5e"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "LineString", 
+                        "type": "LineString",
                         "coordinates": [
                             [
-                                -122.0779499, 
+                                -122.0779499,
                                 37.3959236
-                            ], 
+                            ],
                             [
-                                -122.0761413, 
+                                -122.0761413,
                                 37.3940933
                             ]
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19344f6858f0a02a4a5a9", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T17:43:04.229000-07:00", 
-                        "distance": 258.74285107438715, 
-                        "exit_local_dt": {
-                            "hour": 17, 
-                            "month": 8, 
-                            "second": 34, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 43
-                        }, 
-                        "feature_type": "stop", 
+                        "trip_id": {
+                            "$oid": "5f3d68f06fdd485ce81b5dba"
+                        },
+                        "source": "SmoothedHighConfidenceMotion",
                         "ending_section": {
-                            "$oid": "57e19344f6858f0a02a4a52f"
-                        }, 
+                            "$oid": "5f3d68f06fdd485ce81b5dbc"
+                        },
                         "starting_section": {
-                            "$oid": "57e19344f6858f0a02a4a58c"
-                        }, 
-                        "exit_fmt_time": "2015-08-27T17:43:34.285000-07:00", 
+                            "$oid": "5f3d68f16fdd485ce81b5e19"
+                        },
+                        "enter_ts": 1440722584.229,
                         "enter_local_dt": {
-                            "hour": 17, 
-                            "month": 8, 
-                            "second": 4, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 43
-                        }, 
-                        "exit_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.0761413, 
-                                37.3940933
-                            ]
-                        }, 
-                        "source": "SmoothedHighConfidenceMotion", 
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 17,
+                            "minute": 43,
+                            "second": 4,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "enter_fmt_time": "2015-08-27T17:43:04.229000-07:00",
                         "enter_loc": {
-                            "type": "Point", 
+                            "type": "Point",
                             "coordinates": [
-                                -122.0779499, 
+                                -122.0779499,
                                 37.3959236
                             ]
-                        }, 
-                        "enter_ts": 1440722584.229, 
-                        "duration": 30.055999994277954, 
-                        "trip_id": {
-                            "$oid": "57e19343f6858f0a02a4a52d"
-                        }, 
-                        "exit_ts": 1440722614.285
-                    }
-                }, 
+                        },
+                        "exit_ts": 1440722614.285,
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 17,
+                            "minute": 43,
+                            "second": 34,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "exit_fmt_time": "2015-08-27T17:43:34.285000-07:00",
+                        "exit_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.0761413,
+                                37.3940933
+                            ]
+                        },
+                        "duration": 30.055999994277954,
+                        "distance": 258.74285107438715,
+                        "feature_type": "stop"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e36"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "LineString", 
+                        "type": "LineString",
                         "coordinates": [
                             [
-                                -122.0784937, 
+                                -122.0784937,
                                 37.4012462
-                            ], 
+                            ],
                             [
-                                -122.078664, 
+                                -122.078664,
                                 37.4015876
                             ]
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19344f6858f0a02a4a5aa", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T17:51:04.721000-07:00", 
-                        "distance": 40.833879313803244, 
-                        "exit_local_dt": {
-                            "hour": 17, 
-                            "month": 8, 
-                            "second": 34, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 51
-                        }, 
-                        "feature_type": "stop", 
+                        "trip_id": {
+                            "$oid": "5f3d68f06fdd485ce81b5dba"
+                        },
+                        "source": "SmoothedHighConfidenceMotion",
                         "ending_section": {
-                            "$oid": "57e19344f6858f0a02a4a58c"
-                        }, 
+                            "$oid": "5f3d68f16fdd485ce81b5e19"
+                        },
                         "starting_section": {
-                            "$oid": "57e19344f6858f0a02a4a59e"
-                        }, 
-                        "exit_fmt_time": "2015-08-27T17:51:34.715000-07:00", 
+                            "$oid": "5f3d68f16fdd485ce81b5e2b"
+                        },
+                        "enter_ts": 1440723064.721,
                         "enter_local_dt": {
-                            "hour": 17, 
-                            "month": 8, 
-                            "second": 4, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 51
-                        }, 
-                        "exit_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.078664, 
-                                37.4015876
-                            ]
-                        }, 
-                        "source": "SmoothedHighConfidenceMotion", 
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 17,
+                            "minute": 51,
+                            "second": 4,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "enter_fmt_time": "2015-08-27T17:51:04.721000-07:00",
                         "enter_loc": {
-                            "type": "Point", 
+                            "type": "Point",
                             "coordinates": [
-                                -122.0784937, 
+                                -122.0784937,
                                 37.4012462
                             ]
-                        }, 
-                        "enter_ts": 1440723064.721, 
-                        "duration": 29.99399995803833, 
-                        "trip_id": {
-                            "$oid": "57e19343f6858f0a02a4a52d"
-                        }, 
-                        "exit_ts": 1440723094.715
-                    }
-                }, 
+                        },
+                        "exit_ts": 1440723094.715,
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 17,
+                            "minute": 51,
+                            "second": 34,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "exit_fmt_time": "2015-08-27T17:51:34.715000-07:00",
+                        "exit_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.078664,
+                                37.4015876
+                            ]
+                        },
+                        "duration": 29.99399995803833,
+                        "distance": 40.833879313803244,
+                        "feature_type": "stop"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e37"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "LineString", 
+                        "type": "LineString",
                         "coordinates": [
                             [
-                                -122.0796973, 
+                                -122.0796973,
                                 37.4021489
-                            ], 
+                            ],
                             [
-                                -122.0827923, 
+                                -122.0827923,
                                 37.4027524
                             ]
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19344f6858f0a02a4a5ab", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T17:52:04.657000-07:00", 
-                        "distance": 281.50303421327163, 
-                        "exit_local_dt": {
-                            "hour": 17, 
-                            "month": 8, 
-                            "second": 4, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 53
-                        }, 
-                        "feature_type": "stop", 
+                        "trip_id": {
+                            "$oid": "5f3d68f06fdd485ce81b5dba"
+                        },
+                        "source": "SmoothedHighConfidenceMotion",
                         "ending_section": {
-                            "$oid": "57e19344f6858f0a02a4a59e"
-                        }, 
+                            "$oid": "5f3d68f16fdd485ce81b5e2b"
+                        },
                         "starting_section": {
-                            "$oid": "57e19344f6858f0a02a4a5a1"
-                        }, 
-                        "exit_fmt_time": "2015-08-27T17:53:04.822000-07:00", 
+                            "$oid": "5f3d68f16fdd485ce81b5e2e"
+                        },
+                        "enter_ts": 1440723124.657,
                         "enter_local_dt": {
-                            "hour": 17, 
-                            "month": 8, 
-                            "second": 4, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 52
-                        }, 
-                        "exit_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.0827923, 
-                                37.4027524
-                            ]
-                        }, 
-                        "source": "SmoothedHighConfidenceMotion", 
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 17,
+                            "minute": 52,
+                            "second": 4,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "enter_fmt_time": "2015-08-27T17:52:04.657000-07:00",
                         "enter_loc": {
-                            "type": "Point", 
+                            "type": "Point",
                             "coordinates": [
-                                -122.0796973, 
+                                -122.0796973,
                                 37.4021489
                             ]
-                        }, 
-                        "enter_ts": 1440723124.657, 
-                        "duration": 60.16499996185303, 
-                        "trip_id": {
-                            "$oid": "57e19343f6858f0a02a4a52d"
-                        }, 
-                        "exit_ts": 1440723184.822
-                    }
-                }, 
+                        },
+                        "exit_ts": 1440723184.822,
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 17,
+                            "minute": 53,
+                            "second": 4,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "exit_fmt_time": "2015-08-27T17:53:04.822000-07:00",
+                        "exit_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.0827923,
+                                37.4027524
+                            ]
+                        },
+                        "duration": 60.16499996185303,
+                        "distance": 281.50303421327163,
+                        "feature_type": "stop"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e38"
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.3871046, 
+                                        -122.3871046,
                                         37.5993148
-                                    ], 
+                                    ],
                                     [
-                                        -122.38356472983239, 
+                                        -122.38356472983239,
                                         37.597689832680715
-                                    ], 
+                                    ],
                                     [
-                                        -122.38002485966477, 
+                                        -122.38002485966477,
                                         37.596064865361434
-                                    ], 
+                                    ],
                                     [
-                                        -122.37648498949716, 
+                                        -122.37648498949716,
                                         37.59443989804215
-                                    ], 
+                                    ],
                                     [
-                                        -122.37294511932954, 
+                                        -122.37294511932954,
                                         37.59281493072287
-                                    ], 
+                                    ],
                                     [
-                                        -122.36940524916193, 
+                                        -122.36940524916193,
                                         37.59118996340358
-                                    ], 
+                                    ],
                                     [
-                                        -122.36586537899431, 
+                                        -122.36586537899431,
                                         37.58956499608429
-                                    ], 
+                                    ],
                                     [
-                                        -122.3623255088267, 
+                                        -122.3623255088267,
                                         37.58794002876501
-                                    ], 
+                                    ],
                                     [
-                                        -122.35878563865909, 
+                                        -122.35878563865909,
                                         37.586315061445724
-                                    ], 
+                                    ],
                                     [
-                                        -122.35524576849147, 
+                                        -122.35524576849147,
                                         37.58469009412644
-                                    ], 
+                                    ],
                                     [
-                                        -122.35170589832386, 
+                                        -122.35170589832386,
                                         37.583065126807156
-                                    ], 
+                                    ],
                                     [
-                                        -122.34816602815624, 
+                                        -122.34816602815624,
                                         37.58144015948787
-                                    ], 
+                                    ],
                                     [
-                                        -122.34468019543081, 
+                                        -122.34468019543081,
                                         37.579840004569185
-                                    ], 
+                                    ],
                                     [
-                                        -122.3446799, 
+                                        -122.3446799,
                                         37.5798403
-                                    ], 
+                                    ],
                                     [
-                                        -122.3443736419912, 
+                                        -122.3443736419912,
                                         37.579722681714536
-                                    ], 
+                                    ],
                                     [
-                                        -122.33791026916391, 
+                                        -122.33791026916391,
                                         37.57723340408836
-                                    ], 
+                                    ],
                                     [
-                                        -122.33398028165144, 
+                                        -122.33398028165144,
                                         37.5751987973484
-                                    ], 
+                                    ],
                                     [
-                                        -122.33005863073234, 
+                                        -122.33005863073234,
                                         37.573161716056795
-                                    ], 
+                                    ],
                                     [
-                                        -122.32691923359984, 
+                                        -122.32691923359984,
                                         37.570914755153574
-                                    ], 
+                                    ],
                                     [
-                                        -122.32589190226538, 
+                                        -122.32589190226538,
                                         37.57005352294679
-                                    ], 
+                                    ],
                                     [
-                                        -122.32486457093093, 
+                                        -122.32486457093093,
                                         37.56919229074001
-                                    ], 
+                                    ],
                                     [
-                                        -122.32383723959647, 
+                                        -122.32383723959647,
                                         37.56833105853323
-                                    ], 
+                                    ],
                                     [
-                                        -122.32280990826203, 
+                                        -122.32280990826203,
                                         37.56746982632645
-                                    ], 
+                                    ],
                                     [
-                                        -122.32178257692757, 
+                                        -122.32178257692757,
                                         37.566608594119664
-                                    ], 
+                                    ],
                                     [
-                                        -122.32025392263087, 
+                                        -122.32025392263087,
                                         37.565028860690916
-                                    ], 
+                                    ],
                                     [
-                                        -122.31803730704107, 
+                                        -122.31803730704107,
                                         37.56246313406625
-                                    ], 
+                                    ],
                                     [
-                                        -122.31582069145126, 
+                                        -122.31582069145126,
                                         37.559897407441575
-                                    ], 
+                                    ],
                                     [
-                                        -122.31360407586146, 
+                                        -122.31360407586146,
                                         37.5573316808169
-                                    ], 
+                                    ],
                                     [
-                                        -122.31138746027166, 
+                                        -122.31138746027166,
                                         37.55476595419223
-                                    ], 
+                                    ],
                                     [
-                                        -122.30917084468187, 
+                                        -122.30917084468187,
                                         37.55220022756755
-                                    ], 
+                                    ],
                                     [
-                                        -122.30695422909207, 
+                                        -122.30695422909207,
                                         37.54963450094288
-                                    ], 
+                                    ],
                                     [
-                                        -122.30473761350227, 
+                                        -122.30473761350227,
                                         37.547068774318205
-                                    ], 
+                                    ],
                                     [
-                                        -122.30263492397924, 
+                                        -122.30263492397924,
                                         37.54479855763969
-                                    ], 
+                                    ],
                                     [
-                                        -122.30054415183042, 
+                                        -122.30054415183042,
                                         37.542559253136986
-                                    ], 
+                                    ],
                                     [
-                                        -122.29845337968159, 
+                                        -122.29845337968159,
                                         37.54031994863429
-                                    ], 
+                                    ],
                                     [
-                                        -122.29636260753276, 
+                                        -122.29636260753276,
                                         37.53808064413159
-                                    ], 
+                                    ],
                                     [
-                                        -122.29427183538394, 
+                                        -122.29427183538394,
                                         37.53584133962889
-                                    ], 
+                                    ],
                                     [
-                                        -122.2921810632351, 
+                                        -122.2921810632351,
                                         37.533602035126194
-                                    ], 
+                                    ],
                                     [
-                                        -122.29009029108629, 
+                                        -122.29009029108629,
                                         37.53136273062349
-                                    ], 
+                                    ],
                                     [
-                                        -122.28583339531868, 
+                                        -122.28583339531868,
                                         37.52814620955099
-                                    ], 
+                                    ],
                                     [
-                                        -122.28131059815135, 
+                                        -122.28131059815135,
                                         37.52480973075702
-                                    ], 
+                                    ],
                                     [
-                                        -122.27678780098404, 
+                                        -122.27678780098404,
                                         37.521473251963045
-                                    ], 
+                                    ],
                                     [
-                                        -122.2762817, 
+                                        -122.2762817,
                                         37.5210999
-                                    ], 
+                                    ],
                                     [
-                                        -122.2762375793434, 
+                                        -122.2762375793434,
                                         37.52088455961841
-                                    ], 
+                                    ],
                                     [
-                                        -122.2762314, 
+                                        -122.2762314,
                                         37.5208544
-                                    ], 
+                                    ],
                                     [
-                                        -122.27190235041846, 
+                                        -122.27190235041846,
                                         37.51774628698037
-                                    ], 
+                                    ],
                                     [
-                                        -122.26900497555006, 
+                                        -122.26900497555006,
                                         37.51533189577263
-                                    ], 
+                                    ],
                                     [
-                                        -122.26634534296603, 
+                                        -122.26634534296603,
                                         37.51304445885486
-                                    ], 
+                                    ],
                                     [
-                                        -122.26368571038202, 
+                                        -122.26368571038202,
                                         37.510757021937074
-                                    ], 
+                                    ],
                                     [
-                                        -122.261026077798, 
+                                        -122.261026077798,
                                         37.5084695850193
-                                    ], 
+                                    ],
                                     [
-                                        -122.2607763981307, 
+                                        -122.2607763981307,
                                         37.508067325232936
-                                    ], 
+                                    ],
                                     [
-                                        -122.26069785505071, 
+                                        -122.26069785505071,
                                         37.50768587599611
-                                    ], 
+                                    ],
                                     [
-                                        -122.25802192791353, 
+                                        -122.25802192791353,
                                         37.50533151677355
-                                    ], 
+                                    ],
                                     [
-                                        -122.25368760994891, 
+                                        -122.25368760994891,
                                         37.50141057763227
-                                    ], 
+                                    ],
                                     [
-                                        -122.2491692241119, 
+                                        -122.2491692241119,
                                         37.49730603465813
-                                    ], 
+                                    ],
                                     [
-                                        -122.24506563348574, 
+                                        -122.24506563348574,
                                         37.494624532059746
-                                    ], 
+                                    ],
                                     [
-                                        -122.2410265395756, 
+                                        -122.2410265395756,
                                         37.49216429872531
-                                    ], 
+                                    ],
                                     [
-                                        -122.23698744566546, 
+                                        -122.23698744566546,
                                         37.48970406539087
-                                    ], 
+                                    ],
                                     [
-                                        -122.23294835175531, 
+                                        -122.23294835175531,
                                         37.48724383205642
-                                    ], 
+                                    ],
                                     [
-                                        -122.23215338841807, 
+                                        -122.23215338841807,
                                         37.48681525585265
-                                    ], 
+                                    ],
                                     [
-                                        -122.23215648899297, 
+                                        -122.23215648899297,
                                         37.48688647218231
-                                    ], 
+                                    ],
                                     [
-                                        -122.2321573, 
+                                        -122.2321573,
                                         37.4869051
-                                    ], 
+                                    ],
                                     [
-                                        -122.23100467307621, 
+                                        -122.23100467307621,
                                         37.48604193056071
-                                    ], 
+                                    ],
                                     [
-                                        -122.22951517026158, 
+                                        -122.22951517026158,
                                         37.48492648437185
-                                    ], 
+                                    ],
                                     [
-                                        -122.22802566744696, 
+                                        -122.22802566744696,
                                         37.483811038182985
-                                    ], 
+                                    ],
                                     [
-                                        -122.22177042271733, 
+                                        -122.22177042271733,
                                         37.47987803754828
-                                    ], 
+                                    ],
                                     [
-                                        -122.21473140092638, 
+                                        -122.21473140092638,
                                         37.47548166004949
-                                    ], 
+                                    ],
                                     [
-                                        -122.20769237913545, 
+                                        -122.20769237913545,
                                         37.471085282550696
-                                    ], 
+                                    ],
                                     [
-                                        -122.2006533573445, 
+                                        -122.2006533573445,
                                         37.46668890505191
-                                    ], 
+                                    ],
                                     [
-                                        -122.19361433555358, 
+                                        -122.19361433555358,
                                         37.46229252755312
-                                    ], 
+                                    ],
                                     [
-                                        -122.18657531376265, 
+                                        -122.18657531376265,
                                         37.457896150054324
-                                    ], 
+                                    ],
                                     [
-                                        -122.1844298341005, 
+                                        -122.1844298341005,
                                         37.455406106328304
-                                    ], 
+                                    ],
                                     [
-                                        -122.184236, 
+                                        -122.184236,
                                         37.4550829
-                                    ], 
+                                    ],
                                     [
-                                        -122.184236, 
+                                        -122.184236,
                                         37.4550829
-                                    ], 
+                                    ],
                                     [
-                                        -122.184236, 
+                                        -122.184236,
                                         37.4550829
-                                    ], 
+                                    ],
                                     [
-                                        -122.17839683012052, 
+                                        -122.17839683012052,
                                         37.4518327929526
-                                    ], 
+                                    ],
                                     [
-                                        -122.17177044580883, 
+                                        -122.17177044580883,
                                         37.44814451896936
-                                    ], 
+                                    ],
                                     [
-                                        -122.16514406149714, 
+                                        -122.16514406149714,
                                         37.444456244986114
-                                    ], 
+                                    ],
                                     [
-                                        -122.15851767718546, 
+                                        -122.15851767718546,
                                         37.44076797100287
-                                    ], 
+                                    ],
                                     [
-                                        -122.15189129287377, 
+                                        -122.15189129287377,
                                         37.43707969701963
-                                    ], 
+                                    ],
                                     [
-                                        -122.14526490856208, 
+                                        -122.14526490856208,
                                         37.43339142303638
-                                    ], 
+                                    ],
                                     [
-                                        -122.1386385242504, 
+                                        -122.1386385242504,
                                         37.42970314905314
-                                    ], 
+                                    ],
                                     [
-                                        -122.13201213993871, 
+                                        -122.13201213993871,
                                         37.426014875069896
-                                    ], 
+                                    ],
                                     [
-                                        -122.12538575562702, 
+                                        -122.12538575562702,
                                         37.42232660108665
-                                    ], 
+                                    ],
                                     [
-                                        -122.11875937131533, 
+                                        -122.11875937131533,
                                         37.41863832710341
-                                    ], 
+                                    ],
                                     [
-                                        -122.11213298700365, 
+                                        -122.11213298700365,
                                         37.414950053120165
-                                    ], 
+                                    ],
                                     [
-                                        -122.10550660269196, 
+                                        -122.10550660269196,
                                         37.41126177913692
-                                    ], 
+                                    ],
                                     [
-                                        -122.09888021838027, 
+                                        -122.09888021838027,
                                         37.40757350515368
-                                    ], 
+                                    ],
                                     [
-                                        -122.09225383406859, 
+                                        -122.09225383406859,
                                         37.403885231170435
-                                    ], 
+                                    ],
                                     [
-                                        -122.0856274497569, 
+                                        -122.0856274497569,
                                         37.40019695718719
-                                    ], 
+                                    ],
                                     [
-                                        -122.07900106544521, 
+                                        -122.07900106544521,
                                         37.39650868320395
-                                    ], 
+                                    ],
                                     [
-                                        -122.0779499, 
+                                        -122.0779499,
                                         37.3959236
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19344f6858f0a02a4a52f", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    360.4264896593399, 
-                                    360.43238290068666, 
-                                    360.438275958114, 
-                                    360.44416883002754, 
-                                    360.4500615180019, 
-                                    360.4559540208389, 
-                                    360.46184633852846, 
-                                    360.46773847224904, 
-                                    360.47363042080264, 
-                                    360.47952218417913, 
-                                    360.48541376355695, 
-                                    354.98785469460546, 
-                                    0.0419156658554899, 
-                                    29.990217410595957, 
-                                    633.2735523401939, 
-                                    413.68215949806023, 
-                                    413.22595047162224, 
-                                    372.79669478915827, 
-                                    131.79067828888057, 
-                                    131.79139757175113, 
-                                    131.7921168449584, 
-                                    131.79283610764134, 
-                                    131.79355536295515, 
-                                    221.38008100745762, 
-                                    345.78229659619893, 
-                                    345.7860984883869, 
-                                    345.7899002476667, 
-                                    345.79370187466407, 
-                                    345.7975033686449, 
-                                    345.80130473170686, 
-                                    345.8051059617002, 
-                                    313.19230297004475, 
-                                    309.80552269868343, 
-                                    309.8088170398643, 
-                                    309.81211127794194, 
-                                    309.81540541099434, 
-                                    309.8186994412415, 
-                                    309.82199336758913, 
-                                    518.4897727160508, 
-                                    544.7185953118097, 
-                                    544.7316566258119, 
-                                    60.956282625892165, 
-                                    24.25885459424381, 
-                                    3.397587685147023, 
-                                    514.9876860599126, 
-                                    370.64288541343853, 
-                                    346.00915739550663, 
-                                    346.0140317350037, 
-                                    346.0189059022652, 
-                                    49.85720558083278, 
-                                    42.97731213662191, 
-                                    352.4925240086861, 
-                                    579.8895901710931, 
-                                    605.9603154068149, 
-                                    469.0069079898968, 
-                                    449.24577491755, 
-                                    449.25508567359026, 
-                                    449.26439602363376, 
-                                    84.79891661933465, 
-                                    7.923618625525281, 
-                                    2.0725544797846385, 
-                                    139.8390908758519, 
-                                    180.71083891041695, 
-                                    180.7122659791398, 
-                                    704.2077453807702, 
-                                    790.443837099406, 
-                                    790.4725516487979, 
-                                    790.5012639715675, 
-                                    790.5299740648048, 
-                                    790.5586819295677, 
-                                    335.44959325865807, 
-                                    39.80384400009374, 
-                                    0.0, 
-                                    0.0, 
-                                    629.5069771525089, 
-                                    714.3969006481499, 
-                                    714.4205151815936, 
-                                    714.4441281138162, 
-                                    714.4677394445847, 
-                                    714.4913491736667, 
-                                    714.5149573008296, 
-                                    714.5385638258407, 
-                                    714.5621687484678, 
-                                    714.5857720684783, 
-                                    714.6093737856398, 
-                                    714.63297389972, 
-                                    714.6565724104865, 
-                                    714.680169317707, 
-                                    714.7037646211494, 
-                                    714.7273583205813, 
-                                    113.38175294462827
-                                ], 
-                                "end_ts": 1440722584.229, 
-                                "feature_type": "section", 
-                                "distance": 35813.505599370765, 
-                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
-                                "start_ts": 1440719879.47, 
-                                "start_fmt_time": "2015-08-27T16:57:59.470000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T17:43:04.229000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 17, 
-                                    "month": 8, 
-                                    "second": 4, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 43
-                                }, 
-                                "duration": 2704.7590000629425, 
-                                "end_stop": {
-                                    "$oid": "57e19344f6858f0a02a4a5a9"
-                                }, 
+                                "times": [
+                                    1440719879.47,
+                                    1440719909.47,
+                                    1440719939.47,
+                                    1440719969.47,
+                                    1440719999.47,
+                                    1440720029.47,
+                                    1440720059.47,
+                                    1440720089.47,
+                                    1440720119.47,
+                                    1440720149.47,
+                                    1440720179.47,
+                                    1440720209.47,
+                                    1440720239.47,
+                                    1440720269.47,
+                                    1440720299.47,
+                                    1440720329.47,
+                                    1440720359.47,
+                                    1440720389.47,
+                                    1440720419.47,
+                                    1440720449.47,
+                                    1440720479.47,
+                                    1440720509.47,
+                                    1440720539.47,
+                                    1440720569.47,
+                                    1440720599.47,
+                                    1440720629.47,
+                                    1440720659.47,
+                                    1440720689.47,
+                                    1440720719.47,
+                                    1440720749.47,
+                                    1440720779.47,
+                                    1440720809.47,
+                                    1440720839.47,
+                                    1440720869.47,
+                                    1440720899.47,
+                                    1440720929.47,
+                                    1440720959.47,
+                                    1440720989.47,
+                                    1440721019.47,
+                                    1440721049.47,
+                                    1440721079.47,
+                                    1440721109.47,
+                                    1440721139.47,
+                                    1440721169.47,
+                                    1440721199.47,
+                                    1440721229.47,
+                                    1440721259.47,
+                                    1440721289.47,
+                                    1440721319.47,
+                                    1440721349.47,
+                                    1440721379.47,
+                                    1440721409.47,
+                                    1440721439.47,
+                                    1440721469.47,
+                                    1440721499.47,
+                                    1440721529.47,
+                                    1440721559.47,
+                                    1440721589.47,
+                                    1440721619.47,
+                                    1440721649.47,
+                                    1440721679.47,
+                                    1440721709.47,
+                                    1440721739.47,
+                                    1440721769.47,
+                                    1440721799.47,
+                                    1440721829.47,
+                                    1440721859.47,
+                                    1440721889.47,
+                                    1440721919.47,
+                                    1440721949.47,
+                                    1440721979.47,
+                                    1440722009.47,
+                                    1440722039.47,
+                                    1440722069.47,
+                                    1440722099.47,
+                                    1440722129.47,
+                                    1440722159.47,
+                                    1440722189.47,
+                                    1440722219.47,
+                                    1440722249.47,
+                                    1440722279.47,
+                                    1440722309.47,
+                                    1440722339.47,
+                                    1440722369.47,
+                                    1440722399.47,
+                                    1440722429.47,
+                                    1440722459.47,
+                                    1440722489.47,
+                                    1440722519.47,
+                                    1440722549.47,
+                                    1440722579.47,
+                                    1440722584.229
+                                ],
+                                "timestamps": [
+                                    1440719879470,
+                                    1440719909470,
+                                    1440719939470,
+                                    1440719969470,
+                                    1440719999470,
+                                    1440720029470,
+                                    1440720059470,
+                                    1440720089470,
+                                    1440720119470,
+                                    1440720149470,
+                                    1440720179470,
+                                    1440720209470,
+                                    1440720239470,
+                                    1440720269470,
+                                    1440720299470,
+                                    1440720329470,
+                                    1440720359470,
+                                    1440720389470,
+                                    1440720419470,
+                                    1440720449470,
+                                    1440720479470,
+                                    1440720509470,
+                                    1440720539470,
+                                    1440720569470,
+                                    1440720599470,
+                                    1440720629470,
+                                    1440720659470,
+                                    1440720689470,
+                                    1440720719470,
+                                    1440720749470,
+                                    1440720779470,
+                                    1440720809470,
+                                    1440720839470,
+                                    1440720869470,
+                                    1440720899470,
+                                    1440720929470,
+                                    1440720959470,
+                                    1440720989470,
+                                    1440721019470,
+                                    1440721049470,
+                                    1440721079470,
+                                    1440721109470,
+                                    1440721139470,
+                                    1440721169470,
+                                    1440721199470,
+                                    1440721229470,
+                                    1440721259470,
+                                    1440721289470,
+                                    1440721319470,
+                                    1440721349470,
+                                    1440721379470,
+                                    1440721409470,
+                                    1440721439470,
+                                    1440721469470,
+                                    1440721499470,
+                                    1440721529470,
+                                    1440721559470,
+                                    1440721589470,
+                                    1440721619470,
+                                    1440721649470,
+                                    1440721679470,
+                                    1440721709470,
+                                    1440721739470,
+                                    1440721769470,
+                                    1440721799470,
+                                    1440721829470,
+                                    1440721859470,
+                                    1440721889470,
+                                    1440721919470,
+                                    1440721949470,
+                                    1440721979470,
+                                    1440722009470,
+                                    1440722039470,
+                                    1440722069470,
+                                    1440722099470,
+                                    1440722129470,
+                                    1440722159470,
+                                    1440722189470,
+                                    1440722219470,
+                                    1440722249470,
+                                    1440722279470,
+                                    1440722309470,
+                                    1440722339470,
+                                    1440722369470,
+                                    1440722399470,
+                                    1440722429470,
+                                    1440722459470,
+                                    1440722489470,
+                                    1440722519470,
+                                    1440722549470,
+                                    1440722579470,
+                                    1440722584229
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19343f6858f0a02a4a52d"
-                                }, 
+                                    "$oid": "5f3d68f06fdd485ce81b5dba"
+                                },
+                                "start_ts": 1440719879.47,
                                 "start_local_dt": {
-                                    "hour": 16, 
-                                    "month": 8, 
-                                    "second": 59, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 57
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 16,
+                                    "minute": 57,
+                                    "second": 59,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T16:57:59.470000-07:00",
+                                "end_ts": 1440722584.229,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 17,
+                                    "minute": 43,
+                                    "second": 4,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T17:43:04.229000-07:00",
+                                "duration": 2704.7590000629425,
                                 "speeds": [
-                                    0.0, 
-                                    12.014216321977996, 
-                                    12.014412763356223, 
-                                    12.0146091986038, 
-                                    12.014805627667585, 
-                                    12.015002050600064, 
-                                    12.015198467361296, 
-                                    12.015394877950948, 
-                                    12.015591282408302, 
-                                    12.015787680693421, 
-                                    12.01598407280597, 
-                                    12.016180458785232, 
-                                    11.832928489820182, 
-                                    0.0013971888618496632, 
-                                    0.9996739136865319, 
-                                    21.109118411339796, 
-                                    13.789405316602007, 
-                                    13.774198349054075, 
-                                    12.426556492971942, 
-                                    4.3930226096293525, 
-                                    4.393046585725037, 
-                                    4.393070561498614, 
-                                    4.393094536921378, 
-                                    4.393118512098505, 
-                                    7.379336033581921, 
-                                    11.52607655320663, 
-                                    11.52620328294623, 
-                                    11.526330008255558, 
-                                    11.526456729155468, 
-                                    11.526583445621498, 
-                                    11.526710157723562, 
-                                    11.526836865390006, 
-                                    10.439743432334826, 
-                                    10.32685075662278, 
-                                    10.326960567995478, 
-                                    10.327070375931397, 
-                                    10.327180180366478, 
-                                    10.327289981374717, 
-                                    10.327399778919638, 
-                                    17.282992423868357, 
-                                    18.157286510393657, 
-                                    18.157721887527064, 
-                                    2.031876087529739, 
-                                    0.8086284864747937, 
-                                    0.1132529228382341, 
-                                    17.166256201997086, 
-                                    12.354762847114618, 
-                                    11.533638579850221, 
-                                    11.533801057833456, 
-                                    11.533963530075507, 
-                                    1.661906852694426, 
-                                    1.4325770712207304, 
-                                    11.749750800289537, 
-                                    19.329653005703104, 
-                                    20.19867718022716, 
-                                    15.633563599663226, 
-                                    14.974859163918333, 
-                                    14.975169522453008, 
-                                    14.975479867454458, 
-                                    2.8266305539778216, 
-                                    0.2641206208508427, 
-                                    0.06908514932615462, 
-                                    4.6613030291950635, 
-                                    6.023694630347232, 
-                                    6.02374219930466, 
-                                    23.47359151269234, 
-                                    26.348127903313532, 
-                                    26.34908505495993, 
-                                    26.350042132385582, 
-                                    26.350999135493495, 
-                                    26.351956064318923, 
-                                    11.181653108621935, 
-                                    1.3267948000031247, 
-                                    0.0, 
-                                    0.0, 
-                                    20.98356590508363, 
-                                    23.813230021604998, 
-                                    23.814017172719787, 
-                                    23.814804270460538, 
-                                    23.81559131481949, 
-                                    23.816378305788888, 
-                                    23.817165243360986, 
-                                    23.817952127528024, 
-                                    23.81873895828226, 
-                                    23.819525735615944, 
-                                    23.82031245952133, 
-                                    23.821099129990667, 
-                                    23.821885747016218, 
-                                    23.822672310590235, 
-                                    23.823458820704978, 
-                                    23.82424527735271, 
+                                    0.0,
+                                    12.014216321977996,
+                                    12.014412763356223,
+                                    12.0146091986038,
+                                    12.014805627667585,
+                                    12.015002050600064,
+                                    12.015198467361296,
+                                    12.015394877950948,
+                                    12.015591282408304,
+                                    12.015787680693421,
+                                    12.01598407280597,
+                                    12.016180458785232,
+                                    11.832928489820182,
+                                    0.0013971888618496632,
+                                    0.9996739136865319,
+                                    21.109118411339796,
+                                    13.789405316602007,
+                                    13.774198349054075,
+                                    12.426556492971942,
+                                    4.3930226096293525,
+                                    4.393046585725037,
+                                    4.393070561498614,
+                                    4.393094536921378,
+                                    4.393118512098505,
+                                    7.379336033581921,
+                                    11.52607655320663,
+                                    11.52620328294623,
+                                    11.526330008255558,
+                                    11.526456729155468,
+                                    11.526583445621498,
+                                    11.526710157723562,
+                                    11.526836865390006,
+                                    10.439743432334826,
+                                    10.32685075662278,
+                                    10.326960567995478,
+                                    10.327070375931397,
+                                    10.327180180366478,
+                                    10.327289981374717,
+                                    10.327399778919638,
+                                    17.282992423868357,
+                                    18.157286510393657,
+                                    18.157721887527064,
+                                    2.031876087529739,
+                                    0.8086284864747937,
+                                    0.1132529228382341,
+                                    17.166256201997086,
+                                    12.354762847114618,
+                                    11.533638579850221,
+                                    11.533801057833456,
+                                    11.533963530075507,
+                                    1.661906852694426,
+                                    1.4325770712207304,
+                                    11.749750800289537,
+                                    19.329653005703104,
+                                    20.19867718022716,
+                                    15.633563599663226,
+                                    14.974859163918333,
+                                    14.975169522453008,
+                                    14.975479867454458,
+                                    2.8266305539778216,
+                                    0.2641206208508427,
+                                    0.06908514932615462,
+                                    4.6613030291950635,
+                                    6.023694630347232,
+                                    6.02374219930466,
+                                    23.47359151269234,
+                                    26.348127903313532,
+                                    26.34908505495993,
+                                    26.350042132385582,
+                                    26.350999135493495,
+                                    26.351956064318923,
+                                    11.181653108621935,
+                                    1.3267948000031247,
+                                    0.0,
+                                    0.0,
+                                    20.98356590508363,
+                                    23.813230021604998,
+                                    23.814017172719787,
+                                    23.814804270460538,
+                                    23.81559131481949,
+                                    23.816378305788888,
+                                    23.817165243360986,
+                                    23.817952127528024,
+                                    23.81873895828226,
+                                    23.819525735615944,
+                                    23.82031245952133,
+                                    23.821099129990667,
+                                    23.821885747016218,
+                                    23.822672310590235,
+                                    23.823458820704978,
+                                    23.82424527735271,
                                     23.824700870990107
-                                ]
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    360.4264896593399,
+                                    360.43238290068666,
+                                    360.438275958114,
+                                    360.44416883002754,
+                                    360.4500615180019,
+                                    360.4559540208389,
+                                    360.46184633852846,
+                                    360.4677384722491,
+                                    360.47363042080264,
+                                    360.47952218417913,
+                                    360.48541376355695,
+                                    354.98785469460546,
+                                    0.0419156658554899,
+                                    29.990217410595957,
+                                    633.2735523401939,
+                                    413.68215949806023,
+                                    413.22595047162224,
+                                    372.79669478915827,
+                                    131.79067828888057,
+                                    131.79139757175113,
+                                    131.7921168449584,
+                                    131.79283610764134,
+                                    131.79355536295515,
+                                    221.38008100745762,
+                                    345.78229659619893,
+                                    345.7860984883869,
+                                    345.7899002476667,
+                                    345.79370187466407,
+                                    345.7975033686449,
+                                    345.80130473170686,
+                                    345.8051059617002,
+                                    313.19230297004475,
+                                    309.80552269868343,
+                                    309.8088170398643,
+                                    309.81211127794194,
+                                    309.81540541099434,
+                                    309.8186994412415,
+                                    309.82199336758913,
+                                    518.4897727160508,
+                                    544.7185953118097,
+                                    544.7316566258119,
+                                    60.956282625892165,
+                                    24.25885459424381,
+                                    3.397587685147023,
+                                    514.9876860599126,
+                                    370.64288541343853,
+                                    346.00915739550663,
+                                    346.0140317350037,
+                                    346.0189059022652,
+                                    49.85720558083278,
+                                    42.97731213662191,
+                                    352.4925240086861,
+                                    579.8895901710931,
+                                    605.9603154068149,
+                                    469.0069079898968,
+                                    449.24577491755,
+                                    449.25508567359026,
+                                    449.26439602363376,
+                                    84.79891661933465,
+                                    7.923618625525281,
+                                    2.0725544797846385,
+                                    139.8390908758519,
+                                    180.71083891041695,
+                                    180.7122659791398,
+                                    704.2077453807702,
+                                    790.443837099406,
+                                    790.4725516487979,
+                                    790.5012639715675,
+                                    790.5299740648048,
+                                    790.5586819295677,
+                                    335.44959325865807,
+                                    39.80384400009374,
+                                    0.0,
+                                    0.0,
+                                    629.5069771525089,
+                                    714.3969006481499,
+                                    714.4205151815936,
+                                    714.4441281138162,
+                                    714.4677394445847,
+                                    714.4913491736667,
+                                    714.5149573008296,
+                                    714.5385638258407,
+                                    714.5621687484678,
+                                    714.5857720684783,
+                                    714.6093737856398,
+                                    714.63297389972,
+                                    714.6565724104865,
+                                    714.680169317707,
+                                    714.7037646211494,
+                                    714.7273583205813,
+                                    113.38175294462827
+                                ],
+                                "distance": 35813.505599370765,
+                                "sensed_mode": "MotionTypes.IN_VEHICLE",
+                                "end_stop": {
+                                    "$oid": "5f3d68f16fdd485ce81b5e36"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f06fdd485ce81b5dbc"
                         }
                     ]
-                }, 
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.0761413, 
+                                        -122.0761413,
                                         37.3940933
-                                    ], 
+                                    ],
                                     [
-                                        -122.07681653698792, 
+                                        -122.07681653698792,
                                         37.39485958970722
-                                    ], 
+                                    ],
                                     [
-                                        -122.07749177397585, 
+                                        -122.07749177397585,
                                         37.39562587941444
-                                    ], 
+                                    ],
                                     [
-                                        -122.0774038971201, 
+                                        -122.0774038971201,
                                         37.395543394782024
-                                    ], 
+                                    ],
                                     [
-                                        -122.07773661925353, 
+                                        -122.07773661925353,
                                         37.39566341923015
-                                    ], 
+                                    ],
                                     [
-                                        -122.0775389, 
+                                        -122.0775389,
                                         37.3955742
-                                    ], 
+                                    ],
                                     [
-                                        -122.07754851506421, 
+                                        -122.07754851506421,
                                         37.39558215039109
-                                    ], 
+                                    ],
                                     [
-                                        -122.07788707366433, 
+                                        -122.07788707366433,
                                         37.39586209374013
-                                    ], 
+                                    ],
                                     [
-                                        -122.07776704019916, 
+                                        -122.07776704019916,
                                         37.39603098246543
-                                    ], 
+                                    ],
                                     [
-                                        -122.07782146185397, 
+                                        -122.07782146185397,
                                         37.39587792038169
-                                    ], 
+                                    ],
                                     [
-                                        -122.0777432635118, 
+                                        -122.0777432635118,
                                         37.395666441480564
-                                    ], 
+                                    ],
                                     [
-                                        -122.07694010707229, 
+                                        -122.07694010707229,
                                         37.397029427800916
-                                    ], 
+                                    ],
                                     [
-                                        -122.07620646420425, 
+                                        -122.07620646420425,
                                         37.39786924498624
-                                    ], 
+                                    ],
                                     [
-                                        -122.07673273001728, 
+                                        -122.07673273001728,
                                         37.398083304785615
-                                    ], 
+                                    ],
                                     [
-                                        -122.07788984311638, 
+                                        -122.07788984311638,
                                         37.39899611121382
-                                    ], 
+                                    ],
                                     [
-                                        -122.07848517813805, 
+                                        -122.07848517813805,
                                         37.40121367494206
-                                    ], 
+                                    ],
                                     [
-                                        -122.0784937, 
+                                        -122.0784937,
                                         37.4012462
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19344f6858f0a02a4a58c", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    104.0125419939131, 
-                                    104.01219225042587, 
-                                    12.016162828262692, 
-                                    32.28078397018566, 
-                                    20.087318220175707, 
-                                    1.225971127925706, 
-                                    43.167957779737904, 
-                                    21.566432084607676, 
-                                    17.685701311709384, 
-                                    24.509060042473088, 
-                                    167.34246971335793, 
-                                    113.66880587941668, 
-                                    52.22804341142004, 
-                                    144.0490606828309, 
-                                    252.12731062944542, 
-                                    3.694131307129653
-                                ], 
-                                "feature_type": "section", 
-                                "sensed_mode": "MotionTypes.ON_FOOT", 
-                                "end_ts": 1440723064.721, 
-                                "start_ts": 1440722614.285, 
-                                "start_fmt_time": "2015-08-27T17:43:34.285000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T17:51:04.721000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 17, 
-                                    "month": 8, 
-                                    "second": 4, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 51
-                                }, 
-                                "duration": 450.4359998703003, 
-                                "start_stop": {
-                                    "$oid": "57e19344f6858f0a02a4a5a9"
-                                }, 
-                                "end_stop": {
-                                    "$oid": "57e19344f6858f0a02a4a5aa"
-                                }, 
+                                "times": [
+                                    1440722614.285,
+                                    1440722644.285,
+                                    1440722674.285,
+                                    1440722704.285,
+                                    1440722734.285,
+                                    1440722764.285,
+                                    1440722794.285,
+                                    1440722824.285,
+                                    1440722854.285,
+                                    1440722884.285,
+                                    1440722914.285,
+                                    1440722944.285,
+                                    1440722974.285,
+                                    1440723004.285,
+                                    1440723034.285,
+                                    1440723064.285,
+                                    1440723064.721
+                                ],
+                                "timestamps": [
+                                    1440722614285,
+                                    1440722644285,
+                                    1440722674285,
+                                    1440722704285,
+                                    1440722734285,
+                                    1440722764285,
+                                    1440722794285,
+                                    1440722824285,
+                                    1440722854285,
+                                    1440722884285,
+                                    1440722914285,
+                                    1440722944285,
+                                    1440722974285,
+                                    1440723004285,
+                                    1440723034285,
+                                    1440723064285,
+                                    1440723064721
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19343f6858f0a02a4a52d"
-                                }, 
+                                    "$oid": "5f3d68f06fdd485ce81b5dba"
+                                },
+                                "start_ts": 1440722614.285,
                                 "start_local_dt": {
-                                    "hour": 17, 
-                                    "month": 8, 
-                                    "second": 34, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 43
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 17,
+                                    "minute": 43,
+                                    "second": 34,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T17:43:34.285000-07:00",
+                                "end_ts": 1440723064.721,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 17,
+                                    "minute": 51,
+                                    "second": 4,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T17:51:04.721000-07:00",
+                                "duration": 450.4359998703003,
                                 "speeds": [
-                                    0.0, 
-                                    3.4670847331304366, 
-                                    3.467073075014196, 
-                                    0.40053876094208973, 
-                                    1.076026132339522, 
-                                    0.6695772740058569, 
-                                    0.0408657042641902, 
-                                    1.4389319259912634, 
-                                    0.7188810694869225, 
-                                    0.5895233770569794, 
-                                    0.8169686680824363, 
-                                    5.578082323778598, 
-                                    3.788960195980556, 
-                                    1.740934780380668, 
-                                    4.801635356094364, 
-                                    8.404243687648181, 
+                                    0.0,
+                                    3.4670847331304366,
+                                    3.467073075014196,
+                                    0.40053876094208973,
+                                    1.076026132339522,
+                                    0.6695772740058569,
+                                    0.0408657042641902,
+                                    1.4389319259912634,
+                                    0.7188810694869225,
+                                    0.5895233770569794,
+                                    0.8169686680824363,
+                                    5.578082323778598,
+                                    3.788960195980556,
+                                    1.740934780380668,
+                                    4.801635356094364,
+                                    8.404243687648181,
                                     8.472780747813838
-                                ], 
-                                "distance": 1113.6739432330176
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    104.0125419939131,
+                                    104.01219225042587,
+                                    12.016162828262692,
+                                    32.28078397018566,
+                                    20.087318220175707,
+                                    1.225971127925706,
+                                    43.167957779737904,
+                                    21.566432084607676,
+                                    17.685701311709384,
+                                    24.509060042473088,
+                                    167.34246971335793,
+                                    113.66880587941668,
+                                    52.22804341142004,
+                                    144.0490606828309,
+                                    252.12731062944542,
+                                    3.694131307129653
+                                ],
+                                "distance": 1113.6739432330176,
+                                "sensed_mode": "MotionTypes.ON_FOOT",
+                                "start_stop": {
+                                    "$oid": "5f3d68f16fdd485ce81b5e36"
+                                },
+                                "end_stop": {
+                                    "$oid": "5f3d68f16fdd485ce81b5e37"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f16fdd485ce81b5e19"
                         }
                     ]
-                }, 
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.078664, 
+                                        -122.078664,
                                         37.4015876
-                                    ], 
+                                    ],
                                     [
-                                        -122.0796973, 
+                                        -122.0796973,
                                         37.4021489
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19344f6858f0a02a4a59e", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    110.57324346353148
-                                ], 
-                                "feature_type": "section", 
-                                "sensed_mode": "MotionTypes.BICYCLING", 
-                                "end_ts": 1440723124.657, 
-                                "start_ts": 1440723094.715, 
-                                "start_fmt_time": "2015-08-27T17:51:34.715000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T17:52:04.657000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 17, 
-                                    "month": 8, 
-                                    "second": 4, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 52
-                                }, 
-                                "duration": 29.942000150680542, 
-                                "start_stop": {
-                                    "$oid": "57e19344f6858f0a02a4a5aa"
-                                }, 
-                                "end_stop": {
-                                    "$oid": "57e19344f6858f0a02a4a5ab"
-                                }, 
+                                "times": [
+                                    1440723094.715,
+                                    1440723124.657
+                                ],
+                                "timestamps": [
+                                    1440723094715,
+                                    1440723124657
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19343f6858f0a02a4a52d"
-                                }, 
+                                    "$oid": "5f3d68f06fdd485ce81b5dba"
+                                },
+                                "start_ts": 1440723094.715,
                                 "start_local_dt": {
-                                    "hour": 17, 
-                                    "month": 8, 
-                                    "second": 34, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 51
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 17,
+                                    "minute": 51,
+                                    "second": 34,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T17:51:34.715000-07:00",
+                                "end_ts": 1440723124.657,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 17,
+                                    "minute": 52,
+                                    "second": 4,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T17:52:04.657000-07:00",
+                                "duration": 29.942000150680542,
                                 "speeds": [
-                                    0.0, 
+                                    0.0,
                                     3.692914398072311
-                                ], 
-                                "distance": 110.57324346353148
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    110.57324346353148
+                                ],
+                                "distance": 110.57324346353148,
+                                "sensed_mode": "MotionTypes.BICYCLING",
+                                "start_stop": {
+                                    "$oid": "5f3d68f16fdd485ce81b5e37"
+                                },
+                                "end_stop": {
+                                    "$oid": "5f3d68f16fdd485ce81b5e38"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f16fdd485ce81b5e2b"
                         }
                     ]
-                }, 
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.0827923, 
+                                        -122.0827923,
                                         37.4027524
-                                    ], 
+                                    ],
                                     [
-                                        -122.08334456138144, 
+                                        -122.08334456138144,
                                         37.40279351329594
-                                    ], 
+                                    ],
                                     [
-                                        -122.08327243415631, 
+                                        -122.08327243415631,
                                         37.403089763180404
-                                    ], 
+                                    ],
                                     [
-                                        -122.08313602743902, 
+                                        -122.08313602743902,
                                         37.4037621002979
-                                    ], 
+                                    ],
                                     [
-                                        -122.08366698391958, 
+                                        -122.08366698391958,
                                         37.4036582635619
-                                    ], 
+                                    ],
                                     [
-                                        -122.08370191463239, 
+                                        -122.08370191463239,
                                         37.4036219914472
-                                    ], 
+                                    ],
                                     [
-                                        -122.083702, 
+                                        -122.083702,
                                         37.4036219
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19344f6858f0a02a4a5a1", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    48.995878864870875, 
-                                    33.551934165615684, 
-                                    75.72519595148405, 
-                                    48.30000252282387, 
-                                    5.078120884812968, 
-                                    0.01265930221646351
-                                ], 
-                                "feature_type": "section", 
-                                "sensed_mode": "MotionTypes.ON_FOOT", 
-                                "end_ts": 1440723334.898, 
-                                "start_ts": 1440723184.822, 
-                                "start_fmt_time": "2015-08-27T17:53:04.822000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T17:55:34.898000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 17, 
-                                    "month": 8, 
-                                    "second": 34, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 55
-                                }, 
-                                "duration": 150.07599997520447, 
-                                "start_stop": {
-                                    "$oid": "57e19344f6858f0a02a4a5ab"
-                                }, 
+                                "times": [
+                                    1440723184.822,
+                                    1440723214.822,
+                                    1440723244.822,
+                                    1440723274.822,
+                                    1440723304.822,
+                                    1440723334.822,
+                                    1440723334.898
+                                ],
+                                "timestamps": [
+                                    1440723184822,
+                                    1440723214822,
+                                    1440723244822,
+                                    1440723274822,
+                                    1440723304822,
+                                    1440723334822,
+                                    1440723334898
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19343f6858f0a02a4a52d"
-                                }, 
+                                    "$oid": "5f3d68f06fdd485ce81b5dba"
+                                },
+                                "start_ts": 1440723184.822,
                                 "start_local_dt": {
-                                    "hour": 17, 
-                                    "month": 8, 
-                                    "second": 4, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 53
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 17,
+                                    "minute": 53,
+                                    "second": 4,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T17:53:04.822000-07:00",
+                                "end_ts": 1440723334.898,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 17,
+                                    "minute": 55,
+                                    "second": 34,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T17:55:34.898000-07:00",
+                                "duration": 150.07599997520447,
                                 "speeds": [
-                                    0.0, 
-                                    1.6331959621623624, 
-                                    1.1183978055205228, 
-                                    2.524173198382802, 
-                                    1.6100000840941289, 
-                                    0.16927069616043228, 
+                                    0.0,
+                                    1.6331959621623624,
+                                    1.1183978055205228,
+                                    2.524173198382802,
+                                    1.6100000840941289,
+                                    0.16927069616043228,
                                     0.1665698203506692
-                                ], 
-                                "distance": 211.66379169182392
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    48.995878864870875,
+                                    33.551934165615684,
+                                    75.72519595148405,
+                                    48.30000252282387,
+                                    5.078120884812968,
+                                    0.01265930221646351
+                                ],
+                                "distance": 211.66379169182392,
+                                "sensed_mode": "MotionTypes.ON_FOOT",
+                                "start_stop": {
+                                    "$oid": "5f3d68f16fdd485ce81b5e38"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f16fdd485ce81b5e2e"
                         }
                     ]
                 }
-            ], 
-            "type": "FeatureCollection", 
-            "id": "57e19343f6858f0a02a4a52d", 
+            ],
+            "id": "5f3d68f06fdd485ce81b5dba"
+        },
+        {
+            "type": "FeatureCollection",
             "properties": {
-                "distance": 37830.496342360595, 
-                "end_place": {
-                    "$oid": "57e19346f6858f0a02a4a5d1"
-                }, 
-                "raw_trip": {
-                    "$oid": "57e1933df6858f0a02a4a324"
-                }, 
-                "feature_type": "trip", 
-                "start_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.3871046, 
-                        37.5993148
-                    ]
-                }, 
-                "end_ts": 1440723334.898, 
-                "start_ts": 1440719879.47, 
-                "start_fmt_time": "2015-08-27T16:57:59.470000-07:00", 
+                "source": "DwellSegmentationTimeFilter",
+                "end_ts": 1440729142.709,
+                "end_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 32,
+                    "second": 22,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "end_fmt_time": "2015-08-27T19:32:22.709000-07:00",
                 "end_loc": {
-                    "type": "Point", 
+                    "type": "Point",
                     "coordinates": [
-                        -122.083702, 
+                        -122.0862609,
+                        37.3909709
+                    ]
+                },
+                "raw_trip": {
+                    "$oid": "5f3d68ed6fdd485ce81b5bb3"
+                },
+                "start_ts": 1440728457.4895606,
+                "start_local_dt": {
+                    "year": 2015,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 19,
+                    "minute": 20,
+                    "second": 57,
+                    "weekday": 3,
+                    "timezone": "America/Los_Angeles"
+                },
+                "start_fmt_time": "2015-08-27T19:20:57.489561-07:00",
+                "start_loc": {
+                    "type": "Point",
+                    "coordinates": [
+                        -122.083702,
                         37.4036219
                     ]
-                }, 
-                "source": "DwellSegmentationTimeFilter", 
+                },
+                "duration": 685.2194395065308,
+                "distance": 2031.5499213533446,
                 "start_place": {
-                    "$oid": "57e19346f6858f0a02a4a5d0"
-                }, 
-                "end_fmt_time": "2015-08-27T17:55:34.898000-07:00", 
-                "end_local_dt": {
-                    "hour": 17, 
-                    "month": 8, 
-                    "second": 34, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 55
-                }, 
-                "duration": 3455.427999973297, 
-                "start_local_dt": {
-                    "hour": 16, 
-                    "month": 8, 
-                    "second": 59, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 57
-                }
-            }
-        }, 
-        {
+                    "$oid": "5f3d68f16fdd485ce81b5e5e"
+                },
+                "end_place": {
+                    "$oid": "5f3d68f16fdd485ce81b5e5f"
+                },
+                "feature_type": "trip"
+            },
             "features": [
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.083702, 
+                            -122.083702,
                             37.4036219
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19346f6858f0a02a4a5d1", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T17:55:34.898000-07:00", 
-                        "exit_local_dt": {
-                            "hour": 19, 
-                            "month": 8, 
-                            "second": 57, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 20
-                        }, 
-                        "display_name": "San Pierre Way, Mountain View", 
-                        "feature_type": "start_place", 
-                        "exit_fmt_time": "2015-08-27T19:20:57.489561-07:00", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440723334.898,
                         "enter_local_dt": {
-                            "hour": 17, 
-                            "month": 8, 
-                            "second": 34, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 17,
+                            "month": 8,
+                            "second": 34,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 55
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19343f6858f0a02a4a52d"
-                        }, 
-                        "starting_trip": {
-                            "$oid": "57e19344f6858f0a02a4a5ac"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440723334.898, 
-                        "duration": 5122.591560602188, 
+                        },
+                        "enter_fmt_time": "2015-08-27T17:55:34.898000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a325"
-                            }, 
+                                "$oid": "5f3d68ec6fdd485ce81b5bb2"
+                            },
                             {
-                                "$oid": "57e1933df6858f0a02a4a325"
+                                "$oid": "5f3d68ec6fdd485ce81b5bb2"
                             }
-                        ], 
-                        "exit_ts": 1440728457.4895606
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68f06fdd485ce81b5dba"
+                        },
+                        "starting_trip": {
+                            "$oid": "5f3d68f16fdd485ce81b5e39"
+                        },
+                        "exit_ts": 1440728457.4895606,
+                        "exit_fmt_time": "2015-08-27T19:20:57.489561-07:00",
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 19,
+                            "minute": 20,
+                            "second": 57,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "duration": 5122.591560602188,
+                        "feature_type": "start_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5e"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "Point", 
+                        "type": "Point",
                         "coordinates": [
-                            -122.0862609, 
+                            -122.0862609,
                             37.3909709
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19347f6858f0a02a4a5d2", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T19:32:22.709000-07:00", 
-                        "display_name": "South Shoreline Boulevard, Mountain View", 
-                        "feature_type": "end_place", 
+                        "source": "DwellSegmentationTimeFilter",
+                        "enter_ts": 1440729142.709,
                         "enter_local_dt": {
-                            "hour": 19, 
-                            "month": 8, 
-                            "second": 22, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
+                            "hour": 19,
+                            "month": 8,
+                            "second": 22,
+                            "weekday": 3,
+                            "year": 2015,
+                            "timezone": "America/Los_Angeles",
+                            "day": 27,
                             "minute": 32
-                        }, 
-                        "ending_trip": {
-                            "$oid": "57e19344f6858f0a02a4a5ac"
-                        }, 
-                        "source": "DwellSegmentationTimeFilter", 
-                        "enter_ts": 1440729142.709, 
+                        },
+                        "enter_fmt_time": "2015-08-27T19:32:22.709000-07:00",
                         "raw_places": [
                             {
-                                "$oid": "57e1933df6858f0a02a4a327"
+                                "$oid": "5f3d68ed6fdd485ce81b5bb4"
                             }
-                        ]
-                    }
-                }, 
+                        ],
+                        "ending_trip": {
+                            "$oid": "5f3d68f16fdd485ce81b5e39"
+                        },
+                        "feature_type": "end_place"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e5f"
+                },
                 {
+                    "type": "Feature",
                     "geometry": {
-                        "type": "LineString", 
+                        "type": "LineString",
                         "coordinates": [
                             [
-                                -122.0809948, 
+                                -122.0809948,
                                 37.3983218
-                            ], 
+                            ],
                             [
-                                -122.0804791, 
+                                -122.0804791,
                                 37.3959724
                             ]
                         ]
-                    }, 
-                    "type": "Feature", 
-                    "id": "57e19344f6858f0a02a4a5c8", 
+                    },
                     "properties": {
-                        "enter_fmt_time": "2015-08-27T19:26:04.243000-07:00", 
-                        "distance": 265.18371053989694, 
-                        "exit_local_dt": {
-                            "hour": 19, 
-                            "month": 8, 
-                            "second": 4, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 27
-                        }, 
-                        "feature_type": "stop", 
+                        "trip_id": {
+                            "$oid": "5f3d68f16fdd485ce81b5e39"
+                        },
+                        "source": "SmoothedHighConfidenceMotion",
                         "ending_section": {
-                            "$oid": "57e19344f6858f0a02a4a5ae"
-                        }, 
+                            "$oid": "5f3d68f16fdd485ce81b5e3b"
+                        },
                         "starting_section": {
-                            "$oid": "57e19344f6858f0a02a4a5bb"
-                        }, 
-                        "exit_fmt_time": "2015-08-27T19:27:04.315000-07:00", 
+                            "$oid": "5f3d68f16fdd485ce81b5e48"
+                        },
+                        "enter_ts": 1440728764.243,
                         "enter_local_dt": {
-                            "hour": 19, 
-                            "month": 8, 
-                            "second": 4, 
-                            "weekday": 3, 
-                            "year": 2015, 
-                            "timezone": "America/Los_Angeles", 
-                            "day": 27, 
-                            "minute": 26
-                        }, 
-                        "exit_loc": {
-                            "type": "Point", 
-                            "coordinates": [
-                                -122.0804791, 
-                                37.3959724
-                            ]
-                        }, 
-                        "source": "SmoothedHighConfidenceMotion", 
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 19,
+                            "minute": 26,
+                            "second": 4,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "enter_fmt_time": "2015-08-27T19:26:04.243000-07:00",
                         "enter_loc": {
-                            "type": "Point", 
+                            "type": "Point",
                             "coordinates": [
-                                -122.0809948, 
+                                -122.0809948,
                                 37.3983218
                             ]
-                        }, 
-                        "enter_ts": 1440728764.243, 
-                        "duration": 60.07200002670288, 
-                        "trip_id": {
-                            "$oid": "57e19344f6858f0a02a4a5ac"
-                        }, 
-                        "exit_ts": 1440728824.315
-                    }
-                }, 
+                        },
+                        "exit_ts": 1440728824.315,
+                        "exit_local_dt": {
+                            "year": 2015,
+                            "month": 8,
+                            "day": 27,
+                            "hour": 19,
+                            "minute": 27,
+                            "second": 4,
+                            "weekday": 3,
+                            "timezone": "America/Los_Angeles"
+                        },
+                        "exit_fmt_time": "2015-08-27T19:27:04.315000-07:00",
+                        "exit_loc": {
+                            "type": "Point",
+                            "coordinates": [
+                                -122.0804791,
+                                37.3959724
+                            ]
+                        },
+                        "duration": 60.07200002670288,
+                        "distance": 265.18371053989694,
+                        "feature_type": "stop"
+                    },
+                    "id": "5f3d68f16fdd485ce81b5e55"
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.083702, 
+                                        -122.083702,
                                         37.4036219
-                                    ], 
+                                    ],
                                     [
-                                        -122.08273844985416, 
+                                        -122.08273844985416,
                                         37.40313167441753
-                                    ], 
+                                    ],
                                     [
-                                        -122.08177489970832, 
+                                        -122.08177489970832,
                                         37.40264144883506
-                                    ], 
+                                    ],
                                     [
-                                        -122.0806588640881, 
+                                        -122.0806588640881,
                                         37.40246888114724
-                                    ], 
+                                    ],
                                     [
-                                        -122.07898114757866, 
+                                        -122.07898114757866,
                                         37.401735732462
-                                    ], 
+                                    ],
                                     [
-                                        -122.07909137037572, 
+                                        -122.07909137037572,
                                         37.40150852020396
-                                    ], 
+                                    ],
                                     [
-                                        -122.07983976386248, 
+                                        -122.07983976386248,
                                         37.40087926137392
-                                    ], 
+                                    ],
                                     [
-                                        -122.08053605634629, 
+                                        -122.08053605634629,
                                         37.40009438469056
-                                    ], 
+                                    ],
                                     [
-                                        -122.08079945913543, 
+                                        -122.08079945913543,
                                         37.399595407169855
-                                    ], 
+                                    ],
                                     [
-                                        -122.08074303273789, 
+                                        -122.08074303273789,
                                         37.3994688449539
-                                    ], 
+                                    ],
                                     [
-                                        -122.08093229775706, 
+                                        -122.08093229775706,
                                         37.39857793311084
-                                    ], 
+                                    ],
                                     [
-                                        -122.0809948, 
+                                        -122.0809948,
                                         37.3983218
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19344f6858f0a02a4a5ae", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    101.07091358618317, 
-                                    101.07138248848558, 
-                                    100.43165674253225, 
-                                    169.13950522805024, 
-                                    27.075973190565765, 
-                                    96.26083563933489, 
-                                    106.77010424126591, 
-                                    60.1650604496929, 
-                                    14.929709242816415, 
-                                    100.46577596571488, 
-                                    29.01093805860777
-                                ], 
-                                "end_ts": 1440728764.243, 
-                                "feature_type": "section", 
-                                "distance": 906.3918548332498, 
-                                "sensed_mode": "MotionTypes.IN_VEHICLE", 
-                                "start_ts": 1440728457.4895606, 
-                                "start_fmt_time": "2015-08-27T19:20:57.489561-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T19:26:04.243000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 19, 
-                                    "month": 8, 
-                                    "second": 4, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 26
-                                }, 
-                                "duration": 306.7534394264221, 
-                                "end_stop": {
-                                    "$oid": "57e19344f6858f0a02a4a5c8"
-                                }, 
+                                "times": [
+                                    1440728457.4895606,
+                                    1440728487.4895606,
+                                    1440728517.4895606,
+                                    1440728547.4895606,
+                                    1440728577.4895606,
+                                    1440728607.4895606,
+                                    1440728637.4895606,
+                                    1440728667.4895606,
+                                    1440728697.4895606,
+                                    1440728727.4895606,
+                                    1440728757.4895606,
+                                    1440728764.243
+                                ],
+                                "timestamps": [
+                                    1440728457490,
+                                    1440728487490,
+                                    1440728517490,
+                                    1440728547490,
+                                    1440728577490,
+                                    1440728607490,
+                                    1440728637490,
+                                    1440728667490,
+                                    1440728697490,
+                                    1440728727490,
+                                    1440728757490,
+                                    1440728764243
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19344f6858f0a02a4a5ac"
-                                }, 
+                                    "$oid": "5f3d68f16fdd485ce81b5e39"
+                                },
+                                "start_ts": 1440728457.4895606,
                                 "start_local_dt": {
-                                    "hour": 19, 
-                                    "month": 8, 
-                                    "second": 57, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 20
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 19,
+                                    "minute": 20,
+                                    "second": 57,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T19:20:57.489561-07:00",
+                                "end_ts": 1440728764.243,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 19,
+                                    "minute": 26,
+                                    "second": 4,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T19:26:04.243000-07:00",
+                                "duration": 306.7534394264221,
                                 "speeds": [
-                                    0.0, 
-                                    3.369030452872772, 
-                                    3.3690460829495192, 
-                                    3.347721891417742, 
-                                    5.637983507601675, 
-                                    0.9025324396855255, 
-                                    3.208694521311163, 
-                                    3.559003474708864, 
-                                    2.0055020149897635, 
-                                    0.49765697476054715, 
-                                    3.3488591988571628, 
+                                    0.0,
+                                    3.369030452872772,
+                                    3.3690460829495192,
+                                    3.347721891417742,
+                                    5.637983507601675,
+                                    0.9025324396855255,
+                                    3.208694521311163,
+                                    3.559003474708864,
+                                    2.0055020149897635,
+                                    0.49765697476054715,
+                                    3.3488591988571628,
                                     4.295727884240072
-                                ]
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    101.07091358618317,
+                                    101.07138248848558,
+                                    100.43165674253225,
+                                    169.13950522805024,
+                                    27.075973190565765,
+                                    96.26083563933489,
+                                    106.77010424126591,
+                                    60.1650604496929,
+                                    14.929709242816415,
+                                    100.46577596571488,
+                                    29.01093805860777
+                                ],
+                                "distance": 906.3918548332498,
+                                "sensed_mode": "MotionTypes.IN_VEHICLE",
+                                "end_stop": {
+                                    "$oid": "5f3d68f16fdd485ce81b5e55"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f16fdd485ce81b5e3b"
                         }
                     ]
-                }, 
+                },
                 {
-                    "type": "FeatureCollection", 
+                    "type": "FeatureCollection",
                     "features": [
                         {
+                            "type": "Feature",
                             "geometry": {
-                                "type": "LineString", 
+                                "type": "LineString",
                                 "coordinates": [
                                     [
-                                        -122.0804791, 
+                                        -122.0804791,
                                         37.3959724
-                                    ], 
+                                    ],
                                     [
-                                        -122.08297204509547, 
+                                        -122.08297204509547,
                                         37.3959456445923
-                                    ], 
+                                    ],
                                     [
-                                        -122.08297270839385, 
+                                        -122.08297270839385,
                                         37.39598051606153
-                                    ], 
+                                    ],
                                     [
-                                        -122.0836783940137, 
+                                        -122.0836783940137,
                                         37.39483405888615
-                                    ], 
+                                    ],
                                     [
-                                        -122.08441549613816, 
+                                        -122.08441549613816,
                                         37.39375391129058
-                                    ], 
+                                    ],
                                     [
-                                        -122.08488551380876, 
+                                        -122.08488551380876,
                                         37.393052509223544
-                                    ], 
+                                    ],
                                     [
-                                        -122.08547548499102, 
+                                        -122.08547548499102,
                                         37.3920663815419
-                                    ], 
+                                    ],
                                     [
-                                        -122.08607344217683, 
+                                        -122.08607344217683,
                                         37.39113822877281
-                                    ], 
+                                    ],
                                     [
-                                        -122.08622899782469, 
+                                        -122.08622899782469,
                                         37.39095885504853
-                                    ], 
+                                    ],
                                     [
-                                        -122.08622857893772, 
+                                        -122.08622857893772,
                                         37.39099206421023
-                                    ], 
+                                    ],
                                     [
-                                        -122.08626055360769, 
+                                        -122.08626055360769,
                                         37.39097112682174
-                                    ], 
+                                    ],
                                     [
-                                        -122.0862609, 
+                                        -122.0862609,
                                         37.3909709
                                     ]
                                 ]
-                            }, 
-                            "type": "Feature", 
-                            "id": "57e19344f6858f0a02a4a5bb", 
+                            },
                             "properties": {
-                                "distances": [
-                                    0.0, 
-                                    220.24596296887037, 
-                                    3.877973172190887, 
-                                    141.90680484160671, 
-                                    136.62309664044253, 
-                                    88.356854647153, 
-                                    121.40907514813513, 
-                                    115.93998950371376, 
-                                    24.221494143581648, 
-                                    3.6928757286553218, 
-                                    3.660572969430462, 
-                                    0.03965621641830557
-                                ], 
-                                "feature_type": "section", 
-                                "sensed_mode": "MotionTypes.BICYCLING", 
-                                "end_ts": 1440729142.709, 
-                                "start_ts": 1440728824.315, 
-                                "start_fmt_time": "2015-08-27T19:27:04.315000-07:00", 
-                                "source": "SmoothedHighConfidenceMotion", 
-                                "end_fmt_time": "2015-08-27T19:32:22.709000-07:00", 
-                                "end_local_dt": {
-                                    "hour": 19, 
-                                    "month": 8, 
-                                    "second": 22, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 32
-                                }, 
-                                "duration": 318.39400005340576, 
-                                "start_stop": {
-                                    "$oid": "57e19344f6858f0a02a4a5c8"
-                                }, 
+                                "times": [
+                                    1440728824.315,
+                                    1440728854.315,
+                                    1440728884.315,
+                                    1440728914.315,
+                                    1440728944.315,
+                                    1440728974.315,
+                                    1440729004.315,
+                                    1440729034.315,
+                                    1440729064.315,
+                                    1440729094.315,
+                                    1440729124.315,
+                                    1440729142.709
+                                ],
+                                "timestamps": [
+                                    1440728824315,
+                                    1440728854315,
+                                    1440728884315,
+                                    1440728914315,
+                                    1440728944315,
+                                    1440728974315,
+                                    1440729004315,
+                                    1440729034315,
+                                    1440729064315,
+                                    1440729094315,
+                                    1440729124315,
+                                    1440729142709
+                                ],
+                                "source": "SmoothedHighConfidenceMotion",
                                 "trip_id": {
-                                    "$oid": "57e19344f6858f0a02a4a5ac"
-                                }, 
+                                    "$oid": "5f3d68f16fdd485ce81b5e39"
+                                },
+                                "start_ts": 1440728824.315,
                                 "start_local_dt": {
-                                    "hour": 19, 
-                                    "month": 8, 
-                                    "second": 4, 
-                                    "weekday": 3, 
-                                    "year": 2015, 
-                                    "timezone": "America/Los_Angeles", 
-                                    "day": 27, 
-                                    "minute": 27
-                                }, 
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 19,
+                                    "minute": 27,
+                                    "second": 4,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "start_fmt_time": "2015-08-27T19:27:04.315000-07:00",
+                                "end_ts": 1440729142.709,
+                                "end_local_dt": {
+                                    "year": 2015,
+                                    "month": 8,
+                                    "day": 27,
+                                    "hour": 19,
+                                    "minute": 32,
+                                    "second": 22,
+                                    "weekday": 3,
+                                    "timezone": "America/Los_Angeles"
+                                },
+                                "end_fmt_time": "2015-08-27T19:32:22.709000-07:00",
+                                "duration": 318.39400005340576,
                                 "speeds": [
-                                    0.0, 
-                                    7.341532098962346, 
-                                    0.12926577240636292, 
-                                    4.730226828053557, 
-                                    4.554103221348084, 
-                                    2.9452284882384334, 
-                                    4.046969171604505, 
-                                    3.864666316790459, 
-                                    0.8073831381193882, 
-                                    0.12309585762184407, 
-                                    0.1220190989810154, 
+                                    0.0,
+                                    7.341532098962346,
+                                    0.12926577240636292,
+                                    4.730226828053557,
+                                    4.554103221348084,
+                                    2.9452284882384334,
+                                    4.046969171604505,
+                                    3.864666316790459,
+                                    0.8073831381193882,
+                                    0.12309585762184407,
+                                    0.1220190989810154,
                                     0.0021559321682704346
-                                ], 
-                                "distance": 859.974355980198
-                            }
+                                ],
+                                "distances": [
+                                    0.0,
+                                    220.24596296887037,
+                                    3.877973172190887,
+                                    141.90680484160671,
+                                    136.62309664044253,
+                                    88.356854647153,
+                                    121.40907514813513,
+                                    115.93998950371376,
+                                    24.221494143581648,
+                                    3.6928757286553218,
+                                    3.660572969430462,
+                                    0.03965621641830557
+                                ],
+                                "distance": 859.974355980198,
+                                "sensed_mode": "MotionTypes.BICYCLING",
+                                "start_stop": {
+                                    "$oid": "5f3d68f16fdd485ce81b5e55"
+                                },
+                                "feature_type": "section"
+                            },
+                            "id": "5f3d68f16fdd485ce81b5e48"
                         }
                     ]
                 }
-            ], 
-            "type": "FeatureCollection", 
-            "id": "57e19344f6858f0a02a4a5ac", 
-            "properties": {
-                "distance": 2031.5499213533446, 
-                "end_place": {
-                    "$oid": "57e19347f6858f0a02a4a5d2"
-                }, 
-                "raw_trip": {
-                    "$oid": "57e1933df6858f0a02a4a326"
-                }, 
-                "feature_type": "trip", 
-                "start_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.083702, 
-                        37.4036219
-                    ]
-                }, 
-                "end_ts": 1440729142.709, 
-                "start_ts": 1440728457.4895606, 
-                "start_fmt_time": "2015-08-27T19:20:57.489561-07:00", 
-                "end_loc": {
-                    "type": "Point", 
-                    "coordinates": [
-                        -122.0862609, 
-                        37.3909709
-                    ]
-                }, 
-                "source": "DwellSegmentationTimeFilter", 
-                "start_place": {
-                    "$oid": "57e19346f6858f0a02a4a5d1"
-                }, 
-                "end_fmt_time": "2015-08-27T19:32:22.709000-07:00", 
-                "end_local_dt": {
-                    "hour": 19, 
-                    "month": 8, 
-                    "second": 22, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 32
-                }, 
-                "duration": 685.2194395065308, 
-                "start_local_dt": {
-                    "hour": 19, 
-                    "month": 8, 
-                    "second": 57, 
-                    "weekday": 3, 
-                    "year": 2015, 
-                    "timezone": "America/Los_Angeles", 
-                    "day": 27, 
-                    "minute": 20
-                }
-            }
+            ],
+            "id": "5f3d68f16fdd485ce81b5e39"
         }
-    ], 
-    "_id": {
-        "$oid": "57e19347115514afcd793e92"
-    }, 
-    "user_id": {
-        "$uuid": "4ba23960c1814795b42ba31f05e4f9ad"
-    }, 
+    ],
     "metadata": {
-        "type": "document", 
-        "key": "diary/trips-2015-08-27", 
-        "write_ts": 1474401095.901493
+        "key": "diary/trips-2015-08-27",
+        "type": "document",
+        "write_ts": 1597860083
     }
 }


### PR DESCRIPTION
After updating the ground truth so that it passes. It was originally disabled in
https://github.com/e-mission/e-mission-server/commit/66954ad9765fe89dbab54fb4099d2997fb3f75d6
because it was giving different results.

But it is reused in the section segmentation code, so let's enable it again so
we know what is going on.