### PR TITLE
Ensure that we drop sparse GEOSPHERE indices

### DIFF
--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -173,9 +173,9 @@ def _migrate_sparse_to_dense(collection, geo_index):
     # Should be safe to remove after Jun 2024
     index_info = collection.index_information()
     if geo_index in index_info and "sparse" in index_info[geo_index]:
-        print("Found sparse geosphere index, dropping %s, index list before=%s" % (list(collection.list_indexes())))
+        print("Found sparse geosphere index, dropping %s, index list before=%s" % (geo_index, collection.index_information().keys()))
         collection.drop_index(geo_index)
-        print("Found sparse geosphere index, dropping %s, index list after=%s" % (list(collection.list_indexes())))
+        print("Found sparse geosphere index, dropping %s, index list after=%s" % (geo_index, collection.index_information().keys()))
 
 def get_timeseries_db():
     #current_db = MongoClient().Stage_database
@@ -219,7 +219,7 @@ def _create_analysis_result_indices(tscoll):
     tscoll.create_index([("data.start_ts", pymongo.DESCENDING)], sparse=True)
     tscoll.create_index([("data.end_ts", pymongo.DESCENDING)], sparse=True)
     _migrate_sparse_to_dense(tscoll, "data.start_loc_2dsphere")
-    _migrate_sparse_to_dense(tscoll, "data.start_loc_2dsphere")
+    _migrate_sparse_to_dense(tscoll, "data.end_loc_2dsphere")
     tscoll.create_index([("data.start_loc", pymongo.GEOSPHERE)])
     tscoll.create_index([("data.end_loc", pymongo.GEOSPHERE)])
     _create_local_dt_indices(tscoll, "data.start_local_dt")

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -174,7 +174,12 @@ def get_timeseries_db():
     TimeSeries.create_index([("metadata.key", pymongo.ASCENDING)])
     TimeSeries.create_index([("metadata.write_ts", pymongo.DESCENDING)])
     TimeSeries.create_index([("data.ts", pymongo.DESCENDING)], sparse=True)
-
+    # Hack to migrate from sparse to dense indices to gracefully handle
+    # https://github.com/e-mission/e-mission-server/pull/849/commits/c65a4b209ed00db6aa3ad918fa631f9186ee3266
+    if "sparse" in TimeSeries.index_information()["data.loc_2dsphere"]:
+        print("Before dropping, dropping %s" % (TimeSeries.list_indexes()))
+        TimeSeries.drop_index("data.loc_2dsphere")
+        print("Found sparse geosphere index, dropping %s" % (TimeSeries.list_indexes()))
     TimeSeries.create_index([("data.loc", pymongo.GEOSPHERE)])
 
     return TimeSeries
@@ -209,6 +214,14 @@ def _create_analysis_result_indices(tscoll):
     # trips and sections
     tscoll.create_index([("data.start_ts", pymongo.DESCENDING)], sparse=True)
     tscoll.create_index([("data.end_ts", pymongo.DESCENDING)], sparse=True)
+    if "sparse" in tscoll.index_information()["data.start_loc_2dsphere"]:
+        print("Before dropping, dropping %s" % (tscoll.list_indexes()))
+        tscoll.drop_index("data.start_loc_2dsphere")
+        print("Found sparse geosphere index, dropping %s" % (tscoll.list_indexes()))
+    if "sparse" in tscoll.index_information()["data.end_loc_2dsphere"]:
+        print("Before dropping, dropping %s" % (tscoll.list_indexes()))
+        tscoll.drop_index("data.end_loc_2dsphere")
+        print("Found sparse geosphere index, dropping %s" % (tscoll.list_indexes()))
     tscoll.create_index([("data.start_loc", pymongo.GEOSPHERE)])
     tscoll.create_index([("data.end_loc", pymongo.GEOSPHERE)])
     _create_local_dt_indices(tscoll, "data.start_local_dt")
@@ -219,6 +232,10 @@ def _create_analysis_result_indices(tscoll):
     tscoll.create_index([("data.exit_ts", pymongo.DESCENDING)], sparse=True)
     _create_local_dt_indices(tscoll, "data.enter_local_dt")
     _create_local_dt_indices(tscoll, "data.exit_local_dt")
+    if "sparse" in tscoll.index_information()["data.location_2dsphere"]:
+        print("Before dropping, dropping %s" % (tscoll.list_indexes()))
+        tscoll.drop_index("data.location_2dsphere")
+        print("Found sparse geosphere index, dropping %s" % (tscoll.list_indexes()))
     tscoll.create_index([("data.location", pymongo.GEOSPHERE)])
     tscoll.create_index([("data.duration", pymongo.DESCENDING)], sparse=True)
     tscoll.create_index([("data.mode", pymongo.ASCENDING)], sparse=True)
@@ -226,6 +243,10 @@ def _create_analysis_result_indices(tscoll):
 
     # recreated location
     tscoll.create_index([("data.ts", pymongo.DESCENDING)], sparse=True)
+    if "sparse" in tscoll.index_information()["data.loc_2dsphere"]:
+        print("Before dropping, dropping %s" % (tscoll.list_indexes()))
+        tscoll.drop_index("data.loc_2dsphere")
+        print("Found sparse geosphere index, dropping %s" % (tscoll.list_indexes()))
     tscoll.create_index([("data.loc", pymongo.GEOSPHERE)])
     _create_local_dt_indices(tscoll, "data.local_dt") # recreated location
     return tscoll

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -167,6 +167,16 @@ def get_usercache_db():
     UserCache.create_index([("data.ts", pymongo.DESCENDING)], sparse=True)
     return UserCache
 
+def _migrate_sparse_to_dense(collection, geo_index):
+    # Hack to migrate from sparse to dense indices to gracefully handle
+    # https://github.com/e-mission/e-mission-server/pull/849/commits/c65a4b209ed00db6aa3ad918fa631f9186ee3266
+    # Should be safe to remove after Jun 2024
+    index_info = collection.index_information()
+    if geo_index in index_info and "sparse" in index_info[geo_index]:
+        print("Found sparse geosphere index, dropping %s, index list before=%s" % (list(collection.list_indexes())))
+        collection.drop_index(geo_index)
+        print("Found sparse geosphere index, dropping %s, index list after=%s" % (list(collection.list_indexes())))
+
 def get_timeseries_db():
     #current_db = MongoClient().Stage_database
     TimeSeries = _get_current_db().Stage_timeseries
@@ -174,14 +184,8 @@ def get_timeseries_db():
     TimeSeries.create_index([("metadata.key", pymongo.ASCENDING)])
     TimeSeries.create_index([("metadata.write_ts", pymongo.DESCENDING)])
     TimeSeries.create_index([("data.ts", pymongo.DESCENDING)], sparse=True)
-    # Hack to migrate from sparse to dense indices to gracefully handle
-    # https://github.com/e-mission/e-mission-server/pull/849/commits/c65a4b209ed00db6aa3ad918fa631f9186ee3266
-    if "sparse" in TimeSeries.index_information()["data.loc_2dsphere"]:
-        print("Before dropping, dropping %s" % (TimeSeries.list_indexes()))
-        TimeSeries.drop_index("data.loc_2dsphere")
-        print("Found sparse geosphere index, dropping %s" % (TimeSeries.list_indexes()))
+    _migrate_sparse_to_dense(TimeSeries, "data.loc_2dsphere")
     TimeSeries.create_index([("data.loc", pymongo.GEOSPHERE)])
-
     return TimeSeries
 
 def get_timeseries_error_db():
@@ -214,14 +218,8 @@ def _create_analysis_result_indices(tscoll):
     # trips and sections
     tscoll.create_index([("data.start_ts", pymongo.DESCENDING)], sparse=True)
     tscoll.create_index([("data.end_ts", pymongo.DESCENDING)], sparse=True)
-    if "sparse" in tscoll.index_information()["data.start_loc_2dsphere"]:
-        print("Before dropping, dropping %s" % (tscoll.list_indexes()))
-        tscoll.drop_index("data.start_loc_2dsphere")
-        print("Found sparse geosphere index, dropping %s" % (tscoll.list_indexes()))
-    if "sparse" in tscoll.index_information()["data.end_loc_2dsphere"]:
-        print("Before dropping, dropping %s" % (tscoll.list_indexes()))
-        tscoll.drop_index("data.end_loc_2dsphere")
-        print("Found sparse geosphere index, dropping %s" % (tscoll.list_indexes()))
+    _migrate_sparse_to_dense(tscoll, "data.start_loc_2dsphere")
+    _migrate_sparse_to_dense(tscoll, "data.start_loc_2dsphere")
     tscoll.create_index([("data.start_loc", pymongo.GEOSPHERE)])
     tscoll.create_index([("data.end_loc", pymongo.GEOSPHERE)])
     _create_local_dt_indices(tscoll, "data.start_local_dt")
@@ -232,10 +230,7 @@ def _create_analysis_result_indices(tscoll):
     tscoll.create_index([("data.exit_ts", pymongo.DESCENDING)], sparse=True)
     _create_local_dt_indices(tscoll, "data.enter_local_dt")
     _create_local_dt_indices(tscoll, "data.exit_local_dt")
-    if "sparse" in tscoll.index_information()["data.location_2dsphere"]:
-        print("Before dropping, dropping %s" % (tscoll.list_indexes()))
-        tscoll.drop_index("data.location_2dsphere")
-        print("Found sparse geosphere index, dropping %s" % (tscoll.list_indexes()))
+    _migrate_sparse_to_dense(tscoll, "data.location_2dsphere")
     tscoll.create_index([("data.location", pymongo.GEOSPHERE)])
     tscoll.create_index([("data.duration", pymongo.DESCENDING)], sparse=True)
     tscoll.create_index([("data.mode", pymongo.ASCENDING)], sparse=True)
@@ -243,10 +238,7 @@ def _create_analysis_result_indices(tscoll):
 
     # recreated location
     tscoll.create_index([("data.ts", pymongo.DESCENDING)], sparse=True)
-    if "sparse" in tscoll.index_information()["data.loc_2dsphere"]:
-        print("Before dropping, dropping %s" % (tscoll.list_indexes()))
-        tscoll.drop_index("data.loc_2dsphere")
-        print("Found sparse geosphere index, dropping %s" % (tscoll.list_indexes()))
+    _migrate_sparse_to_dense(tscoll, "data.loc_2dsphere")
     tscoll.create_index([("data.loc", pymongo.GEOSPHERE)])
     _create_local_dt_indices(tscoll, "data.local_dt") # recreated location
     return tscoll


### PR DESCRIPTION
Since mongo re-creates dropped indices, this effectively functions as a
backwards compatible migration path for
https://github.com/e-mission/e-mission-server/commit/c65a4b209ed00db6aa3ad918fa631f9186ee3266

This allows:
- restored databases to run without using `--noIndexRestore`
- online systems to upgrade to master without downtime

Testing done:
- Restored old mongodump

```
$ ~/bin/deploy_mongodump_local.sh ~/ceo_datasets/canbikeco_mongodump_participant_only_jan_31_2021.tar.gz bin_stage_1
...
2022-06-09T07:41:48.745+0000    restoring indexes for collection Stage_database.Stage_timeseries from metadata
2022-06-09T07:42:34.294+0000    finished restoring Stage_database.Stage_timeseries (4423949 documents, 0 failures)
2022-06-09T07:42:34.294+0000    4787862 document(s) restored successfully. 0 document(s) failed to restore.
```

- Without the fix, got the error while starting the server

```
pymongo.errors.OperationFailure: Index with name: data.loc_2dsphere already exists with different options, full error: {'ok': 0.0, 'errmsg': 'Index with name: data.loc_2dsphere already exists with different options', 'code': 85, 'codeName': 'IndexOptionsConflict'}
```

- Added hack to drop GEOSPHERE indices, note that this is not only in the
  timeseries, but also at multiple locations in the analysis timeseries.

- Re-started the server successfully

```
Before dropping, dropping <pymongo.command_cursor.CommandCursor object at 0x7fb2f0e49950>
Found sparse geosphere index, dropping <pymongo.command_cursor.CommandCursor object at 0x7fb2f0e499d0>
Before dropping, dropping <pymongo.command_cursor.CommandCursor object at 0x7fb2f0e49e90>
Found sparse geosphere index, dropping <pymongo.command_cursor.CommandCursor object at 0x7fb2f0e49810>
Before dropping, dropping <pymongo.command_cursor.CommandCursor object at 0x7fb2f0e49910>
Found sparse geosphere index, dropping <pymongo.command_cursor.CommandCursor object at 0x7fb2f0e49890>
Before dropping, dropping <pymongo.command_cursor.CommandCursor object at 0x7fb2f0e49fd0>
Found sparse geosphere index, dropping <pymongo.command_cursor.CommandCursor object at 0x7fb2f0e49b90>
```