### PR TITLE
Refactor to pull out the visualization code

### DIFF
--- a/emission/analysis/modelling/tour_model/similarity.py
+++ b/emission/analysis/modelling/tour_model/similarity.py
@@ -77,8 +77,7 @@ class similarity(object):
                 self.bins.append([a])
         self.bins.sort(key=lambda bin: len(bin), reverse=True)
 
-    #delete lower portion of bins
-    def delete_bins(self):
+    def calc_cutoff_bins(self):
         if len(self.bins) <= 1:
             self.newdata = self.data
             return
@@ -93,7 +92,10 @@ class similarity(object):
         logging.debug('the new number of trips is %d' % sum)
         logging.debug('the cutoff point is %d' % num)
         self.num = num
-        #self.graph()
+
+    #delete lower portion of bins
+    def delete_bins(self):
+        self.calc_cutoff_bins()
         for i in range(len(self.bins) - num):
             self.bins.pop()
         newdata = []
@@ -141,27 +143,6 @@ class similarity(object):
             if not self.distance_helper(a, b):
                 return False
         return True
-
-    #create the histogram
-    def graph(self):
-        import matplotlib
-        matplotlib.use('Agg')
-        import matplotlib.pyplot as plt
-        bars = [0] * len(self.bins)
-        for i in range(len(self.bins)):
-            bars[i] = len(self.bins[i])
-        N = len(bars)
-        index = numpy.arange(N)
-        width = .2
-        plt.bar(index+width, bars, color='k')
-        try:
-            plt.bar(self.num+width, bars[self.num], color='g')
-        except Exception:
-            pass
-        plt.xlim([0, N])
-        plt.xlabel('Bins')
-        plt.ylabel('Number of elements')
-        plt.savefig('histogram.png')
 
     #evaluate the bins as if they were a clustering on the data
     def evaluate_bins(self):


### PR DESCRIPTION
Pull out the visualization code so it can be run in a notebook
New code is here:
https://github.com/e-mission/e-mission-eval-private-data/pull/14

Required a minor refactor since the prior call to graph was in the middle of
`delete_bins` - after the cutoff and before the remove.

We clearly don't want to generate graphs for this as part of a production
system. So it is correct to remove the `graph()` call.

To access the state of the object between the cutoff and the remove, we pull
out the cutoff into a separate function