### PR TITLE
Create a new function to expand final labels

### DIFF
--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -103,7 +103,8 @@ def group_by_local_date(user_id, from_dt, to_dt, freq, summary_fn_list):
         }
 
     groupby_arr = _get_local_group_by(freq)
-    time_grouped_df = section_df.groupby(groupby_arr)
+    adjusted_df = adjust_for_user_inputs_if_needed(section_df)
+    time_grouped_df = adjusted_df.groupby(groupby_arr)
     local_dt_fill_fn = _get_local_key_to_fill_fn(freq)
     return {
         "last_ts_processed": section_df.iloc[-1].start_ts,

--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -137,7 +137,7 @@ def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
         result_section_key = eac.get_section_key_for_analysis_results()
         if result_section_key == "analysis/confirmed_trip":
             import emission.storage.decorations.trip_queries as esdt
-            section_group_df = esdt.expand_userinputs(section_group_df)
+            section_group_df = esdt.expand_finallabels(section_group_df)
             # if none of the trips in the time grouping are labeled,
             # we add a dummy column
             # pandas checks in TestMetricsConfirmedTripsPandas.testPandasConcatModeConfirm

--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -56,9 +56,10 @@ def group_by_timestamp(user_id, start_ts, end_ts, freq, summary_fn_list):
     logging.debug("first row is %s" % section_df.iloc[0])
     secs_to_nanos = lambda x: x * 10 ** 9
     section_df['start_dt'] = pd.to_datetime(secs_to_nanos(section_df.start_ts))
-    time_grouped_df = section_df.groupby(pd.Grouper(freq=freq, key='start_dt'))
+    adjusted_df = adjust_for_user_inputs_if_needed(section_df)
+    time_grouped_df = adjusted_df.groupby(pd.Grouper(freq=freq, key='start_dt'))
     return {
-        "last_ts_processed": section_df.iloc[-1].start_ts,
+        "last_ts_processed": adjusted_df.iloc[-1].start_ts,
         "result": [grouped_to_summary(time_grouped_df, timestamp_fill_times, summary_fn)
                    for summary_fn in summary_fn_list]
     }
@@ -125,6 +126,32 @@ def fix_int64_key_if_needed(key):
     else:
         return key
 
+def adjust_for_user_inputs_if_needed(section_df):
+    result_section_key = eac.get_section_key_for_analysis_results()
+    if result_section_key == "analysis/confirmed_trip":
+        import emission.storage.decorations.trip_queries as esdt
+        adjusted_df = esdt.expand_finallabels(section_df)
+        # if none of the trips in the time grouping are labeled,
+        # we add a dummy column
+        # pandas checks in TestMetricsConfirmedTripsPandas.testPandasConcatModeConfirm
+        if "mode_confirm" not in adjusted_df.columns:
+            # If we don't reset the index and the index doesn't start from 1,
+            # the concat will end up with additional rows
+            # see TestMetricsConfirmedTripsPandas.testPandasConcatModeConfirm
+            adjusted_df.reset_index(inplace=True)
+            dummy_col = pd.Series([np.NaN] * len(adjusted_df), name="mode_confirm")
+            adjusted_df = pd.concat([adjusted_df, dummy_col],
+                axis = 1, copy=True)
+        # pandas ignores NaN entries while grouping
+        # (see TestMetricsConfirmedTripsPandas.testPandasNaNHandlingAndWorkaround)
+        # so we convert them to "unlabeled" first
+        adjusted_df.fillna("unlabeled", inplace=True)
+        logging.debug("After replacing unlabeled, we get %s " % list(adjusted_df.mode_confirm))
+        return adjusted_df
+    else:
+        return section_df
+
+
 def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
     ret_list = []
     # When we group by a time range, the key is the end of the range
@@ -136,24 +163,6 @@ def grouped_to_summary(time_grouped_df, key_to_fill_fn, summary_fn):
         curr_msts.nUsers = len(section_group_df.user_id.unique())
         result_section_key = eac.get_section_key_for_analysis_results()
         if result_section_key == "analysis/confirmed_trip":
-            import emission.storage.decorations.trip_queries as esdt
-            section_group_df = esdt.expand_finallabels(section_group_df)
-            # if none of the trips in the time grouping are labeled,
-            # we add a dummy column
-            # pandas checks in TestMetricsConfirmedTripsPandas.testPandasConcatModeConfirm
-            if "mode_confirm" not in section_group_df.columns:
-                # If we don't reset the index and the index doesn't start from 1,
-                # the concat will end up with additional rows
-                # see TestMetricsConfirmedTripsPandas.testPandasConcatModeConfirm
-                section_group_df.reset_index(inplace=True)
-                dummy_col = pd.Series([np.NaN] * len(section_group_df), name="mode_confirm")
-                section_group_df = pd.concat([section_group_df, dummy_col],
-                    axis = 1, copy=True)
-            # pandas ignores NaN entries while grouping
-            # (see TestMetricsConfirmedTripsPandas.testPandasNaNHandlingAndWorkaround)
-            # so we convert them to "unlabeled" first
-            section_group_df.fillna("unlabeled", inplace=True)
-            logging.debug("After replacing unlabeled, we get %s " % list(section_group_df.mode_confirm))
             grouping_field = "mode_confirm"
         else:
             grouping_field = "sensed_mode"

--- a/emission/storage/decorations/trip_queries.py
+++ b/emission/storage/decorations/trip_queries.py
@@ -207,11 +207,11 @@ def filter_labeled_trips(mixed_trip_df):
 
 def expand_userinputs(labeled_ct):
     """
-    labeled_ct: a dataframe that contains only labeled trips
+    labeled_ct: a dataframe that contains potentially mixed trips.
     Returns a dataframe with the labels expanded into the main dataframe
     If the labels are simple, single level kv pairs (e.g. {mode_confirm:
     bike}), the expanded columns can be indexed very simply, like the other
-    columns in the dataframe.
+    columns in the dataframe. Trips without labels are represented by N/A
 
     TODO: Replace by pandas.io.json.json_normalize?
     TODO: Currently duplicated from 
@@ -232,3 +232,83 @@ def expand_userinputs(labeled_ct):
     logging.debug(expanded_ct.head())
     return expanded_ct
 
+def has_final_labels(confirmed_trip_data):
+    return (confirmed_trip_data["user_input"] != {}
+            or confirmed_trip_data["expectation"]["to_label"] == False)
+
+def get_max_prob_label(inferred_label_list):
+    # Two columns: "labels" and "p"
+    label_prob_df = pd.DataFrame(inferred_label_list)
+    # logging.debug(label_prob_df)
+    # idxmax returns the index corresponding to the max data value in each column
+    max_p_idx = label_prob_df.p.idxmax()
+    # logging.debug(max_p_idx)
+    # now we look up the labels for that index
+    return label_prob_df.loc[max_p_idx].labels
+
+def expand_finallabels(labeled_ct):
+    """
+    labeled_ct: a dataframe that contains potentially mixed trips.
+    Returns a dataframe with the user input labels and the high confidence
+    inferred labels expanded into the main dataframe.  If the labels are
+    simple, single level kv pairs (e.g. {mode_confirm: bike}), the expanded columns
+    can be indexed very simply, like the other columns in the dataframe. Trips
+    without labels are represented by N/A
+    """
+    if len(labeled_ct) == 0:
+        return labeled_ct
+    user_input_only = pd.DataFrame(labeled_ct.user_input.to_list(), index=labeled_ct.index)
+    # Drop entries that are blank so we don't end up with duplicate entries in the concatenated dataframe.
+    # without this change, concat might involve N/A rows from user entries,
+    # inserted because the index is specified manually
+    # then if they have high confidence entries, we will end up with
+    # duplicated entries for N/A and the yellow labels
+    user_input_only.dropna('index', how="all", inplace=True)
+    logging.debug("user_input_only %s" % user_input_only.head())
+
+    # see testExpandFinalLabelsPandasFunctionsNestedPostFilter for a step by step
+    # walkthrough of how this section works. Note that
+    # testExpandFinalLabelsPandasFunctionsNestedPostFilter has an alternate
+    # implementation that we don't choose because it generates a UserWarning
+
+    # Note that we could have entries that have both user inputs and high
+    # confidence inferred values. This could happen if the user chooses to go
+    # into "All Labels" and label high-confidence values. That's why the
+    # algorithm
+    # https://github.com/e-mission/e-mission-docs/issues/688#issuecomment-1000981037
+    # specifies that we look for inferred values only if the user input does
+    # not exist
+    expectation_expansion = pd.DataFrame(labeled_ct.expectation.to_list(), index=labeled_ct.index)
+    high_confidence_no_userinput_df = labeled_ct[
+        (labeled_ct.user_input == {}) & (expectation_expansion.to_label == False)
+    ]
+    high_confidence_no_userinput_df.dropna('index', how="all", inplace=True)
+    if len(high_confidence_no_userinput_df) > 0:
+        high_confidence_inferred_labels = high_confidence_no_userinput_df.inferred_labels
+        high_confidence_max_p_inferred_labels = high_confidence_inferred_labels.apply(get_max_prob_label)
+        high_confidence_max_p_inferred_labels_only = pd.DataFrame(
+                high_confidence_max_p_inferred_labels.to_list(),
+                index=high_confidence_inferred_labels.index)
+        logging.debug("high confidence inferred %s" % high_confidence_max_p_inferred_labels_only.head())
+
+        assert pd.Series(labeled_ct.loc[
+                high_confidence_max_p_inferred_labels_only.index].user_input == {}).all(), \
+            ("Did not filter out all user inputs before expanding high confidence labels %s" %
+                labeled_ct.loc[high_confidence_max_p_inferred_labels_only.index].user_input)
+    else:
+        high_confidence_max_p_inferred_labels_only = pd.DataFrame()
+
+
+    # see testExpandFinalLabelsPandasFunctions for a step by step walkthrough of this section
+    naive_concat = pd.concat([user_input_only, high_confidence_max_p_inferred_labels_only], axis=0)
+    print(naive_concat)
+    label_only = naive_concat.reindex(labeled_ct.index)
+
+    expanded_ct = pd.concat([labeled_ct, label_only], axis=1)
+    assert len(expanded_ct) == len(labeled_ct), \
+        ("Mismatch after expanding labels, expanded_ct.rows = %s != labeled_ct.columns %s" %
+            (len(expanded_ct), len(labeled_ct)))
+    logging.debug("After expanding, columns went from %s -> %s" %
+        (len(labeled_ct.columns), len(expanded_ct.columns)))
+    logging.debug(expanded_ct.head())
+    return expanded_ct

--- a/emission/storage/decorations/trip_queries.py
+++ b/emission/storage/decorations/trip_queries.py
@@ -301,7 +301,7 @@ def expand_finallabels(labeled_ct):
 
     # see testExpandFinalLabelsPandasFunctions for a step by step walkthrough of this section
     naive_concat = pd.concat([user_input_only, high_confidence_max_p_inferred_labels_only], axis=0)
-    print(naive_concat)
+    # print(naive_concat)
     label_only = naive_concat.reindex(labeled_ct.index)
 
     expanded_ct = pd.concat([labeled_ct, label_only], axis=1)

--- a/emission/tests/storageTests/TestTripQueries.py
+++ b/emission/tests/storageTests/TestTripQueries.py
@@ -14,6 +14,8 @@ import json
 import bson.json_util as bju
 import numpy as np
 import copy
+import pandas as pd
+import numpy as np
 
 # Our imports
 import emission.storage.decorations.trip_queries as esdt
@@ -30,6 +32,7 @@ import emission.core.wrapper.rawtrip as ecwrt
 import emission.core.wrapper.section as ecwc
 import emission.core.wrapper.stop as ecws
 import emission.core.wrapper.entry as ecwe
+import emission.core.wrapper.confirmedtrip as ecwct
 
 import emission.tests.storageTests.analysis_ts_common as etsa
 import emission.tests.common as etc
@@ -294,7 +297,7 @@ class TestTripQueries(unittest.TestCase):
              esdt.filter_labeled_trips(None)
 
         # Test valid inputs
-        
+
         # no labeled
         test_unlabeled_df = pd.DataFrame([{"user_input": {}}] * 3)
         self.assertTrue(esdt.filter_labeled_trips(test_unlabeled_df).empty)
@@ -321,7 +324,7 @@ class TestTripQueries(unittest.TestCase):
              esdt.expand_userinputs(None)
 
         # Test valid inputs
-        
+
         # no labeled trips; no additional columns added
         logging.debug("About to test unlabeled")
         test_unlabeled_df = pd.DataFrame([{"user_input": {}}] * 3)
@@ -367,6 +370,352 @@ class TestTripQueries(unittest.TestCase):
         # The last three entries have N/A for all expanded values
         logging.debug(pd.isna(actual_result.loc[6:,["mode_confirm", "purpose_confirm", "replaced_mode"]]))
         self.assertTrue(pd.isna(actual_result.loc[6:,["mode_confirm", "purpose_confirm", "replaced_mode"]].to_numpy().flatten()).all())
+
+    def testHasFinalLabels(self):
+        import pandas as pd
+
+        # no user input, no high-confidence inference (yellow "To Label" case)
+        self.assertFalse(esdt.has_final_labels(ecwct.Confirmedtrip({
+            "user_input": {},
+            "expectation": {"to_label": True}
+        })))
+
+        # no user input, but we do have a high-confidence inference (yellow
+        # "All unlabeled" case)
+        self.assertTrue(esdt.has_final_labels(ecwct.Confirmedtrip({
+            "user_input": {},
+            "expectation": {"to_label": False}
+        })))
+
+        # user input without a high-confidence inference (red -> green label case)
+        self.assertTrue(esdt.has_final_labels(ecwct.Confirmedtrip({
+            "user_input": {"mode_confirm": "drove_alone", "purpose_confirm": "work"},
+            "expectation": {"to_label": True}
+        })))
+
+        # user input with a high-confidence inference (yellow -> green label case)
+        self.assertTrue(esdt.has_final_labels(ecwct.Confirmedtrip({
+            "user_input": {"mode_confirm": "drove_alone", "purpose_confirm": "work"},
+            "expectation": {"to_label": False}
+        })))
+
+    def testGetMaxProbLabel(self):
+        self.assertEqual(esdt.get_max_prob_label([
+            {'labels': {'mc': 30, 'pc': 40}, 'p': 0.9}]), {'mc': 30, 'pc': 40})
+        self.assertEqual(esdt.get_max_prob_label([
+            {'labels': {'mc': 30, 'pc': 40}, 'p': 0.08249999999999999},
+            {'labels': {'mc': 50, 'pc': 60}, 'p': 0.9075}]),
+            {'mc': 50, 'pc': 60})
+        self.assertEqual(esdt.get_max_prob_label([
+            {'labels': {'mc': 10, 'pc': 20}, 'p': 0.043040248408698994},
+            {'labels': {'mc': 31, 'pc': 41}, 'p': 0.9038452165826789},
+            {'labels': {'mc': 50, 'pc': 60 }, 'p': 0.043040248408698994}]),
+            {'mc': 31, 'pc': 41})
+
+    def testExpandFinalLabelsPandasFunctions(self):
+        import pandas as pd
+        all_df = pd.DataFrame([
+            {"trip": "t1", "mc": 10, "pc": 20},
+            {"trip": "t2", "mc": 30, "pc": 40},
+            {"trip": "t3", "mc": 10, "pc": 20},
+            {"trip": "t4", "mc": 30, "pc": 40},
+            {"trip": "t5", "mc": 10, "pc": 20},
+            {"trip": "t6", "mc": 30, "pc": 40},
+            {"trip": "t7", "mc": 10, "pc": 20}])
+
+        labeled_df = all_df[all_df.mc == 10]
+        inferred_df = all_df[all_df.mc == 30]
+
+        logging.debug("Testing naive vs. reindexed concat")
+        # Naive concat will not concatenate values correctly because the
+        # indices will be out of order
+        naive_concat = pd.concat([labeled_df, inferred_df], axis=0)
+        logging.debug(naive_concat)
+        try:
+            pd.testing.assert_index_equal(naive_concat.index, all_df.index)
+        except AssertionError as e:
+            logging.info(e)
+
+        # We need to reindex so that the values are back in order
+        correct_concat = naive_concat.reindex(all_df.index)
+        logging.debug(correct_concat)
+        pd.testing.assert_index_equal(correct_concat.index, all_df.index)
+
+        logging.debug("Testing concat with one dataframe empty")
+        labeled_df = all_df[all_df.mc == 100]
+        inferred_df = all_df[all_df.mc == 30]
+        naive_concat = pd.concat([labeled_df, inferred_df], axis=0)
+        logging.debug(naive_concat)
+        correct_concat = naive_concat.reindex(all_df.index)
+        logging.debug(correct_concat)
+
+        logging.debug("Testing concat with one dataframe empty and forced index")
+        labeled_df = all_df[all_df.mc == 100].reindex(all_df.index)
+        inferred_df = all_df[all_df.mc == 30]
+        naive_concat = pd.concat([labeled_df, inferred_df], axis=0)
+        logging.debug(naive_concat)
+        correct_concat = naive_concat.reindex(all_df.index)
+        logging.debug(correct_concat)
+
+    def testExpandFinalLabelsPandasFunctionsNestedPostFilter(self):
+        import pandas as pd
+        nested_df = pd.DataFrame([
+            {"trip": "t1", "user_input": {},
+                "expectation" : {"to_label": True},
+                "inferred_labels": [{"labels": {"mc": 10, "pc": 20}, "p": 0.2}]},
+            {"trip": "t2", "user_input": {},
+                "expectation" : {"to_label": False},
+                "inferred_labels": [{"labels": {"mc": 30, "pc": 40}, "p": 0.9}]},
+            {"trip": "t3", "user_input": {},
+                "expectation" : {"to_label": False},
+                "inferred_labels": [{"labels": {"mc": 50, "pc": 60}, "p": 0.9},
+                                    {"labels": {"mc": 70, "pc": 80}, "p": 0.1}]},
+            {"trip": "t4", "user_input": {"mc": 100, "pc": 200},
+                "expectation" : {"to_label": False},
+                "inferred_labels": [{"labels": {"mc": 90, "pc": 91}, "p": 0.1},
+                                    {"labels": {"mc": 92, "pc": 93}, "p": 0.9}]}
+        ])
+
+        # logging.debug(nested_df.expectation)
+        # we cannot use a nested query like this. Instead, let's expand the
+        # expectation and then do some merging
+        self.assertEqual(len(nested_df[nested_df.expectation == {"to_label" == False}]), 0)
+        expectation_expansion = pd.DataFrame(nested_df.expectation.to_list(), index=nested_df.index)
+        # logging.debug(expectation_expansion)
+        # logging.debug(nested_df[expectation_expansion.to_label == False])
+        self.assertEqual(nested_df[expectation_expansion.to_label == False].index.to_list(), [1, 2, 3])
+        self.assertEqual(nested_df[expectation_expansion.to_label == False].trip.to_list(), ["t2", "t3", "t4"])
+        logging.debug(nested_df[expectation_expansion.to_label == False].inferred_labels)
+        high_confidence_inferred_labels = nested_df[expectation_expansion.to_label == False].inferred_labels
+        # logging.debug(pd.DataFrame(high_confidence_inferred_labels))
+        high_confidence_max_p_inferred_labels = high_confidence_inferred_labels.apply(esdt.get_max_prob_label)
+        logging.debug(high_confidence_max_p_inferred_labels)
+        pd.testing.assert_series_equal(high_confidence_max_p_inferred_labels,
+            pd.Series([{'mc': 30, 'pc': 40}, {'mc': 50, 'pc': 60}, {'mc': 92, 'pc': 93}],
+                index=range(1,4),
+                name="inferred_labels"))
+        high_confidence_max_p_inferred_labels_only = \
+            pd.DataFrame(high_confidence_max_p_inferred_labels.to_list(),
+            index=high_confidence_inferred_labels.index)
+        logging.debug(high_confidence_max_p_inferred_labels_only)
+
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.mc.to_list(),
+            [30, 50, 92])
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.pc.to_list(),
+            [40, 60, 93])
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.index.to_list(),
+            [1, 2, 3])
+
+        # but t4 already has a user input, so we need to filter it out
+        # Note that we could have entries that have both user inputs and high
+        # confidence inferred values. This could happen if the user chooses to go
+        # into "All Labels" and label high-confidence values.
+        high_confidence_max_p_inferred_labels_only = \
+            high_confidence_max_p_inferred_labels_only[nested_df.user_input == {}]
+        logging.debug(high_confidence_max_p_inferred_labels_only)
+
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.mc.to_list(),
+            [30, 50])
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.pc.to_list(),
+            [40, 60])
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.index.to_list(),
+            [1, 2])
+
+    def testExpandFinalLabelsPandasFunctionsNestedPreFilter(self):
+        import pandas as pd
+        nested_df = pd.DataFrame([
+            {"trip": "t1", "user_input": {},
+                "expectation" : {"to_label": True},
+                "inferred_labels": [{"labels": {"mc": 10, "pc": 20}, "p": 0.2}]},
+            {"trip": "t2", "user_input": {},
+                "expectation" : {"to_label": False},
+                "inferred_labels": [{"labels": {"mc": 30, "pc": 40}, "p": 0.9}]},
+            {"trip": "t3", "user_input": {},
+                "expectation" : {"to_label": False},
+                "inferred_labels": [{"labels": {"mc": 50, "pc": 60}, "p": 0.9},
+                                    {"labels": {"mc": 70, "pc": 80}, "p": 0.1}]},
+            {"trip": "t4", "user_input": {"mc": 100, "pc": 200},
+                "expectation" : {"to_label": False},
+                "inferred_labels": [{"labels": {"mc": 90, "pc": 91}, "p": 0.1},
+                                    {"labels": {"mc": 92, "pc": 93}, "p": 0.9}]}
+        ])
+
+        # logging.debug(nested_df.expectation)
+        # we cannot use a nested query like this. Instead, let's expand the
+        # expectation and then do some merging
+        self.assertEqual(len(nested_df[nested_df.expectation == {"to_label" == False}]), 0)
+        expectation_expansion = pd.DataFrame(nested_df.expectation.to_list(), index=nested_df.index)
+        # logging.debug(expectation_expansion)
+        # logging.debug(nested_df[expectation_expansion.to_label == False])
+        # logging.debug(nested_df.user_input == {})
+        # logging.debug(expectation_expansion.to_label == False)
+
+        # t4 already has a user input, so we need to filter it out
+        # here, we filter first before the expansion
+        self.assertEqual(nested_df[(nested_df.user_input == {}) & (expectation_expansion.to_label == False)].index.to_list(), [1, 2])
+        self.assertEqual(nested_df[(nested_df.user_input == {}) & (expectation_expansion.to_label == False)].trip.to_list(), ["t2", "t3"])
+        logging.debug(nested_df[(nested_df.user_input == {}) & (expectation_expansion.to_label == False)].inferred_labels)
+        high_confidence_inferred_labels = nested_df[(nested_df.user_input == {}) & (expectation_expansion.to_label == False)].inferred_labels
+        # logging.debug(pd.DataFrame(high_confidence_inferred_labels))
+        high_confidence_max_p_inferred_labels = high_confidence_inferred_labels.apply(esdt.get_max_prob_label)
+        logging.debug(high_confidence_max_p_inferred_labels)
+        pd.testing.assert_series_equal(high_confidence_max_p_inferred_labels,
+            pd.Series([{'mc': 30, 'pc': 40}, {'mc': 50, 'pc': 60}],
+                index=range(1,3),
+                name="inferred_labels"))
+        high_confidence_max_p_inferred_labels_only = \
+            pd.DataFrame(high_confidence_max_p_inferred_labels.to_list(),
+            index=high_confidence_inferred_labels.index)
+        logging.debug(high_confidence_max_p_inferred_labels_only)
+
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.mc.to_list(),
+            [30, 50])
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.pc.to_list(),
+            [40, 60])
+        self.assertEqual(high_confidence_max_p_inferred_labels_only.index.to_list(),
+            [1, 2])
+
+        # Check that none of the high confidence expanded labels has a user input
+        self.assertTrue(pd.Series(nested_df.loc[
+            high_confidence_max_p_inferred_labels_only.index].user_input == {}).all())
+
+    def testExpandFinalLabels(self):
+
+        # Test invalid inputs
+        pd.testing.assert_frame_equal(esdt.expand_finallabels(pd.DataFrame()),
+            pd.DataFrame())
+        with self.assertRaises(TypeError):
+             esdt.expand_finallabels(None)
+
+        # Test valid inputs
+
+        # no labeled trips
+
+        # all red trips; no additional columns added
+        logging.debug("About to test unlabeled + uninferred")
+        test_unlabeled_df = pd.DataFrame([{"user_input": {},
+            "expectation": {"to_label": True}}] * 3)
+        pd.testing.assert_frame_equal(esdt.expand_finallabels(test_unlabeled_df),
+            test_unlabeled_df)
+
+        # all high-confidence yellow; mode_confirm and purpose_confirm columns added
+        logging.debug("About to test unlabeled + all inferred")
+        test_unlabeled_df = pd.DataFrame([{"user_input": {},
+            "expectation": {"to_label": False},
+            "inferred_labels": [{"labels": {"mode_confirm": "walk",
+                "purpose_confirm": "exercise"}, "p": 0.9}]}
+        ] * 3)
+        test_exp_result = pd.concat([test_unlabeled_df, pd.DataFrame([
+            {"mode_confirm": "walk", "purpose_confirm" : "exercise"}] * 3)], axis=1)
+        pd.testing.assert_frame_equal(esdt.expand_finallabels(test_unlabeled_df),
+            test_exp_result)
+
+        # all green; labeled from scratch
+        test_labeled_df = pd.DataFrame([{
+            "user_input": {"mode_confirm": "bike", "purpose_confirm": "shopping"},
+            "expectation": {"to_label": True}}] * 3)
+        test_exp_result = pd.concat([test_labeled_df, pd.DataFrame([
+            {"mode_confirm": "bike", "purpose_confirm" : "shopping"}] * 3)], axis=1)
+        # logging.debug("expected result index = %s" % test_exp_result.index)
+        # logging.debug("actual result index = %s" % esdt.expand_finallabels(test_labeled_df).index)
+        pd.testing.assert_frame_equal(esdt.expand_finallabels(test_labeled_df),
+            test_exp_result)
+
+        # all green; labeled from high confidence trips; user input is retained
+        test_labeled_df = pd.DataFrame([{
+            "user_input": {"mode_confirm": "bike", "purpose_confirm": "shopping"},
+            "expectation": {"to_label": False},
+            "inferred_labels": [{"labels": {"mode_confirm": "walk",
+                "purpose_confirm": "exercise"}, "p": 0.9}]}
+        ] * 3)
+        test_exp_result = pd.concat([test_labeled_df, pd.DataFrame([
+            {"mode_confirm": "bike", "purpose_confirm" : "shopping"}] * 3)], axis=1)
+        logging.debug(test_exp_result)
+        pd.testing.assert_frame_equal(esdt.expand_finallabels(test_labeled_df),
+            test_exp_result)
+
+        # all green; labeled from low confidence trips; user input is retained
+        test_labeled_df = pd.DataFrame([{
+            "user_input": {"mode_confirm": "bike", "purpose_confirm": "shopping"},
+            "expectation": {"to_label": True},
+            "inferred_labels": [{"labels": {"mode_confirm": "walk",
+                "purpose_confirm": "exercise"}, "p": 0.9}]}
+        ] * 3)
+        test_exp_result = pd.concat([test_labeled_df, pd.DataFrame([
+            {"mode_confirm": "bike", "purpose_confirm" : "shopping"}] * 3)], axis=1)
+        logging.debug(test_exp_result)
+        pd.testing.assert_frame_equal(esdt.expand_finallabels(test_labeled_df),
+            test_exp_result)
+
+        # mixed labeled; three rows user input, three rows high confidence, three rows
+        # low confidence, three rows unlabeled. additional columns added but
+        # with some N/A
+        test_mixed_df = pd.DataFrame(
+            [{"user_input": {"mode_confirm": "bike", "purpose_confirm": "shopping"},
+            "expectation": {"to_label": True}}] * 3 +
+            [{"user_input": {}, "expectation": {"to_label": False},
+            "inferred_labels":
+                [{"labels": {"mode_confirm": "bike", "purpose_confirm": "shopping"}, "p": 0.1},
+                {"labels": {"mode_confirm": "walk", "purpose_confirm": "exercise"}, "p": 0.9}]
+            }] * 3 +
+            [{"user_input": {}, "expectation": {"to_label": True},
+            "inferred_labels":
+                [{"labels": {"mode_confirm": "bike", "purpose_confirm": "shopping"}, "p": 0.2},
+                {"labels": {"mode_confirm": "walk", "purpose_confirm": "exercise"}, "p": 0.4},
+                {"labels": {"mode_confirm": "drove_alone", "purpose_confirm": "work"}, "p": 0.4}]
+            }] * 3 +
+            [{"user_input": {}, "expectation": {"to_label": True}}] * 3)
+        result_df = pd.concat([test_mixed_df, pd.DataFrame(
+        # Three green labels
+            [{"mode_confirm": "bike", "purpose_confirm" : "shopping"}] * 3 +
+        # Three high confidence yellow labels
+            [{"mode_confirm": "walk", "purpose_confirm" : "exercise"}] * 3 +
+        # Three low confidence yellow labels
+            [{}] * 3 +
+        # Three red labels
+            [{}] * 3)], axis=1)
+        actual_result = esdt.expand_finallabels(test_mixed_df)
+        pd.testing.assert_frame_equal(actual_result, result_df)
+        logging.debug(actual_result[["mode_confirm", "purpose_confirm"]])
+        # The first three entries are bike
+        self.assertEqual(actual_result.loc[0:2, "mode_confirm"].to_list(),
+            ["bike"] * 3)
+        # The next three entries are walk
+        self.assertEqual(actual_result.loc[3:5, "mode_confirm"].to_list(),
+            ["walk"] * 3)
+        # The last six entries are N/A since they are red or low confidence
+        # yellow labels
+        self.assertTrue(pd.isna(actual_result.loc[6:12, "mode_confirm"]).all())
+
+        # mixed labeled with different columns; additional columns added but with some N/A
+        test_mixed_df = pd.DataFrame(
+            [{"user_input": {"mode_confirm": "bike", "purpose_confirm": "shopping"},
+            "expectation": {"to_label": True}}] * 3 +
+            [{"user_input": {},
+            "expectation": {"to_label": False},
+            "inferred_labels": [{"labels": {"mode_confirm": "bike", "purpose_confirm": "shopping", "replaced_mode": "running"}, "p": 0.9}]
+            }] * 3 +
+            [{"user_input": {}, "expectation": {"to_label": True}}] * 3)
+        result_df = pd.concat([test_mixed_df, pd.DataFrame(
+        # Three partially expanded entries
+            [{"mode_confirm": "bike", "purpose_confirm" : "shopping"}] * 3 +
+        # Three fully expanded entries
+            [{"mode_confirm": "bike", "purpose_confirm" : "shopping", "replaced_mode": "running"}] * 3 +
+        # Three partial entries
+            [{}] * 3)], axis=1)
+        actual_result = esdt.expand_finallabels(test_mixed_df)
+        pd.testing.assert_frame_equal(actual_result, result_df)
+        # The first three entries have N/A replaced mode
+        logging.debug(pd.isna(actual_result.loc[:2, "replaced_mode"]))
+        self.assertTrue(pd.isna(actual_result.loc[:2, "replaced_mode"]).all())
+        # The middle three entries have "running" replaced mode
+        logging.debug(actual_result.loc[3:5, "replaced_mode"])
+        self.assertEqual(actual_result.loc[3:5, "replaced_mode"].to_list(), ["running"] * 3)
+        # The last three entries have N/A for all expanded values
+        logging.debug(pd.isna(actual_result.loc[6:,["mode_confirm", "purpose_confirm", "replaced_mode"]]))
+        self.assertTrue(pd.isna(actual_result.loc[6:,["mode_confirm", "purpose_confirm", "replaced_mode"]].to_numpy().flatten()).all())
+
+
 
 if __name__ == '__main__':
     import emission.tests.common as etc

--- a/emission/tests/storageTests/TestTripQueries.py
+++ b/emission/tests/storageTests/TestTripQueries.py
@@ -445,13 +445,19 @@ class TestTripQueries(unittest.TestCase):
         labeled_df = all_df[all_df.mc == 100]
         inferred_df = all_df[all_df.mc == 30]
         naive_concat = pd.concat([labeled_df, inferred_df], axis=0)
-        logging.debug(naive_concat)
-        correct_concat = naive_concat.reindex(all_df.index)
-        logging.debug(correct_concat)
+        # The naive re-index fails with the error
+        # ValueError: cannot reindex from a duplicate axis
+        # since we have N/A entries for the labeled df entries
+        # We need to drop the N/A first as seen below
+        try:
+            correct_concat = naive_concat.reindex(all_df.index)
+        except ValueError as e:
+            logging.info(e)
 
         logging.debug("Testing concat with one dataframe empty and forced index")
         labeled_df = all_df[all_df.mc == 100].reindex(all_df.index)
         inferred_df = all_df[all_df.mc == 30]
+        labeled_df.dropna('index', how="all", inplace=True)
         naive_concat = pd.concat([labeled_df, inferred_df], axis=0)
         logging.debug(naive_concat)
         correct_concat = naive_concat.reindex(all_df.index)


### PR DESCRIPTION
This will expand the user labels if they exist, and expand the highest
probability inferred label if we did not prompt the user.

Basically, this is now consistent with
https://github.com/e-mission/e-mission-docs/issues/688#issuecomment-1000981037

There were some minor trickinesses working with this data structure and pandas.
- We had to expand the expectation field to filter by to_label and then
- We had to create a separate dataframe for the inferred labels and the apply a
  custom filter to them to pick the one with the max probability
- We had to ensure that rows didn't appear twice - i.e. once for user inputs
  and once for inferred labels. This is true even if the user_inputs were not
  filled out; without changes, we would end up with both N/A and the inferred
  label for the same row.

And we had to keep the indices constant throughout these changes.
Added multiple tests, both of the individual pandas steps and the complete
function to test this fairly complex piece of code.

Testing done:
- Ran the newly added tests

Next steps:
- Change the metrics code and the leaderboard to use the new functions