### PR TITLE
Server side changes to support infinite scroll

### DIFF
--- a/emission/net/api/pipeline.py
+++ b/emission/net/api/pipeline.py
@@ -21,13 +21,20 @@ def get_range(user_id):
     start_ts = ts.get_first_value_for_field("analysis/confirmed_trip", "data.start_ts", pymongo.ASCENDING)
     if start_ts == -1:
         start_ts = ts.get_first_value_for_field("analysis/cleaned_trip", "data.start_ts", pymongo.ASCENDING)
+    if start_ts == -1:
+        start_ts = None
 
     end_ts = ts.get_first_value_for_field("analysis/confirmed_trip", "data.end_ts", pymongo.DESCENDING)
     if end_ts == -1:
         end_ts = ts.get_first_value_for_field("analysis/cleaned_trip", "data.end_ts", pymongo.DESCENDING)
+    if end_ts == -1:
+        end_ts = None
 
     complete_ts = get_complete_ts(user_id)
-    if (end_ts != (complete_ts - esp.END_FUZZ_AVOID_LTE)):
-        logging.exception("end_ts %s != complete_ts no fuzz %s" % (end_ts, (complete_ts - esp.END_FUZZ_AVOID_LTE)))
+    if complete_ts is not None and end_ts is not None\
+        and (end_ts != (complete_ts - esp.END_FUZZ_AVOID_LTE)):
+        logging.exception("end_ts %s != complete_ts no fuzz %s" %
+            (end_ts, (complete_ts - esp.END_FUZZ_AVOID_LTE)))
 
+    logging.debug("Returning range (%s, %s)" % (start_ts, end_ts))
     return (start_ts, end_ts)

--- a/emission/net/api/pipeline.py
+++ b/emission/net/api/pipeline.py
@@ -6,10 +6,28 @@ from future import standard_library
 standard_library.install_aliases()
 from builtins import *
 import logging
+import pymongo
 
 import emission.storage.pipeline_queries as esp
+import emission.storage.timeseries.abstract_timeseries as esta
 
 def get_complete_ts(user_id):
     complete_ts = esp.get_complete_ts(user_id)
     logging.debug("Returning complete_ts = %s" % complete_ts)
     return complete_ts
+
+def get_range(user_id):
+    ts = esta.TimeSeries.get_time_series(user_id)
+    start_ts = ts.get_first_value_for_field("analysis/confirmed_trip", "data.start_ts", pymongo.ASCENDING)
+    if start_ts == -1:
+        start_ts = ts.get_first_value_for_field("analysis/cleaned_trip", "data.start_ts", pymongo.ASCENDING)
+
+    end_ts = ts.get_first_value_for_field("analysis/confirmed_trip", "data.end_ts", pymongo.DESCENDING)
+    if end_ts == -1:
+        end_ts = ts.get_first_value_for_field("analysis/cleaned_trip", "data.end_ts", pymongo.DESCENDING)
+
+    complete_ts = get_complete_ts(user_id)
+    if (end_ts != (complete_ts - esp.END_FUZZ_AVOID_LTE)):
+        logging.exception("end_ts %s != complete_ts no fuzz %s" % (end_ts, (complete_ts - esp.END_FUZZ_AVOID_LTE)))
+
+    return (start_ts, end_ts)

--- a/emission/net/usercache/builtin_usercache_handler.py
+++ b/emission/net/usercache/builtin_usercache_handler.py
@@ -180,7 +180,7 @@ class BuiltinUserCacheHandler(enuah.UserCacheHandler):
         trip_gj_list = self.get_trip_list_for_seven_days(start_ts)
         if len(trip_gj_list) == 0:
             ts = etsa.TimeSeries.get_time_series(self.user_id)
-            max_loc_ts = ts.get_max_value_for_field("background/filtered_location", "data.ts")
+            max_loc_ts = ts.get_first_value_for_field("background/filtered_location", "data.ts", pymongo.DESCENDING)
             if max_loc_ts == -1:
                 logging.warning("No entries for user %s, early return " % self.user_id)
                 return

--- a/emission/storage/timeseries/abstract_timeseries.py
+++ b/emission/storage/timeseries/abstract_timeseries.py
@@ -61,13 +61,15 @@ class TimeSeries(object):
         """
         pass
 
-    def get_max_value_for_field(self, key, field):
+    def get_first_value_for_field(self, key, sort_order, field):
         """
         Currently used to get the max value of the location values so that we can send data
         that actually exists into the usercache. Is that too corner of a use case? Do we want to do
         this in some other way?
         :param key: the metadata key for the entries, used to identify the stream
         :param field: the field in the stream whose max value we want.
+        :param time_query: the time range in which to search the stream
+        :param sort_order: pymongo.ASCENDING or pymongon.DESCENDING
         It is assumed that the values for the field are sortable.
         :return: the max value for the field in the stream identified by key.  -1 if there are no entries for the key.
         """

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -290,7 +290,7 @@ class BuiltinTimeSeries(esta.TimeSeries):
         return deduped_df.reset_index(drop=True)
 
 
-    def get_max_value_for_field(self, key, field, time_query=None):
+    def get_first_value_for_field(self, key, field, sort_order, time_query=None):
         """
         Currently used to get the max value of the location values so that we can send data
         that actually exists into the usercache. Is that too corner of a use case? Do we want to do
@@ -298,11 +298,12 @@ class BuiltinTimeSeries(esta.TimeSeries):
         :param key: the metadata key for the entries, used to identify the stream
         :param field: the field in the stream whose max value we want.
         :param time_query: the time range in which to search the stream
+        :param sort_order: pymongo.ASCENDING or pymongon.DESCENDING
         It is assumed that the values for the field are sortable.
         :return: the max value for the field in the stream identified by key. -1 if there are no entries for the key.
         """
         result_it = self.get_timeseries_db(key).find(self._get_query([key], time_query),
-                                                 {"_id": False, field: True}).sort(field, pymongo.DESCENDING).limit(1)
+                                                 {"_id": False, field: True}).sort(field, sort_order).limit(1)
         result_list = list(result_it)
         if len(result_list) == 0:
             return -1

--- a/emission/storage/timeseries/non_user_timeseries.py
+++ b/emission/storage/timeseries/non_user_timeseries.py
@@ -43,7 +43,7 @@ class NonUserTimeSeries(bits.BuiltinTimeSeries):
     # get_entry_at_ts is unchanged
     # get_data_df is unchanged
     # to_data_df is unchanged
-    # get_max_value_for_field is unchanged
+    # get_first_value_for_field is unchanged
     # bulk_insert is unchanged
 
     def insert(self, entry):

--- a/emission/tests/netTests/TestPipeline.py
+++ b/emission/tests/netTests/TestPipeline.py
@@ -1,0 +1,42 @@
+import unittest
+import logging
+import arrow
+import os
+
+import emission.core.get_database as edb
+import emission.core.wrapper.localdate as ecwl
+import emission.tests.common as etc
+
+from emission.net.api import pipeline
+
+class TestPipeline(unittest.TestCase):
+    def setUp(self):
+        etc.setupRealExample(self,
+                             "emission/tests/data/real_examples/shankari_2015-aug-21")
+        self.testUUID1 = self.testUUID
+        etc.setupRealExample(self,
+                             "emission/tests/data/real_examples/shankari_2015-aug-27")
+  
+    def tearDown(self):
+        self.clearRelatedDb()
+
+    def clearRelatedDb(self):
+        edb.get_timeseries_db().delete_many({"user_id": self.testUUID})
+        edb.get_analysis_timeseries_db().delete_many({"user_id": self.testUUID})
+        edb.get_pipeline_state_db().delete_many({"user_id": self.testUUID})
+        edb.get_timeseries_db().delete_many({"user_id": self.testUUID1})
+        edb.get_analysis_timeseries_db().delete_many({"user_id": self.testUUID1})
+        edb.get_pipeline_state_db().delete_many({"user_id": self.testUUID1})
+
+    def testNoAnalysisResults(self):
+        self.assertEqual(pipeline.get_range(self.testUUID), (None, None))
+
+    def testAnalysisResults(self):
+        self.assertEqual(pipeline.get_range(self.testUUID), (None, None))
+        etc.runIntakePipeline(self.testUUID)
+        self.assertAlmostEqual(pipeline.get_range(self.testUUID), (1440688739.672, 1440729142.709))
+
+if __name__ == '__main__':
+    import emission.tests.common as etc
+    etc.configLogging()
+    unittest.main()

--- a/emission/tests/storageTests/TestTimeSeries.py
+++ b/emission/tests/storageTests/TestTimeSeries.py
@@ -10,6 +10,7 @@ import unittest
 import datetime as pydt
 import logging
 import json
+import pymongo
 
 # Our imports
 import emission.core.get_database as edb
@@ -56,7 +57,7 @@ class TestTimeSeries(unittest.TestCase):
 
     def testGetMaxValueForField(self):
         ts = esta.TimeSeries.get_time_series(self.testUUID)
-        self.assertEqual(ts.get_max_value_for_field("background/filtered_location", "data.ts"), 1440729334.797)
+        self.assertEqual(ts.get_first_value_for_field("background/filtered_location", "data.ts", pymongo.DESCENDING), 1440729334.797)
 
     def testGetDataDf(self):
         ts = esta.TimeSeries.get_time_series(self.testUUID)


### PR DESCRIPTION
+ support querying by other time keys instead of only `metadata.write_ts`. This
ensures that we can accurately query for analysed results as well, since they
can be generated at any time after the raw data is collected.
+ support returning both the max and min value of any data field
    - Change the existing call to get_max_value_for_field to use it
    - Add a new method to the API that gets the pipeline range, not just the last entry
+ use this to figure out when to properly stop the infinite scroll