### PR TITLE
Change the geojson export code to use confirmed trips instead of clea…

### DIFF
--- a/.github/workflows/osx-ubuntu-manual-install.yml
+++ b/.github/workflows/osx-ubuntu-manual-install.yml
@@ -19,12 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest, macos-latest]
+        os: [ubuntu-18.04, ubuntu-latest, macos-latest]
         include:
         - os: macos-latest
           PLATFORM: MacOSX-x86_64
-        - os: ubuntu-16.04
-          PLATFORM: Linux-x86_64
         - os: ubuntu-18.04
           PLATFORM: Linux-x86_64
         - os: ubuntu-latest

--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-latest]
+        os: [ubuntu-18.04, ubuntu-latest]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/emission/analysis/plotting/geojson/geojson_feature_converter.py
+++ b/emission/analysis/plotting/geojson/geojson_feature_converter.py
@@ -238,7 +238,11 @@ def trip_to_geojson(trip, tl):
     end_place_geojson["properties"]["feature_type"] = "end_place"
     feature_array.append(end_place_geojson)
 
-    trip_tl = esdt.get_cleaned_timeline_for_trip(trip.user_id, trip.get_id())
+    if "cleaned_trip" in trip.data:
+        trip_tl = esdt.get_cleaned_timeline_for_trip(trip.user_id, trip.data.cleaned_trip)
+    else:
+        trip_tl = esdt.get_cleaned_timeline_for_trip(trip.user_id, trip.get_id())
+
     stops = trip_tl.places
     for stop in stops:
         feature_array.append(stop_to_geojson(stop))
@@ -267,13 +271,13 @@ def trip_to_geojson(trip, tl):
     return trip_geojson
 
 def get_geojson_for_ts(user_id, start_ts, end_ts):
-    tl = esdtl.get_cleaned_timeline(user_id, start_ts, end_ts)
+    tl = esdtl.get_confirmed_timeline(user_id, start_ts, end_ts)
     tl.fill_start_end_places()
     return get_geojson_for_timeline(user_id, tl)
 
 def get_geojson_for_dt(user_id, start_local_dt, end_local_dt):
     logging.debug("Getting geojson for %s -> %s" % (start_local_dt, end_local_dt))
-    tl = esdtl.get_cleaned_timeline_from_dt(user_id, start_local_dt, end_local_dt)
+    tl = esdtl.get_confirmed_timeline_from_dt(user_id, start_local_dt, end_local_dt)
     tl.fill_start_end_places()
     return get_geojson_for_timeline(user_id, tl)
 

--- a/emission/storage/decorations/timeline.py
+++ b/emission/storage/decorations/timeline.py
@@ -26,6 +26,11 @@ def get_cleaned_timeline_from_dt(user_id, start_local_dt, end_local_dt,
     return get_timeline_from_dt(user_id, esda.CLEANED_PLACE_KEY, esda.CLEANED_TRIP_KEY, esda.CLEANED_UNTRACKED_KEY,
                                 start_local_dt, end_local_dt, geojson, extra_query_list)
 
+def get_confirmed_timeline_from_dt(user_id, start_local_dt, end_local_dt,
+                                 geojson=None, extra_query_list=None):
+    return get_timeline_from_dt(user_id, esda.CLEANED_PLACE_KEY, esda.CONFIRMED_TRIP_KEY, esda.CLEANED_UNTRACKED_KEY,
+                                start_local_dt, end_local_dt, geojson, extra_query_list)
+
 def get_raw_timeline(user_id, start_ts, end_ts,
                      geojson=None, extra_query_list=None):
     return get_timeline(user_id, esda.RAW_PLACE_KEY, esda.RAW_TRIP_KEY, esda.RAW_UNTRACKED_KEY,
@@ -34,6 +39,11 @@ def get_raw_timeline(user_id, start_ts, end_ts,
 def get_cleaned_timeline(user_id, start_ts, end_ts,
                          geojson=None, extra_query_list=None):
     return get_timeline(user_id, esda.CLEANED_PLACE_KEY, esda.CLEANED_TRIP_KEY, esda.CLEANED_UNTRACKED_KEY,
+                        start_ts, end_ts, geojson, extra_query_list)
+
+def get_confirmed_timeline(user_id, start_ts, end_ts,
+                         geojson=None, extra_query_list=None):
+    return get_timeline(user_id, esda.CLEANED_PLACE_KEY, esda.CONFIRMED_TRIP_KEY, esda.CLEANED_UNTRACKED_KEY,
                         start_ts, end_ts, geojson, extra_query_list)
 
 def get_timeline(user_id, place_key, trip_key, untracked_key, start_ts, end_ts,


### PR DESCRIPTION
…ned trips

The changes were actually fairly minor
- add new `get_confirmed_timeline` and `get_confirmed_timeline_from_dt` which
  reads cleaned places but confirmed trips
- fortunately, the timeline linkage code focuses on trips, so it works with
  confirmed trips instead of cleaned trips
- change the code which looks up the sections and stops to use the cleaned_trip
  id instead of the trip id if it is a confirmed trip

TODO: change this if/when we have confirmed sections.

We now get back a geojson with the inferred label fields.

This completes the server changes outlined in
https://github.com/e-mission/e-mission-docs/issues/674#issuecomment-933961854