### PR TITLE
Split the compound index into its constituent parts

### DIFF
--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -148,10 +148,9 @@ def get_perturbed_trips_db():
 def get_usercache_db():
     #current_db = MongoClient().Stage_database
     UserCache = _get_current_db().Stage_usercache
-    UserCache.create_index([("user_id", pymongo.ASCENDING),
-                            ("metadata.type", pymongo.ASCENDING),
-                            ("metadata.write_ts", pymongo.ASCENDING),
-                            ("metadata.key", pymongo.ASCENDING)])
+    UserCache.create_index([("user_id", pymongo.ASCENDING)])
+    UserCache.create_index([("metadata.type", pymongo.ASCENDING)])
+    UserCache.create_index([("metadata.key", pymongo.ASCENDING)])
     UserCache.create_index([("metadata.write_ts", pymongo.DESCENDING)])
     UserCache.create_index([("data.ts", pymongo.DESCENDING)], sparse=True)
     return UserCache


### PR DESCRIPTION
This fixes
https://github.com/e-mission/e-mission-docs/issues/635

After splitting the compound index, we ended up with two `metadata.write_ts`
indices, one `ASCENDING` and one `DESCENDING`.

Retained the `DESCENDING` one because:
- all the other timestamp indices are `DESCENDING`
    - `get_timeseries_db`: `metadata.write_ts`, `data.ts`
    - `_create_analysis_result_indices`: `data.ts`
- the `DESCENDING` index was added in
    https://github.com/e-mission/e-mission-server/commit/2032751816484d77d5331eeaa10e8032c3a05864 (Apr 2016),
    after the compound index in
    https://github.com/e-mission/e-mission-server/commit/0652dc4f113d0bce57a0caf56698bcdac00400e8 (Dec 2015)
    The goal of the new index was to improve performance.

However, we are sorting in `ASCENDING` order

```
         retrievedMsgs = list(self.db.find(combo_query).sort("metadata.write_ts", pymongo.ASCENDING).limit(100000))
```

But we do that everywhere

```
    section_doc_cursor = edb.get_analysis_timeseries_db().find(
        section_query).sort(sort_field, pymongo.ASCENDING)
```

We are going to make everything consistent and then deal with consistent optimizations.