### PR TITLE
Create a dataframe version of has_final_labels

### DIFF
--- a/emission/storage/decorations/trip_queries.py
+++ b/emission/storage/decorations/trip_queries.py
@@ -236,6 +236,15 @@ def has_final_labels(confirmed_trip_data):
     return (confirmed_trip_data["user_input"] != {}
             or confirmed_trip_data["expectation"]["to_label"] == False)
 
+# Create an alternate method to work on the dataframe column-wise
+# instead of iterating over each individual row for improved performance
+def has_final_labels_df(df):
+    # print(df.expectation)
+    # print(pd.DataFrame(df.expectation.to_list(), index=df.index))
+    to_list_series = pd.DataFrame(df.expectation.to_list(), index=df.index).to_label
+    return df[(df.user_input != {})
+            | (to_list_series == False)]
+
 def get_max_prob_label(inferred_label_list):
     # Two columns: "labels" and "p"
     label_prob_df = pd.DataFrame(inferred_label_list)


### PR DESCRIPTION
Try two separate versions of applying `has_final_labels` for dataframes.
- one row by row using `dataframe.apply`
- the other filtering directly with column-wise operations

I think that the second is more peformant so going with it for now
If that is no longer true, we can switch back to the `apply`, in which case we
can remove `has_final_labels_df`