### PR TITLE
Add support for generating metrics based on confirmed trips

### DIFF
--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -129,6 +129,7 @@ def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
     ret_list = []
     # When we group by a time range, the key is the end of the range
     for key, section_group_df in time_grouped_df:
+        logging.debug("For key %s, found %s sections" % (key, len(section_group_df)))
         curr_msts = ecwms.ModeStatTimeSummary()
         key = fix_int64_key_if_needed(key)
         key_to_fill_fn(key, section_group_df, curr_msts)
@@ -141,17 +142,22 @@ def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
             # we add a dummy column
             # pandas checks in TestMetricsConfirmedTripsPandas.testPandasConcatModeConfirm
             if "mode_confirm" not in section_group_df.columns:
+                # If we don't reset the index and the index doesn't start from 1,
+                # the concat will end up with additional rows
+                # see TestMetricsConfirmedTripsPandas.testPandasConcatModeConfirm
+                section_group_df.reset_index(inplace=True)
                 dummy_col = pd.Series([np.NaN] * len(section_group_df), name="mode_confirm")
                 section_group_df = pd.concat([section_group_df, dummy_col],
-                    axis = 1, copy=False)
+                    axis = 1, copy=True)
             # pandas ignores NaN entries while grouping
             # (see TestMetricsConfirmedTripsPandas.testPandasNaNHandlingAndWorkaround)
             # so we convert them to "unknown" first
             section_group_df.fillna("unknown", inplace=True)
-            logging.debug(section_group_df.mode_confirm)
+            logging.debug("After replacing unknown, we get %s " % list(section_group_df.mode_confirm))
             grouping_field = "mode_confirm"
         else:
             grouping_field = "sensed_mode"
+
         mode_grouped_df = section_group_df.groupby(grouping_field)
         mode_results = summary_fn(mode_grouped_df)
         for mode, result in mode_results.items():

--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -136,6 +136,11 @@ def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
         if result_section_key == "analysis/confirmed_trip":
             import emission.storage.decorations.trip_queries as esdt
             section_group_df = esdt.expand_userinputs(section_group_df)
+            # pandas ignores NaN entries while grouping
+            # (see TestMetricsConfirmed.testPandasNaNHandlingAndWorkaround)
+            # so we convert them to "unknown" first
+            section_group_df.fillna("unknown", inplace=True)
+            logging.debug(section_group_df.mode_confirm)
             grouping_field = "mode_confirm"
         else:
             grouping_field = "sensed_mode"

--- a/emission/tests/data/real_examples/shankari_2016-06-21.user_inputs
+++ b/emission/tests/data/real_examples/shankari_2016-06-21.user_inputs
@@ -1,0 +1,434 @@
+[
+    {
+        "_id": {
+            "$oid": "61af8dd3de1d3fd97454cc4f"
+        },
+        "user_id": {
+            "$uuid": "d8f16cbefb2841509a4d5e3ff5963a7f"
+        },
+        "metadata": {
+            "key": "manual/mode_confirm",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1638894973.372,
+            "write_local_dt": {
+                "year": 2021,
+                "month": 12,
+                "day": 7,
+                "hour": 8,
+                "minute": 36,
+                "second": 13,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2021-12-07T08:36:13.372000-08:00"
+        },
+        "data": {
+            "start_ts": 1466547704.0862284,
+            "end_ts": 1466549677.544,
+            "label": "bike",
+            "start_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 15,
+                "minute": 21,
+                "second": 44,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "start_fmt_time": "2016-06-21T15:21:44.086228-07:00",
+            "end_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 15,
+                "minute": 54,
+                "second": 37,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "end_fmt_time": "2016-06-21T15:54:37.544000-07:00"
+        }
+    },
+    {
+        "_id": {
+            "$oid": "61af8dd3de1d3fd97454cc53"
+        },
+        "user_id": {
+            "$uuid": "d8f16cbefb2841509a4d5e3ff5963a7f"
+        },
+        "metadata": {
+            "key": "manual/purpose_confirm",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1638894986.222,
+            "write_local_dt": {
+                "year": 2021,
+                "month": 12,
+                "day": 7,
+                "hour": 8,
+                "minute": 36,
+                "second": 26,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2021-12-07T08:36:26.222000-08:00"
+        },
+        "data": {
+            "start_ts": 1466547704.0862284,
+            "end_ts": 1466549677.544,
+            "label": "entertainment",
+            "start_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 15,
+                "minute": 21,
+                "second": 44,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "start_fmt_time": "2016-06-21T15:21:44.086228-07:00",
+            "end_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 15,
+                "minute": 54,
+                "second": 37,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "end_fmt_time": "2016-06-21T15:54:37.544000-07:00"
+        }
+    },
+    {
+        "_id": {
+            "$oid": "61af8dd3de1d3fd97454cc63"
+        },
+        "user_id": {
+            "$uuid": "d8f16cbefb2841509a4d5e3ff5963a7f"
+        },
+        "metadata": {
+            "key": "manual/mode_confirm",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1638894996.703,
+            "write_local_dt": {
+                "year": 2021,
+                "month": 12,
+                "day": 7,
+                "hour": 8,
+                "minute": 36,
+                "second": 36,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2021-12-07T08:36:36.703000-08:00"
+        },
+        "data": {
+            "start_ts": 1466549964.5914452,
+            "end_ts": 1466550380.105,
+            "label": "bike",
+            "start_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 15,
+                "minute": 59,
+                "second": 24,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "start_fmt_time": "2016-06-21T15:59:24.591445-07:00",
+            "end_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 16,
+                "minute": 6,
+                "second": 20,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "end_fmt_time": "2016-06-21T16:06:20.105000-07:00"
+        }
+    },
+    {
+        "_id": {
+            "$oid": "61af8dd3de1d3fd97454cc67"
+        },
+        "user_id": {
+            "$uuid": "d8f16cbefb2841509a4d5e3ff5963a7f"
+        },
+        "metadata": {
+            "key": "manual/purpose_confirm",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1638894999.723,
+            "write_local_dt": {
+                "year": 2021,
+                "month": 12,
+                "day": 7,
+                "hour": 8,
+                "minute": 36,
+                "second": 39,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2021-12-07T08:36:39.723000-08:00"
+        },
+        "data": {
+            "start_ts": 1466549964.5914452,
+            "end_ts": 1466550380.105,
+            "label": "home",
+            "start_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 15,
+                "minute": 59,
+                "second": 24,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "start_fmt_time": "2016-06-21T15:59:24.591445-07:00",
+            "end_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 16,
+                "minute": 6,
+                "second": 20,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "end_fmt_time": "2016-06-21T16:06:20.105000-07:00"
+        }
+    },
+    {
+        "_id": {
+            "$oid": "61af8dd3de1d3fd97454cc77"
+        },
+        "user_id": {
+            "$uuid": "d8f16cbefb2841509a4d5e3ff5963a7f"
+        },
+        "metadata": {
+            "key": "manual/mode_confirm",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1638895010.996,
+            "write_local_dt": {
+                "year": 2021,
+                "month": 12,
+                "day": 7,
+                "hour": 8,
+                "minute": 36,
+                "second": 50,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2021-12-07T08:36:50.996000-08:00"
+        },
+        "data": {
+            "start_ts": 1466554382.5681126,
+            "end_ts": 1466554947.766,
+            "label": "walk",
+            "start_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 17,
+                "minute": 13,
+                "second": 2,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "start_fmt_time": "2016-06-21T17:13:02.568113-07:00",
+            "end_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 17,
+                "minute": 22,
+                "second": 27,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "end_fmt_time": "2016-06-21T17:22:27.766000-07:00"
+        }
+    },
+    {
+        "_id": {
+            "$oid": "61af8dd3de1d3fd97454cc7b"
+        },
+        "user_id": {
+            "$uuid": "d8f16cbefb2841509a4d5e3ff5963a7f"
+        },
+        "metadata": {
+            "key": "manual/purpose_confirm",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1638895026.95,
+            "write_local_dt": {
+                "year": 2021,
+                "month": 12,
+                "day": 7,
+                "hour": 8,
+                "minute": 37,
+                "second": 6,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2021-12-07T08:37:06.950000-08:00"
+        },
+        "data": {
+            "start_ts": 1466554382.5681126,
+            "end_ts": 1466554947.766,
+            "label": "library",
+            "start_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 17,
+                "minute": 13,
+                "second": 2,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "start_fmt_time": "2016-06-21T17:13:02.568113-07:00",
+            "end_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 17,
+                "minute": 22,
+                "second": 27,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "end_fmt_time": "2016-06-21T17:22:27.766000-07:00"
+        }
+    },
+    {
+        "_id": {
+            "$oid": "61af8dd3de1d3fd97454cc7f"
+        },
+        "user_id": {
+            "$uuid": "d8f16cbefb2841509a4d5e3ff5963a7f"
+        },
+        "metadata": {
+            "key": "manual/mode_confirm",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1638895031.464,
+            "write_local_dt": {
+                "year": 2021,
+                "month": 12,
+                "day": 7,
+                "hour": 8,
+                "minute": 37,
+                "second": 11,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2021-12-07T08:37:11.464000-08:00"
+        },
+        "data": {
+            "start_ts": 1466559839.156,
+            "end_ts": 1466560322.144,
+            "label": "walk",
+            "start_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 18,
+                "minute": 43,
+                "second": 59,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "start_fmt_time": "2016-06-21T18:43:59.156000-07:00",
+            "end_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 18,
+                "minute": 52,
+                "second": 2,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "end_fmt_time": "2016-06-21T18:52:02.144000-07:00"
+        }
+    },
+    {
+        "_id": {
+            "$oid": "61af8dd3de1d3fd97454cc83"
+        },
+        "user_id": {
+            "$uuid": "d8f16cbefb2841509a4d5e3ff5963a7f"
+        },
+        "metadata": {
+            "key": "manual/purpose_confirm",
+            "platform": "android",
+            "read_ts": 0,
+            "time_zone": "America/Los_Angeles",
+            "type": "message",
+            "write_ts": 1638895034.019,
+            "write_local_dt": {
+                "year": 2021,
+                "month": 12,
+                "day": 7,
+                "hour": 8,
+                "minute": 37,
+                "second": 14,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "write_fmt_time": "2021-12-07T08:37:14.019000-08:00"
+        },
+        "data": {
+            "start_ts": 1466559839.156,
+            "end_ts": 1466560322.144,
+            "label": "home",
+            "start_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 18,
+                "minute": 43,
+                "second": 59,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "start_fmt_time": "2016-06-21T18:43:59.156000-07:00",
+            "end_local_dt": {
+                "year": 2016,
+                "month": 6,
+                "day": 21,
+                "hour": 18,
+                "minute": 52,
+                "second": 2,
+                "weekday": 1,
+                "timezone": "America/Los_Angeles"
+            },
+            "end_fmt_time": "2016-06-21T18:52:02.144000-07:00"
+        }
+    }
+]

--- a/emission/tests/netTests/TestMetricsConfirmedTrips.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTrips.py
@@ -80,25 +80,6 @@ class TestMetrics(unittest.TestCase):
         self.assertTrue('shared_ride' not in agg_met_result[2] and
                          'bike' not in agg_met_result[2])
 
-    def testPandasNaNHandlingAndWorkaround(self):
-        # Pandas currently ignores NaN entries in groupby
-        import pandas as pd
-        import numpy as np
-
-        test_df = pd.DataFrame({"id": [1,2,3,4,5,6],
-            "mode_confirm": ["walk", "bike", "bike", "walk", np.NaN, np.NaN]})
-
-        # Current pandas behavior ignores NaN
-        orig_grouping = test_df.groupby("mode_confirm").groups
-        self.assertEquals(list(orig_grouping.keys()), ["bike", "walk"])
-
-        # workaround replaces NaN with "unknown"
-        new_test_df = test_df.fillna("unknown")
-
-        # Now we should not ignore NaN
-        new_grouping = new_test_df.groupby("mode_confirm").groups
-        self.assertEquals(list(new_grouping.keys()), ["bike", "unknown", "walk"])
-
     def testCountTimestampPartialMissingLabels(self):
         self.entries = json.load(open("emission/tests/data/real_examples/shankari_2016-07-22"), object_hook = bju.object_hook)
         etc.setupRealExampleWithEntries(self)
@@ -133,6 +114,76 @@ class TestMetrics(unittest.TestCase):
         # since these are never negative, it implies that their sum is zero
         self.assertTrue('unknown' in agg_met_result[0])
         self.assertEqual(agg_met_result[0]["unknown"], 5)
+
+    def testCountTimestampFullMissingLabels(self):
+        self.entries = json.load(open("emission/tests/data/real_examples/shankari_2016-07-22"), object_hook = bju.object_hook)
+        etc.setupRealExampleWithEntries(self)
+        etc.runIntakePipeline(self.testUUID2)
+        # We group by day, so the last day will not have any labeled entries
+        met_result = metrics.summarize_by_timestamp(self.testUUID2,
+                                                    self.jun_start_ts, self.jun_end_ts,
+                                       'd', ['count'], True)
+        logging.debug(met_result)
+
+        self.assertEqual(list(met_result.keys()), ['aggregate_metrics', 'user_metrics'])
+        user_met_result = met_result['user_metrics'][0]
+        agg_met_result = met_result['aggregate_metrics'][0]
+
+        self.assertEqual(len(user_met_result), 32)
+        self.assertEqual([m.nUsers for m in user_met_result], [1,1] + [0] * 29 + [1])
+        self.assertEqual(user_met_result[0].local_dt.day, 21)
+        self.assertEqual(user_met_result[0]["bike"], 2)
+        self.assertEqual(user_met_result[1]["walk"], 2)
+        self.assertEqual(user_met_result[31].local_dt.day, 22)
+        self.assertEqual(user_met_result[31]["unknown"], 6)
+        # We are not going to make absolute value assertions about
+        # the aggregate values since they are affected by other
+        # entries in the database. However, because we have at least
+        # data for two days in the database, the aggregate data
+        # must be at least that much larger than the original data.
+        self.assertEqual(len(agg_met_result), 33)
+        # no overlap between users at the daily level
+        # bunch of intermediate entries with no users since this binning works
+        # by range
+        self.assertEqual([m.nUsers for m in agg_met_result], [1,1,1] + [0] * 29 + [1])
+        # If there are no users, there are no values for any of the fields
+        # since these are never negative, it implies that their sum is zero
+        self.assertTrue('unknown' in agg_met_result[32])
+        self.assertEqual(agg_met_result[32]["unknown"], 6)
+
+    def testCountTimestampFullMissingLabelsMonth(self):
+        self.entries = json.load(open("emission/tests/data/real_examples/shankari_2016-07-22"), object_hook = bju.object_hook)
+        etc.setupRealExampleWithEntries(self)
+        etc.runIntakePipeline(self.testUUID2)
+        # We group by day, so the last day will not have any labeled entries
+        met_result = metrics.summarize_by_timestamp(self.testUUID2,
+                                                    self.jun_start_ts, self.jun_end_ts,
+                                       'm', ['count'], True)
+        logging.debug(met_result)
+
+        self.assertEqual(list(met_result.keys()), ['aggregate_metrics', 'user_metrics'])
+        user_met_result = met_result['user_metrics'][0]
+        agg_met_result = met_result['aggregate_metrics'][0]
+
+        self.assertEqual(len(user_met_result), 2)
+        self.assertEqual([m.nUsers for m in user_met_result], [1,1])
+        self.assertEqual(user_met_result[0].local_dt.day, 30)
+        self.assertEqual(user_met_result[0]["bike"], 2)
+        self.assertEqual(user_met_result[0]["walk"], 2)
+        self.assertEqual(user_met_result[1].local_dt.day, 31)
+        self.assertEqual(user_met_result[1]["unknown"], 6)
+        self.assertNotIn("walk", user_met_result[1].keys())
+        self.assertNotIn("bike", user_met_result[1].keys())
+
+        self.assertEqual(len(agg_met_result), 2)
+        # no overlap between users at the daily level
+        # bunch of intermediate entries with no users since this binning works
+        # by range
+        self.assertEqual([m.nUsers for m in agg_met_result], [2,1])
+        # If there are no users, there are no values for any of the fields
+        # since these are never negative, it implies that their sum is zero
+        self.assertTrue('unknown' in agg_met_result[1])
+        self.assertEqual(agg_met_result[1]["unknown"], 6)
 
     def testCountLocalDateMetrics(self):
         met_result = metrics.summarize_by_local_date(self.testUUID,

--- a/emission/tests/netTests/TestMetricsConfirmedTrips.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTrips.py
@@ -80,6 +80,60 @@ class TestMetrics(unittest.TestCase):
         self.assertTrue('shared_ride' not in agg_met_result[2] and
                          'bike' not in agg_met_result[2])
 
+    def testPandasNaNHandlingAndWorkaround(self):
+        # Pandas currently ignores NaN entries in groupby
+        import pandas as pd
+        import numpy as np
+
+        test_df = pd.DataFrame({"id": [1,2,3,4,5,6],
+            "mode_confirm": ["walk", "bike", "bike", "walk", np.NaN, np.NaN]})
+
+        # Current pandas behavior ignores NaN
+        orig_grouping = test_df.groupby("mode_confirm").groups
+        self.assertEquals(list(orig_grouping.keys()), ["bike", "walk"])
+
+        # workaround replaces NaN with "unknown"
+        new_test_df = test_df.fillna("unknown")
+
+        # Now we should not ignore NaN
+        new_grouping = new_test_df.groupby("mode_confirm").groups
+        self.assertEquals(list(new_grouping.keys()), ["bike", "unknown", "walk"])
+
+    def testCountTimestampPartialMissingLabels(self):
+        self.entries = json.load(open("emission/tests/data/real_examples/shankari_2016-07-22"), object_hook = bju.object_hook)
+        etc.setupRealExampleWithEntries(self)
+        etc.runIntakePipeline(self.testUUID2)
+        # We group the entire year so we get partial labels
+        met_result = metrics.summarize_by_timestamp(self.testUUID2,
+                                                    self.jun_start_ts, self.jun_end_ts,
+                                       'y', ['count'], True)
+        logging.debug(met_result)
+
+        self.assertEqual(list(met_result.keys()), ['aggregate_metrics', 'user_metrics'])
+        user_met_result = met_result['user_metrics'][0]
+        agg_met_result = met_result['aggregate_metrics'][0]
+
+        self.assertEqual(len(user_met_result), 1)
+        self.assertEqual([m.nUsers for m in user_met_result], [1])
+        self.assertEqual(user_met_result[0].local_dt.day, 31)
+        self.assertEqual(user_met_result[0]["bike"], 2)
+        self.assertEqual(user_met_result[0]["walk"], 2)
+        self.assertEqual(user_met_result[0]["unknown"], 3)
+        # We are not going to make absolute value assertions about
+        # the aggregate values since they are affected by other
+        # entries in the database. However, because we have at least
+        # data for two days in the database, the aggregate data
+        # must be at least that much larger than the original data.
+        self.assertEqual(len(agg_met_result), 1)
+        # no overlap between users at the daily level
+        # bunch of intermediate entries with no users since this binning works
+        # by range
+        self.assertEqual([m.nUsers for m in agg_met_result], [2])
+        # If there are no users, there are no values for any of the fields
+        # since these are never negative, it implies that their sum is zero
+        self.assertTrue('unknown' in agg_met_result[0])
+        self.assertEqual(agg_met_result[0]["unknown"], 5)
+
     def testCountLocalDateMetrics(self):
         met_result = metrics.summarize_by_local_date(self.testUUID,
                                                      ecwl.LocalDate({'year': 2016, 'month': 6}),

--- a/emission/tests/netTests/TestMetricsConfirmedTrips.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTrips.py
@@ -1,0 +1,127 @@
+import unittest
+import logging
+import arrow
+import os
+import json
+import bson.json_util as bju
+from datetime import datetime
+
+import emission.core.get_database as edb
+import emission.core.wrapper.localdate as ecwl
+
+import emission.tests.common as etc
+import emission.analysis.intake.cleaning.filter_accuracy as eaicf
+import emission.storage.timeseries.format_hacks.move_filter_field as estfm
+
+from emission.net.api import metrics
+
+class TestMetrics(unittest.TestCase):
+    def setUp(self):
+        self.analysis_conf_path = \
+            etc.set_analysis_config("analysis.result.section.key", "analysis/confirmed_trip")
+        self._loadDataFileAndInputs("emission/tests/data/real_examples/shankari_2016-06-20")
+        self.testUUID1 = self.testUUID
+        self._loadDataFileAndInputs("emission/tests/data/real_examples/shankari_2016-06-21")
+        self.testUUID2 = self.testUUID
+
+        logging.info(
+            "After loading, timeseries db size = %s" % edb.get_timeseries_db().estimated_document_count())
+        self.jun_start_ts = arrow.get(datetime(2016,6,1), "America/Los_Angeles").timestamp
+        self.jun_end_ts = arrow.get(datetime(2016,7,30), "America/Los_Angeles").timestamp
+        self.jun_start_dt = ecwl.LocalDate.get_local_date(self.jun_start_ts, "America/Los_Angeles")
+        self.jun_end_dt = ecwl.LocalDate.get_local_date(self.jun_end_ts, "America/Los_Angeles")
+
+    def _loadDataFileAndInputs(self, dataFile):
+        etc.setupRealExample(self, dataFile)
+        self.entries = json.load(open(dataFile+".user_inputs"), object_hook = bju.object_hook)
+        etc.setupRealExampleWithEntries(self)
+        etc.runIntakePipeline(self.testUUID)
+
+    def tearDown(self):
+        self.clearRelatedDb()
+        os.remove(self.analysis_conf_path)
+
+    def clearRelatedDb(self):
+        edb.get_timeseries_db().delete_many({"user_id": self.testUUID1})
+        edb.get_analysis_timeseries_db().delete_many({"user_id": self.testUUID1})
+        edb.get_pipeline_state_db().delete_many({"user_id": self.testUUID1})
+        edb.get_timeseries_db().delete_many({"user_id": self.testUUID2})
+        edb.get_analysis_timeseries_db().delete_many({"user_id": self.testUUID2})
+        edb.get_pipeline_state_db().delete_many({"user_id": self.testUUID2})
+
+    def testCountTimestampMetrics(self):
+        met_result = metrics.summarize_by_timestamp(self.testUUID2,
+                                                    self.jun_start_ts, self.jun_end_ts,
+                                       'd', ['count'], True)
+        logging.debug(met_result)
+
+        self.assertEqual(list(met_result.keys()), ['aggregate_metrics', 'user_metrics'])
+        user_met_result = met_result['user_metrics'][0]
+        agg_met_result = met_result['aggregate_metrics'][0]
+ 
+        self.assertEqual(len(user_met_result), 2)
+        self.assertEqual([m.nUsers for m in user_met_result], [1, 1])
+        self.assertEqual(user_met_result[0].local_dt.day, 21)
+        self.assertEqual(user_met_result[0]["bike"], 2)
+        self.assertEqual(user_met_result[1].local_dt.day, 22)
+        self.assertEqual(user_met_result[1]["walk"], 2)
+        # We are not going to make absolute value assertions about
+        # the aggregate values since they are affected by other
+        # entries in the database. However, because we have at least
+        # data for two days in the database, the aggregate data
+        # must be at least that much larger than the original data.
+        self.assertEqual(len(agg_met_result), 3)
+        # no overlap between users at the daily level
+        # bunch of intermediate entries with no users since this binning works
+        # by range
+        self.assertEqual([m.nUsers for m in agg_met_result], [1,1,1])
+        # If there are no users, there are no values for any of the fields
+        # since these are never negative, it implies that their sum is zero
+        self.assertTrue('shared_ride' not in agg_met_result[2] and
+                         'bike' not in agg_met_result[2])
+
+    def testCountLocalDateMetrics(self):
+        met_result = metrics.summarize_by_local_date(self.testUUID,
+                                                     ecwl.LocalDate({'year': 2016, 'month': 6}),
+                                                     ecwl.LocalDate({'year': 2016, 'month': 6}),
+                                                     'MONTHLY', ['count'], True)
+        self.assertEqual(list(met_result.keys()), ['aggregate_metrics', 'user_metrics'])
+        user_met_result = met_result['user_metrics'][0]
+        agg_met_result = met_result['aggregate_metrics'][0]
+
+        logging.debug(met_result)
+
+        # local timezone means that we only have one entry
+        self.assertEqual(len(user_met_result), 1)
+        self.assertEqual(user_met_result[0].nUsers, 1)
+        self.assertEqual(user_met_result[0]["walk"], 2)
+        self.assertEqual(user_met_result[0]["bike"], 2)
+        self.assertEqual(len(agg_met_result), 1)
+        self.assertEqual(agg_met_result[0].nUsers, 2)
+        self.assertGreaterEqual(agg_met_result[0]["shared_ride"], 2)
+        self.assertGreaterEqual(agg_met_result[0]["walk"], 4)
+
+    def testCountNoEntries(self):
+        # Ensure that we don't crash if we don't find any entries
+        # Should return empty array instead
+        # Unlike in https://amplab.cs.berkeley.edu/jenkins/job/e-mission-server-prb/591/
+        met_result_ld = metrics.summarize_by_local_date(self.testUUID,
+                                                     ecwl.LocalDate({'year': 2000}),
+                                                     ecwl.LocalDate({'year': 2001}),
+                                                     'MONTHLY', ['count'], True)
+        self.assertEqual(list(met_result_ld.keys()), ['aggregate_metrics', 'user_metrics'])
+        self.assertEqual(met_result_ld['aggregate_metrics'][0], [])
+        self.assertEqual(met_result_ld['user_metrics'][0], [])
+
+        met_result_ts = metrics.summarize_by_timestamp(self.testUUID,
+                                                       arrow.get(2000,1,1).timestamp,
+                                                       arrow.get(2001,1,1).timestamp,
+                                                        'm', ['count'], True)
+        self.assertEqual(list(met_result_ts.keys()), ['aggregate_metrics', 'user_metrics'])
+        self.assertEqual(met_result_ts['aggregate_metrics'][0], [])
+        self.assertEqual(met_result_ts['user_metrics'][0], [])
+
+if __name__ == '__main__':
+    import emission.tests.common as etc
+    etc.configLogging()
+    unittest.main()

--- a/emission/tests/netTests/TestMetricsConfirmedTripsPandas.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTripsPandas.py
@@ -1,0 +1,44 @@
+import unittest
+import pandas as pd
+import numpy as np
+
+import emission.storage.decorations.trip_queries as esdt
+
+class TestMetricsConfirmedTripsPandas(unittest.TestCase):
+
+    # Pandas currently ignores NaN entries in groupby
+    def testPandasNaNHandlingAndWorkaround(self):
+        test_df = pd.DataFrame({"id": [1,2,3,4,5,6],
+            "mode_confirm": ["walk", "bike", "bike", "walk", np.NaN, np.NaN]})
+
+        # Current pandas behavior ignores NaN
+        orig_grouping = test_df.groupby("mode_confirm").groups
+        self.assertEqual(list(orig_grouping.keys()), ["bike", "walk"])
+
+        # workaround replaces NaN with "unknown"
+        new_test_df = test_df.fillna("unknown")
+
+        # Now we should not ignore NaN
+        new_grouping = new_test_df.groupby("mode_confirm").groups
+        self.assertEqual(list(new_grouping.keys()), ["bike", "unknown", "walk"])
+
+    # Pandas currently ignores NaN entries in groupby
+    def testPandasConcatModeConfirm(self):
+        test_df = pd.DataFrame({"id": [1,2,3,4,5,6], "user_input": [{}] * 6})
+
+        # unlabeled trips result in no additional columns
+        expanded_test_df = esdt.expand_userinputs(test_df)
+        self.assertNotIn("mode_confirm", expanded_test_df.columns)
+
+        dummy_col = pd.Series([np.NaN] * len(expanded_test_df), name="mode_confirm")
+        self.assertEqual(len(dummy_col), len(expanded_test_df))
+        filled_expanded_test_df = pd.concat([expanded_test_df, dummy_col],
+            axis = 1, copy=False)
+
+        self.assertIn("mode_confirm", filled_expanded_test_df.columns)
+        self.assertEqual(len(filled_expanded_test_df.mode_confirm), len(dummy_col))
+
+if __name__ == '__main__':
+    import emission.tests.common as etc
+    etc.configLogging()
+    unittest.main()


### PR DESCRIPTION
The changes are relatively minor, and are consistent with the design here:
https://github.com/e-mission/e-mission-docs/issues/688#issuecomment-987048115

if the "section" key is confirmed_trips, then:
    - expand the user inputs
    - set the grouping key to mode_confirm
    - ensure that we don't try to wrap the modes in this case since they are strings

Testing done:
- add additional unit tests that set the config to `confirmed_trips`
- add user inputs for a second day to support loading two users with user
  inputs, and allowing us to check aggregate vs. user values.