### PR TITLE
Minor clarifications to the clustering code

### DIFF
--- a/emission/analysis/modelling/tour_model/cluster_pipeline.py
+++ b/emission/analysis/modelling/tour_model/cluster_pipeline.py
@@ -58,12 +58,13 @@ def remove_noise(data, radius):
     return sim.newdata, sim.bins
 
 #cluster the data using k-means
-def cluster(data, bins):
+def cluster(data, nBins):
+    logging.debug("Calling cluster(%s, %d)" % (data, nBins))
     if not data:
         return 0, [], []
     feat = featurization.featurization(data)
-    min = bins
-    max = int(math.ceil(1.5 * bins))
+    min = nBins
+    max = int(math.ceil(1.5 * nBins))
     feat.cluster(min_clusters=min, max_clusters=max)
     logging.debug('number of clusters: %d' % feat.clusters)
     return feat.clusters, feat.labels, feat.data
@@ -89,6 +90,8 @@ def main(uuid=None):
     return tour_dict
 
 if __name__=='__main__':
+    logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
+        level=logging.DEBUG)
     uuid = None
     if len(sys.argv) == 2:
         uuid = sys.argv[1]


### PR DESCRIPTION
+ rename the `bins` paramter to `nBins` to clarify that it is a number
+ add additional logging to print the inputs to the clustering function
+ Set the logging level so that we can see the new output

Testing done:

```
$ ./e-mission-py.bash emission/analysis/modelling/tour_model/cluster_pipeline.py 2>&1 | tee /tmp/cluster_pipeline.logs
$ grep "Calling cluster" /tmp/cluster_pipeline.logs | less
2021-02-02 15:32:58,995:DEBUG:Calling cluster([Entry({'_id': ObjectId('5fb8947f9eb497c598fba90b'),....'start_place': ObjectId('600f99c1c9b5acbf75cb16ea'), 'end_place': ObjectId('600f99c1c9b5acbf75cb16eb')}})], 104)
```