### PR TITLE
Minor fixes while sending push notifications to inform end users abou…

### DIFF
--- a/emission/net/ext_service/push/notify_queries.py
+++ b/emission/net/ext_service/push/notify_queries.py
@@ -35,8 +35,8 @@ def get_matching_tokens(query):
                "android": []}
     ret_cursor = edb.get_profile_db().find(query, {"_id": False, "device_token": True, "curr_platform": True})
     for i, entry in enumerate(ret_cursor):
-        curr_platform = entry["curr_platform"]
-        device_token = entry["device_token"]
+        curr_platform = entry.get("curr_platform", None)
+        device_token = entry.get("device_token", None)
         if curr_platform is None or device_token is None:
             logging.warning("ignoring entry %s due to None values" % entry)
         else:

--- a/emission/tests/netTests/TestPush.py
+++ b/emission/tests/netTests/TestPush.py
@@ -35,7 +35,7 @@ def generate_fake_result(successful_tokens, failed_tokens):
     }
     fake_result["results"] = fake_result["results"] + [{"status": "no_matching_token",
                     "apns_token": token} for token in failed_tokens]
-    return fake_result
+    return fake_result["results"]
 
 
 class TestPush(unittest.TestCase):


### PR DESCRIPTION
…t server retirement

- Handle the case where there is no curr_platform set by using `.get()` with a
  default value of `None`. This ensures that these entries are skipped.
- Send the mapping tokens to firebase in batches of 100
- This required some additional refactoring around return types since we needed
  to concatenate the values from the various batches before storing them to the database

This fixes the iOS issues described in
https://github.com/e-mission/e-mission-docs/issues/326#issuecomment-836117248
as seen in
https://github.com/e-mission/e-mission-docs/issues/326#issuecomment-836151853