### PR TITLE
Add CORS support

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -195,8 +195,11 @@ def getPipelineState():
     user_uuid = getUUID(request)
     return {"complete_ts": pipeline.get_complete_ts(user_uuid)}
 
-@post("/datastreams/find_entries/<time_type>")
+@post("/datastreams/find_entries/<time_type>", method=['OPTIONS', 'POST'])
 def getTimeseriesEntries(time_type):
+    print("method is ", request.method)
+    if request.method == "OPTIONS":
+        return
     if 'user' not in request.json:
         abort(401, "only a user can read his/her data")
 
@@ -410,6 +413,10 @@ def before_request():
 
 @app.hook('after_request')
 def after_request():
+  response.set_header('Access-Control-Allow-Origin', '*')
+  response.add_header('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS')
+  response.add_header('Access-Control-Allow-Headers', 'Origin, Accept, Content-Type, X-Requested-With')
+
   msTimeNow = time.time()
   request.params.timer.__exit__()
   duration = msTimeNow - request.params.start_ts


### PR DESCRIPTION
Since emevalzephyr calls the server directly using $http
Without this fix, we get an error

```
/#/root/main/eval:1 Access to XMLHttpRequest at 'http://exv-91200.sb.dfki.de:6638/datastreams/find_entries/timestamp' from origin 'http://localhost' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

Fix is based on https://stackoverflow.com/questions/17262170/bottle-py-enabling-cors-for-jquery-ajax-requests