### PR TITLE
Fix median_speed call when returning confirmed trips

### DIFF
--- a/emission/analysis/result/metrics/simple_metrics.py
+++ b/emission/analysis/result/metrics/simple_metrics.py
@@ -39,7 +39,7 @@ def get_duration(mode_section_grouped_df):
 def get_median_speed(mode_section_grouped_df):
     ret_dict = {}
     for (mode, mode_section_df) in mode_section_grouped_df:
-        print("while getting median speed %s, %s" % (mode, mode_section_df.columns))
+        # print("while getting median speed %s, %s" % (mode, mode_section_df.columns))
         if "speeds" in mode_section_df.columns:
             speeds_list = mode_section_df.speeds
         else:

--- a/emission/analysis/result/metrics/simple_metrics.py
+++ b/emission/analysis/result/metrics/simple_metrics.py
@@ -39,11 +39,31 @@ def get_duration(mode_section_grouped_df):
 def get_median_speed(mode_section_grouped_df):
     ret_dict = {}
     for (mode, mode_section_df) in mode_section_grouped_df:
+        print("while getting median speed %s, %s" % (mode, mode_section_df.columns))
+        if "speeds" in mode_section_df.columns:
+            speeds_list = mode_section_df.speeds
+        else:
+            # we are using the confirmed trips, which don't have the speed list
+            # let's get it by concatenating from the sections
+            speeds_list = mode_section_df.apply(_get_speeds_for_trip, axis=1)
+
+        # speeds series is a series with one row per section/trip where the
+        # value is the list of speeds in that section/trip
         median_speeds = [pd.Series(sl).dropna().median() for sl
-                            in mode_section_df.speeds]
+                            in speeds_list]
         mode_median = pd.Series(median_speeds).dropna().median()
         if np.isnan(mode_median):
             logging.debug("still found nan for mode %s, skipping")
         else:
             ret_dict[mode] = float(mode_median)
     return ret_dict
+
+def _get_speeds_for_trip(trip_df_row):
+    import itertools
+    import emission.storage.decorations.trip_queries as esdt
+
+    section_list = esdt.get_cleaned_sections_for_trip(trip_df_row.user_id, trip_df_row.cleaned_trip)
+    logging.debug("Found %s matching sections for trip %s" % (len(section_list), trip_df_row._id))
+    speed_list_of_lists = [s["data"]["speeds"] for s in section_list]
+    speed_list = list(itertools.chain(*speed_list_of_lists))
+    return speed_list

--- a/emission/tests/netTests/TestMetricsConfirmedTrips.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTrips.py
@@ -80,6 +80,37 @@ class TestMetrics(unittest.TestCase):
         self.assertTrue('shared_ride' not in agg_met_result[2] and
                          'bike' not in agg_met_result[2])
 
+    def testAllTimestampMetrics(self):
+        met_result = metrics.summarize_by_timestamp(self.testUUID2,
+                                                    self.jun_start_ts, self.jun_end_ts,
+                                       'd', ['count', 'distance', 'duration', 'median_speed'], True)
+        logging.debug(met_result)
+
+        self.assertEqual(list(met_result.keys()), ['aggregate_metrics', 'user_metrics'])
+        self.assertEqual(len(met_result["user_metrics"]), 4)
+        self.assertEqual(len(met_result["aggregate_metrics"]), 4)
+
+        user_met_count_result = met_result['user_metrics'][0]
+        agg_met_count_result = met_result['aggregate_metrics'][0]
+
+        user_met_dist_result = met_result['user_metrics'][1]
+        agg_met_dist_result = met_result['aggregate_metrics'][1]
+
+        user_met_dur_result = met_result['user_metrics'][2]
+        agg_met_dur_result = met_result['aggregate_metrics'][2]
+
+        user_met_spd_result = met_result['user_metrics'][3]
+        agg_met_spd_result = met_result['aggregate_metrics'][3]
+
+        self.assertEqual([len(ml) for ml in met_result["user_metrics"]], [2]*4)
+        self.assertEqual([len(ml) for ml in met_result["aggregate_metrics"]], [3]*4)
+        self.assertEqual([[m.nUsers for m in ml] for ml in met_result["user_metrics"]],
+            [[1, 1]]*4)
+        self.assertEqual(user_met_count_result[0]["bike"], 2)
+        self.assertAlmostEqual(user_met_dist_result[0]["bike"], 4305.02678, places=3)
+        self.assertAlmostEqual(user_met_dur_result[0]["bike"], 2388.97132, places=3)
+        self.assertAlmostEqual(user_met_spd_result[0]["bike"], 1.98726, places=3)
+
     def testCountTimestampPartialMissingLabels(self):
         self.entries = json.load(open("emission/tests/data/real_examples/shankari_2016-07-22"), object_hook = bju.object_hook)
         etc.setupRealExampleWithEntries(self)

--- a/emission/tests/netTests/TestMetricsConfirmedTripsPandas.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTripsPandas.py
@@ -2,8 +2,16 @@ import unittest
 import pandas as pd
 import numpy as np
 import logging
+import uuid
+import statistics
 
 import emission.storage.decorations.trip_queries as esdt
+import emission.storage.timeseries.abstract_timeseries as esta
+
+import emission.core.wrapper.trip as ecwt
+import emission.core.wrapper.entry as ecwe
+
+import emission.analysis.result.metrics.simple_metrics as earms
 
 class TestMetricsConfirmedTripsPandas(unittest.TestCase):
 
@@ -56,6 +64,42 @@ class TestMetricsConfirmedTripsPandas(unittest.TestCase):
 
         self.assertIn("mode_confirm", filled_expanded_test_df.columns)
         self.assertEqual(len(filled_expanded_test_df.mode_confirm), len(dummy_col))
+
+    def testGetSpeedsForTrip(self):
+        self.testUUID = uuid.uuid4()
+        self.ts = esta.TimeSeries.get_time_series(self.testUUID)
+        section1_speeds = list(range(0,10))
+        section2_speeds = list(range(5,15))
+        section3_speeds = list(range(10,20))
+
+        trip_entry = ecwe.Entry.create_entry(self.testUUID,
+                                "analysis/confirmed_trip",
+                                {}, create_id=True)
+        trip_entry_id = self.ts.insert(trip_entry)
+        section_entry_1 = ecwe.Entry.create_entry(self.testUUID,
+                                "analysis/cleaned_section",
+                                {"trip_id": trip_entry_id, "speeds": section1_speeds},
+                                create_id=True)
+        self.ts.insert(section_entry_1)
+        section_entry_2 = ecwe.Entry.create_entry(self.testUUID,
+                                "analysis/cleaned_section",
+                                {"trip_id": trip_entry_id, "speeds": section2_speeds},
+                                create_id=True)
+        self.ts.insert(section_entry_2)
+        section_entry_3 = ecwe.Entry.create_entry(self.testUUID,
+                                "analysis/cleaned_section",
+                                {"trip_id": trip_entry_id, "speeds": section3_speeds},
+                                create_id=True)
+        self.ts.insert(section_entry_3)
+
+        trip_df = pd.DataFrame([{"_id": trip_entry_id, "user_id": self.testUUID}])
+        self.assertEqual(len(trip_df), 1)
+        speeds_list = trip_df.apply(earms._get_speeds_for_trip, axis=1)
+        print(speeds_list.iloc[0])
+        self.assertEqual(len(speeds_list), 1)
+        self.assertEqual(len(speeds_list[0]), 3*10)
+        self.assertEqual(pd.Series(speeds_list[0]).dropna().median(),
+            statistics.median(section1_speeds + section2_speeds + section3_speeds))
 
 if __name__ == '__main__':
     import emission.tests.common as etc

--- a/emission/tests/netTests/TestMetricsConfirmedTripsPandas.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTripsPandas.py
@@ -72,27 +72,32 @@ class TestMetricsConfirmedTripsPandas(unittest.TestCase):
         section2_speeds = list(range(5,15))
         section3_speeds = list(range(10,20))
 
+        cltrip_entry = ecwe.Entry.create_entry(self.testUUID,
+                                "analysis/cleaned_trip",
+                                {}, create_id=True)
+        cltrip_entry_id = self.ts.insert(cltrip_entry)
         trip_entry = ecwe.Entry.create_entry(self.testUUID,
                                 "analysis/confirmed_trip",
-                                {}, create_id=True)
+                                {"cleaned_trip": cltrip_entry_id}, create_id=True)
         trip_entry_id = self.ts.insert(trip_entry)
         section_entry_1 = ecwe.Entry.create_entry(self.testUUID,
                                 "analysis/cleaned_section",
-                                {"trip_id": trip_entry_id, "speeds": section1_speeds},
+                                {"trip_id": cltrip_entry_id, "speeds": section1_speeds},
                                 create_id=True)
         self.ts.insert(section_entry_1)
         section_entry_2 = ecwe.Entry.create_entry(self.testUUID,
                                 "analysis/cleaned_section",
-                                {"trip_id": trip_entry_id, "speeds": section2_speeds},
+                                {"trip_id": cltrip_entry_id, "speeds": section2_speeds},
                                 create_id=True)
         self.ts.insert(section_entry_2)
         section_entry_3 = ecwe.Entry.create_entry(self.testUUID,
                                 "analysis/cleaned_section",
-                                {"trip_id": trip_entry_id, "speeds": section3_speeds},
+                                {"trip_id": cltrip_entry_id, "speeds": section3_speeds},
                                 create_id=True)
         self.ts.insert(section_entry_3)
 
-        trip_df = pd.DataFrame([{"_id": trip_entry_id, "user_id": self.testUUID}])
+        trip_df = pd.DataFrame([{"_id": trip_entry_id,
+            "cleaned_trip": cltrip_entry_id, "user_id": self.testUUID}])
         self.assertEqual(len(trip_df), 1)
         speeds_list = trip_df.apply(earms._get_speeds_for_trip, axis=1)
         print(speeds_list.iloc[0])


### PR DESCRIPTION
In https://github.com/e-mission/e-mission-server/pull/841
we added support for returning metrics based on confirmed trips.
This works for all the metrics that we support, except for median_speed, since
the trips don't have a list of speeds.

I first tried to fix this by adding a list of speeds to each trip, but was
worried about breaking the `ground_truth` comparison tests.

So for now, if we are returning `confirmed_trips`, and there is no `speed`
field, we concatenate the speeds lists from the sections to generate the speed
list for the trip.

+ additional pandas test to check the concatenation
+ additional metrics test that retrieves all kinds of metrics and ensures that
    we don't have a similar issue in the future