### PR TITLE
Refactor the similarity code to pull out static methods

### DIFF
--- a/emission/analysis/modelling/tour_model/cluster_pipeline.py
+++ b/emission/analysis/modelling/tour_model/cluster_pipeline.py
@@ -85,7 +85,7 @@ def main(uuid=None):
     data = read_data(uuid)
     logging.debug("len(data) is %d" % len(data))
     data, bins = remove_noise(data, 300)
-    n, labels, data = cluster(data, len(bins))
+    n, labels, data, points = cluster(data, len(bins))
     tour_dict = cluster_to_tour_model(data, labels)
     return tour_dict
 


### PR DESCRIPTION
Instead of making everything an instance method.
This is the correct implementation of
https://github.com/e-mission/e-mission-server/pull/814

testing done:
I haven't tested extensively since I assume @corinne-hcr will take care of that.
But I did run the cluster pipeline without any obvious failures in the refactoring

```
2021-05-25 21:25:26,044:DEBUG:endpoints are = (-122.0864571, 37.3910449) and (-122.087199, 37.3910048)
2021-05-25 21:25:26,044:DEBUG:After removing trips that are points, there are 5 data points
2021-05-25 21:25:26,045:DEBUG:number of bins before filtering: 5
2021-05-25 21:25:26,046:DEBUG:the new number of trips is 0
2021-05-25 21:25:26,046:DEBUG:the cutoff point is 0
2021-05-25 21:25:26,046:DEBUG:number of bins after filtering: 0
2021-05-25 21:25:26,049:DEBUG:min_clusters = 0, max_clusters = 0, len(self.points) = 5
2021-05-25 21:25:26,049:DEBUG:min_clusters < 2, setting min_clusters = 2
Must have at least 2 clusters
2021-05-25 21:25:26,062:DEBUG:number of clusters: 2
```

There appears to be an unrelated error in the clustering code, probably due to
a prior refactoring which was not backwards compatible.

```
Traceback (most recent call last):
  File "emission/analysis/modelling/tour_model/cluster_pipeline.py", line 99, in <module>
    main(uuid=uuid)
  File "emission/analysis/modelling/tour_model/cluster_pipeline.py", line 88, in main
    n, labels, data = cluster(data, len(bins))
ValueError: too many values to unpack (expected 3)
```