### PR TITLE
Fix motion activity formatter

### DIFF
--- a/emission/net/usercache/formatters/android/motion_activity.py
+++ b/emission/net/usercache/formatters/android/motion_activity.py
@@ -23,8 +23,12 @@ def format(entry):
     formatted_entry.metadata = metadata
 
     #logging.info('*** Motion Data write_ts: %d' % metadata.write_ts)
-    
-    data = ad.AttrDict()
+   
+    if 'ts' not in entry.data:
+        # old style entries
+        data = ad.AttrDict()
+    else:
+        data = entry.data
 
     if 'agb' in entry.data:
         data.type = ecwa.MotionTypes(entry.data.agb).value


### PR DESCRIPTION
Before
https://github.com/e-mission/e-mission-data-collection/commit/944c091ecab7b91740d80c3693d48731b6581bac,
we used to create a new data object so the incomprehensible fields such as
`zzbxC` would not show up in the formatted data.

We now have comprehensible fields, so we don't have to set them any more. But
in that case, we need to retain the incoming data object and not create a new one!

Testing done:

- Generated some more motion activity points.
- Ran the pipeline and ensured that the resulting points were formatted correctly

```
{'_id': ObjectId('5f50092a6b07dd3c2be754e5'),
  'user_id': UUID('9ded2249-895e-419f-879d-39d27b3ea961'),
  'metadata': {'key': 'background/motion_activity',
   'platform': 'android',
   'read_ts': 0,
   'time_zone': 'America/Los_Angeles',
   'type': 'sensor-data',
   'write_ts': 1599080698.738,
   'write_local_dt': { },
   'write_fmt_time': '2020-09-02T14:04:58.738000-07:00'},
  'data': {'confidence': 100,
   'ts': 1599080698.737,
   'type': 3,
   'local_dt': { },
   'fmt_time': '2020-09-02T14:04:58.738000-07:00'}},
```