### PR TITLE
Set the default iOS token format to fcm

### DIFF
--- a/conf/net/ext_service/push.json.sample
+++ b/conf/net/ext_service/push.json.sample
@@ -2,5 +2,5 @@
     "provider": "firebase",
     "server_auth_token": "Get from firebase console",
     "app_package_name": "full package name from config.xml. e.g. edu.berkeley.eecs.emission or edu.berkeley.eecs.embase. Defaults to edu.berkeley.eecs.embase",
-    "ios_token_format": "apns"
+    "ios_token_format": "fcm"
 }


### PR DESCRIPTION
Since Firebase turns it on by default, and our workaround hook is not working.
We can revert this if/when we restore the hook
https://github.com/e-mission/e-mission-docs/issues/733