### PR TITLE
Add the (simple) CRUD functionality for the bike library

### DIFF
--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -275,6 +275,12 @@ def get_tiersys_db():
     TierSys=_get_current_db().Tier_Sys
     return TierSys
 
+def get_checkinout_db():
+    Checkinout =_get_current_db().Checkinout
+    Checkinout.create_index([("bikeLabel",  pymongo.ASCENDING)], unique=True)
+    Checkinout.create_index([("user_id",  pymongo.ASCENDING)], unique=True)
+    return Checkinout
+
 def get_new_tier_db():
     newTier =_get_current_db().New_tier
     return newTier

--- a/emission/net/api/checkinout.py
+++ b/emission/net/api/checkinout.py
@@ -1,0 +1,22 @@
+import logging
+import arrow
+from uuid import UUID
+
+import emission.core.get_database as edb
+
+def checkin(cop):
+    edb.get_checkinout_db().delete_one(cop)
+
+def checkout(cop):
+    cop["ts"] = arrow.get().timestamp
+    edb.get_checkinout_db().insert_one(cop)
+
+def checkedoutlist():
+    all_list = list(edb.get_checkinout_db().find())
+    for co in all_list:
+        del co["user_id"]
+        del co["_id"]
+    return all_list
+
+def checkedoutget(user_id):
+    return edb.get_checkinout_db().find_one({"user_id": user_id})


### PR DESCRIPTION
- Add a new checkinout collection
- Add two unique indices to it to ensure that each user can only check out one
  bike and one bike can only be checked out by one user at a time
- Add three functions
    - one for the check in/out operations
    - one to get the list of all checked out bikes. This has the UUIDs stripped out for security.
    - one to get the currently checked out bike for this user (if any). If we
      weren't stripping out the UUIDs, and we had our UUID on the phone, we could just compare against it
      but that could allow participants to scrape the list and try and figure
      out when others were leaving by looking at checkin/out patterns. Better to aggregate and strip the uuids for safety.
      This also matches the current pattern in which aggregated info does not have any UUIDs listed
- add a new module to interface with the database - this is basically a wrapper
  except for the list retrieval which strips out the UUIDs

This, combined with the phone changes, largely fixes https://github.com/e-mission/e-mission-docs/issues/633

Testing done:
- Ad-hoc end-to-end testing, integrated with the client changes