### PR TITLE
Add a configurable result limit

### DIFF
--- a/conf/storage/db.conf.sample
+++ b/conf/storage/db.conf.sample
@@ -1,5 +1,6 @@
 {
     "timeseries": {
-        "url": "localhost"
+        "url": "localhost",
+        "result_limit": 250000
     }
 }

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -18,6 +18,7 @@ except:
 
 config_data = json.load(config_file)
 url = config_data["timeseries"]["url"]
+result_limit = config_data["timeseries"]["result_limit"]
 config_file.close()
 
 print("Connecting to database URL "+url)

--- a/emission/net/usercache/builtin_usercache.py
+++ b/emission/net/usercache/builtin_usercache.py
@@ -132,7 +132,7 @@ class BuiltinUserCache(ucauc.UserCache):
         # the write timestamp, because we use the last_ts_processed to mark the
         # beginning of the entry for the next query. So let's sort by the
         # write_ts before returning.
-        retrievedMsgs = list(self.db.find(combo_query).sort("metadata.write_ts", pymongo.ASCENDING).limit(100000))
+        retrievedMsgs = list(self.db.find(combo_query).sort("metadata.write_ts", pymongo.ASCENDING).limit(edb.result_limit))
         logging.debug("Found %d messages in response to query %s" % (len(retrievedMsgs), combo_query))
         return retrievedMsgs
 

--- a/emission/net/usercache/builtin_usercache.py
+++ b/emission/net/usercache/builtin_usercache.py
@@ -12,7 +12,7 @@ import pymongo
 
 # Our imports
 import emission.net.usercache.abstract_usercache as ucauc # ucauc = usercache.abstract_usercache
-from emission.core.get_database import get_usercache_db
+import emission.core.get_database as edb
 
 """
 Format of the usercache_db.
@@ -63,7 +63,7 @@ class BuiltinUserCache(ucauc.UserCache):
         self.key_query = lambda key: {"metadata.key": key};
         self.ts_query = lambda tq: BuiltinUserCache._get_ts_query(tq)
         self.type_query = lambda entry_type: {"metadata.type": entry_type}
-        self.db = get_usercache_db()
+        self.db = edb.get_usercache_db()
 
     @staticmethod
     def _get_ts_query(tq):
@@ -71,7 +71,7 @@ class BuiltinUserCache(ucauc.UserCache):
 
     @staticmethod
     def get_uuid_list():
-        return get_usercache_db().distinct("user_id")
+        return edb.get_usercache_db().distinct("user_id")
 
     def putDocument(self, key, value):
         """

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -227,7 +227,7 @@ class BuiltinTimeSeries(esta.TimeSeries):
             #
             # In [593]: edb.get_timeseries_db().find({"user_id": UUID('ea59084e-11d4-4076-9252-3b9a29ce35e0')}).count()
             # Out[593]: 449869
-            ts_db_result.limit(25 * 10000)
+            ts_db_result.limit(edb.result_limit)
         else:
             ts_db_result = tsdb.find(INVALID_QUERY)
             ts_db_count = 0


### PR DESCRIPTION
Before this, we returned hardcoded limits (100k for the usercache and 250k for
the timeseries) by default. However, when switching to the DFKI server, we
frequently got errors of the form "JSONDecodeError error Unterminated string".
It looks like some networking stack was truncating messages, which led to
malformed results.

Even worse, the data retrieval would periodically hang on the client. I assume
this was because of overload/overflowing buffers somewhere in the middle.

Reducing the retrieval limit fixed the problem. Let's make the retrieval limit
configurable so that it is easier to customize this in the future.