### PR TITLE
Replace median_speed by mean_speed

### DIFF
--- a/emission/analysis/result/metrics/simple_metrics.py
+++ b/emission/analysis/result/metrics/simple_metrics.py
@@ -14,7 +14,8 @@ def get_summary_fn(key):
         "count": get_count,
         "distance": get_distance,
         "duration": get_duration,
-        "median_speed": get_median_speed
+        "median_speed": get_median_speed,
+        "mean_speed": get_mean_speed
     }
     return summary_fn_map[key]
 
@@ -36,34 +37,15 @@ def get_duration(mode_section_grouped_df):
         ret_dict[mode] = float(mode_section_df.duration.sum())
     return ret_dict
 
+# Redirect from median to mean for backwards compatibility
+# TODO: Remove in Dec 2022
 def get_median_speed(mode_section_grouped_df):
+    return get_mean_speed(mode_section_grouped_df)
+
+def get_mean_speed(mode_section_grouped_df):
     ret_dict = {}
     for (mode, mode_section_df) in mode_section_grouped_df:
-        # print("while getting median speed %s, %s" % (mode, mode_section_df.columns))
-        if "speeds" in mode_section_df.columns:
-            speeds_list = mode_section_df.speeds
-        else:
-            # we are using the confirmed trips, which don't have the speed list
-            # let's get it by concatenating from the sections
-            speeds_list = mode_section_df.apply(_get_speeds_for_trip, axis=1)
-
-        # speeds series is a series with one row per section/trip where the
-        # value is the list of speeds in that section/trip
-        median_speeds = [pd.Series(sl).dropna().median() for sl
-                            in speeds_list]
-        mode_median = pd.Series(median_speeds).dropna().median()
-        if np.isnan(mode_median):
-            logging.debug("still found nan for mode %s, skipping")
-        else:
-            ret_dict[mode] = float(mode_median)
+        # mean_speeds is a series with one row per section/trip where the
+        # value is the mean speed (distance/duration) for that section/trip
+        ret_dict[mode] = float(mode_section_df.distance.sum() / mode_section_df.duration.sum())
     return ret_dict
-
-def _get_speeds_for_trip(trip_df_row):
-    import itertools
-    import emission.storage.decorations.trip_queries as esdt
-
-    section_list = esdt.get_cleaned_sections_for_trip(trip_df_row.user_id, trip_df_row.cleaned_trip)
-    logging.debug("Found %s matching sections for trip %s" % (len(section_list), trip_df_row._id))
-    speed_list_of_lists = [s["data"]["speeds"] for s in section_list]
-    speed_list = list(itertools.chain(*speed_list_of_lists))
-    return speed_list

--- a/emission/analysis/result/metrics/simple_metrics.py
+++ b/emission/analysis/result/metrics/simple_metrics.py
@@ -47,5 +47,10 @@ def get_mean_speed(mode_section_grouped_df):
     for (mode, mode_section_df) in mode_section_grouped_df:
         # mean_speeds is a series with one row per section/trip where the
         # value is the mean speed (distance/duration) for that section/trip
-        ret_dict[mode] = float(mode_section_df.distance.sum() / mode_section_df.duration.sum())
+        mean_speeds = mode_section_df.distance / mode_section_df.duration
+        mode_mean = mean_speeds.dropna().mean()
+        if np.isnan(mode_mean):
+            logging.debug("still found nan for mode %s, skipping")
+        else:
+            ret_dict[mode] = float(mode_mean)
     return ret_dict

--- a/emission/tests/netTests/TestMetricsConfirmedTrips.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTrips.py
@@ -83,12 +83,12 @@ class TestMetrics(unittest.TestCase):
     def testAllTimestampMetrics(self):
         met_result = metrics.summarize_by_timestamp(self.testUUID2,
                                                     self.jun_start_ts, self.jun_end_ts,
-                                       'd', ['count', 'distance', 'duration', 'median_speed'], True)
+                                       'd', ['count', 'distance', 'duration', 'median_speed', 'mean_speed'], True)
         logging.debug(met_result)
 
         self.assertEqual(list(met_result.keys()), ['aggregate_metrics', 'user_metrics'])
-        self.assertEqual(len(met_result["user_metrics"]), 4)
-        self.assertEqual(len(met_result["aggregate_metrics"]), 4)
+        self.assertEqual(len(met_result["user_metrics"]), 5)
+        self.assertEqual(len(met_result["aggregate_metrics"]), 5)
 
         user_met_count_result = met_result['user_metrics'][0]
         agg_met_count_result = met_result['aggregate_metrics'][0]
@@ -99,17 +99,21 @@ class TestMetrics(unittest.TestCase):
         user_met_dur_result = met_result['user_metrics'][2]
         agg_met_dur_result = met_result['aggregate_metrics'][2]
 
-        user_met_spd_result = met_result['user_metrics'][3]
-        agg_met_spd_result = met_result['aggregate_metrics'][3]
+        user_met_old_spd_result = met_result['user_metrics'][4]
+        agg_met_old_spd_result = met_result['aggregate_metrics'][4]
 
-        self.assertEqual([len(ml) for ml in met_result["user_metrics"]], [2]*4)
-        self.assertEqual([len(ml) for ml in met_result["aggregate_metrics"]], [3]*4)
+        user_met_spd_result = met_result['user_metrics'][4]
+        agg_met_spd_result = met_result['aggregate_metrics'][4]
+
+        self.assertEqual([len(ml) for ml in met_result["user_metrics"]], [2]*5)
+        self.assertEqual([len(ml) for ml in met_result["aggregate_metrics"]], [3]*5)
         self.assertEqual([[m.nUsers for m in ml] for ml in met_result["user_metrics"]],
-            [[1, 1]]*4)
+            [[1, 1]]*5)
         self.assertEqual(user_met_count_result[0]["label_bike"], 2)
         self.assertAlmostEqual(user_met_dist_result[0]["label_bike"], 4305.02678, places=3)
         self.assertAlmostEqual(user_met_dur_result[0]["label_bike"], 2388.97132, places=3)
-        self.assertAlmostEqual(user_met_spd_result[0]["label_bike"], 1.98726, places=3)
+        self.assertAlmostEqual(user_met_old_spd_result[0]["label_bike"], (4305.02678 / 2388.97132), places=3)
+        self.assertAlmostEqual(user_met_spd_result[0]["label_bike"], (4305.02678 / 2388.97132), places=3)
 
     def testCountTimestampPartialMissingLabels(self):
         self.entries = json.load(open("emission/tests/data/real_examples/shankari_2016-07-22"), object_hook = bju.object_hook)

--- a/emission/tests/netTests/TestMetricsConfirmedTrips.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTrips.py
@@ -112,8 +112,8 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(user_met_count_result[0]["label_bike"], 2)
         self.assertAlmostEqual(user_met_dist_result[0]["label_bike"], 4305.02678, places=3)
         self.assertAlmostEqual(user_met_dur_result[0]["label_bike"], 2388.97132, places=3)
-        self.assertAlmostEqual(user_met_old_spd_result[0]["label_bike"], (4305.02678 / 2388.97132), places=3)
-        self.assertAlmostEqual(user_met_spd_result[0]["label_bike"], (4305.02678 / 2388.97132), places=3)
+        self.assertAlmostEqual(user_met_old_spd_result[0]["label_bike"], 2.24535722467578, places=3)
+        self.assertAlmostEqual(user_met_spd_result[0]["label_bike"], 2.24535722467578, places=3)
 
     def testCountTimestampPartialMissingLabels(self):
         self.entries = json.load(open("emission/tests/data/real_examples/shankari_2016-07-22"), object_hook = bju.object_hook)

--- a/emission/tests/netTests/TestMetricsConfirmedTripsPandas.py
+++ b/emission/tests/netTests/TestMetricsConfirmedTripsPandas.py
@@ -65,47 +65,6 @@ class TestMetricsConfirmedTripsPandas(unittest.TestCase):
         self.assertIn("mode_confirm", filled_expanded_test_df.columns)
         self.assertEqual(len(filled_expanded_test_df.mode_confirm), len(dummy_col))
 
-    def testGetSpeedsForTrip(self):
-        self.testUUID = uuid.uuid4()
-        self.ts = esta.TimeSeries.get_time_series(self.testUUID)
-        section1_speeds = list(range(0,10))
-        section2_speeds = list(range(5,15))
-        section3_speeds = list(range(10,20))
-
-        cltrip_entry = ecwe.Entry.create_entry(self.testUUID,
-                                "analysis/cleaned_trip",
-                                {}, create_id=True)
-        cltrip_entry_id = self.ts.insert(cltrip_entry)
-        trip_entry = ecwe.Entry.create_entry(self.testUUID,
-                                "analysis/confirmed_trip",
-                                {"cleaned_trip": cltrip_entry_id}, create_id=True)
-        trip_entry_id = self.ts.insert(trip_entry)
-        section_entry_1 = ecwe.Entry.create_entry(self.testUUID,
-                                "analysis/cleaned_section",
-                                {"trip_id": cltrip_entry_id, "speeds": section1_speeds},
-                                create_id=True)
-        self.ts.insert(section_entry_1)
-        section_entry_2 = ecwe.Entry.create_entry(self.testUUID,
-                                "analysis/cleaned_section",
-                                {"trip_id": cltrip_entry_id, "speeds": section2_speeds},
-                                create_id=True)
-        self.ts.insert(section_entry_2)
-        section_entry_3 = ecwe.Entry.create_entry(self.testUUID,
-                                "analysis/cleaned_section",
-                                {"trip_id": cltrip_entry_id, "speeds": section3_speeds},
-                                create_id=True)
-        self.ts.insert(section_entry_3)
-
-        trip_df = pd.DataFrame([{"_id": trip_entry_id,
-            "cleaned_trip": cltrip_entry_id, "user_id": self.testUUID}])
-        self.assertEqual(len(trip_df), 1)
-        speeds_list = trip_df.apply(earms._get_speeds_for_trip, axis=1)
-        print(speeds_list.iloc[0])
-        self.assertEqual(len(speeds_list), 1)
-        self.assertEqual(len(speeds_list[0]), 3*10)
-        self.assertEqual(pd.Series(speeds_list[0]).dropna().median(),
-            statistics.median(section1_speeds + section2_speeds + section3_speeds))
-
 if __name__ == '__main__':
     import emission.tests.common as etc
     etc.configLogging()


### PR DESCRIPTION
Keep a redirect from median_speed to mean_speed for backward compatibility
We should remove this redirect in ~ 1 year.

We primarily use the median speed for the calorie calculation, but:
- it is not clear that we need the median speed
- it is harder to calculate for trip-based entities
https://github.com/e-mission/e-mission-docs/issues/688#issuecomment-998466419

So we switch to the mean speed instead. This is currently the grand mean (sum
of all distances / sum of all durations), but we can fairly easily change it to
mean of means if we want.

+ remove _get_speeds_for_trip
+ fix answers in `testAllTimestampMetrics`
+ change `testAllTimestampMetrics` to retrieve both mean and median speeds for now

Testing done:
`testAllTimestampMetrics` passes