### PR TITLE
Support language-specific surveys

### DIFF
--- a/emission/net/ext_service/push/query/language.py
+++ b/emission/net/ext_service/push/query/language.py
@@ -1,0 +1,21 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+# Input spec sample at
+# emission/net/ext_service/push/sample.specs/platform.query.sample
+
+# Input: query spec
+# Output: list of uuids
+# 
+
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+import logging
+
+import emission.net.ext_service.push.notify_queries as pnq
+
+def query(spec):
+  userid_list = pnq.get_matching_user_ids(spec)
+  return userid_list

--- a/emission/net/ext_service/push/sample.specs/query/language.query.sample
+++ b/emission/net/ext_service/push/sample.specs/query/language.query.sample
@@ -1,0 +1,6 @@
+{
+    "query_type": "language",
+    "spec": {
+        "phone_lang": "en"
+    }
+}


### PR DESCRIPTION
The entire survey spec can be tailored to a particular language, so we can support both separate prompts and separate surveys with slightly different questions.

Testing done:
The code gets to the interface and then fails because there is no `push_config`. But the query selection clearly works. We could test further on production where there is in fact a push_config defined.

```
$ ./e-mission-py.bash bin/push/send_survey.py -q emission/net/ext_service/push/sample.specs/query/language.query.sample -- emission/net/ext_service/push/sample.specs/push/gforms.demographics.survey.sample
storage not configured, falling back to sample, default configuration
Connecting to database URL localhost
WARNING:root:push service not configured, push notifications not supported
Traceback (most recent call last):
  File "bin/push/send_survey.py", line 69, in <module>
    dev = args.dev)
  File "/Users/kshankar/e-mission/e-mission-server/emission/net/ext_service/push/notify_usage.py", line 28, in send_visible_notification_to_users
    return __get_default_interface__().send_visible_notification(token_map, title, message, json_data, dev)
  File "/Users/kshankar/e-mission/e-mission-server/emission/net/ext_service/push/notify_usage.py", line 20, in __get_default_interface__
    interface_obj = pni.NotifyInterfaceFactory.getDefaultNotifyInterface()
  File "/Users/kshankar/e-mission/e-mission-server/emission/net/ext_service/push/notify_interface.py", line 29, in getDefaultNotifyInterface
    return NotifyInterfaceFactory.getNotifyInterface(push_config["provider"])
NameError: name 'push_config' is not defined
```