### PR TITLE
Add server-side support for storing the app configuration

### DIFF
--- a/emission/core/wrapper/appuiconfig.py
+++ b/emission/core/wrapper/appuiconfig.py
@@ -1,0 +1,28 @@
+
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+import logging
+import emission.core.wrapper.wrapperbase as ecwb
+
+class Location(ecwb.WrapperBase):
+    props = {"ts": ecwb.WrapperBase.Access.RO, # timestamp the configuration was last changed
+             "local_dt": ecwb.WrapperBase.Access.RO, # searchable datetime in local time
+             "fmt_time": ecwb.WrapperBase.Access.RO, # formatted version of the timestampst changed
+             "version": ecwb.WrapperBase.Access.RO,  # the format version of the document
+             "server": ecwb.WrapperBase.Access.RO,       # server customizations, notably the URL
+             "intro": ecwb.WrapperBase.Access.RO,        # introduction customizations, notably the text in the summary and consent, and the auth method
+             "display_config": ecwb.WrapperBase.Access.RO, # customizations for display/UI screens
+             "profile_controls": ecwb.WrapperBase.Access.RO}  # customizations for entries to show in the profile
+
+    enums = {}
+    geojson = []
+    nullable = []
+    local_dates = ['local_dt']
+
+    def _populateDependencies(self):
+        pass

--- a/emission/core/wrapper/entry.py
+++ b/emission/core/wrapper/entry.py
@@ -50,6 +50,8 @@ class Entry(ecwb.WrapperBase):
             "config/sync_config": "syncconfig",
             # user consent time + protocol version
             "config/consent": "consentconfig",
+            # phone ui configuration, applied by scanning a QR code
+            "config/app_ui_config": "appuiconfig",
             # webapp API call time, measured on the server
             "stats/server_api_time": "statsevent",
             # intended to log the occurrence of errors in the webapp

--- a/emission/net/usercache/formatters/android/app_ui_config.py
+++ b/emission/net/usercache/formatters/android/app_ui_config.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+import logging
+import emission.net.usercache.formatters.generic.one_time_survey as fgo
+
+def format(entry):
+    return fgo.format(entry)

--- a/emission/net/usercache/formatters/ios/app_ui_config.py
+++ b/emission/net/usercache/formatters/ios/app_ui_config.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
+import logging
+import emission.net.usercache.formatters.generic.one_time_survey as fgo
+
+def format(entry):
+    return fgo.format(entry)

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -49,6 +49,7 @@ class BuiltinTimeSeries(esta.TimeSeries):
                 "config/sensor_config": self.timeseries_db,
                 "config/sync_config": self.timeseries_db,
                 "config/consent": self.timeseries_db,
+                "config/app_ui_config": self.timeseries_db,
                 "stats/server_api_time": self.timeseries_db,
                 "stats/server_api_error": self.timeseries_db,
                 "stats/pipeline_time": self.timeseries_db,


### PR DESCRIPTION
We decided to store this as an app configuration object on the server that is
synced to the server instead of only storing it on localhost. The primary
reason is that we are in the early stages of instrumenting and analying
OpenPATH data and don't yet know how this can be used.
https://github.com/e-mission/e-mission-docs/issues/739#issuecomment-1154180901

The change itself is fairly straightforward and follows prior templates such
as https://github.com/e-mission/e-mission-server/pull/517/files

Testing done:

**Received `put` message**

```
iSTART 2022-06-13 12:51:39.102390 POST /usercache/put
START 2022-06-13 12:51:39.121680 POST /usercache/get
END 2022-06-13 12:51:39.501505 POST /usercache/get 711fccd1-826a-4fd7-8b24-ebb14a4c7166 0.3797619342803955
END 2022-06-13 12:51:39.508138 POST /usercache/put 711fccd1-826a-4fd7-8b24-ebb14a4c7166 0.40569496154785156
```

**Received it on the server**

```
2022-06-13 12:51:39,117:DEBUG:123145513443328:Updated result for user = 711fccd1-826a-4fd7-8b24-ebb14a4c7166,
key = stats/client_time, write_ts = 1655149692.474828 = {'n': 1, 'nModified': 0, 'upserted': ObjectId('62a7954
b4fc0b5ba624ae49e'), 'ok': 1.0, 'updatedExisting': False}
2022-06-13 12:51:39,119:DEBUG:123145513443328:Updated result for user = 711fccd1-826a-4fd7-8b24-ebb14a4c7166,
key = config/app_ui_config, write_ts = 1655149751.753663 = {'n': 1, 'nModified': 0, 'upserted': ObjectId('62a7
954b4fc0b5ba624ae4a0'), 'ok': 1.0, 'updatedExisting': False}
2022-06-13 12:51:39,121:DEBUG:123145513443328:Updated result for user = 711fccd1-826a-4fd7-8b24-ebb14a4c7166,
key = statemachine/transition, write_ts = 1655149751.958808 = {'n': 1, 'nModified': 0, 'upserted': ObjectId('6
2a7954b4fc0b5ba624ae4a2'), 'ok': 1.0, 'updatedExisting': False}
```

**No errors in processing the usercache**

```
2022-06-13T12:53:38.972341-07:00**********UUID 711fccd1-826a-4fd7-8b24-ebb14a4c7166: moving to long term**********
Got error 'T_GEOFENCE_CREATION_ERROR' while saving entry AttrDict({'_id': ObjectId('62a7954b4fc0b5ba624ae4a2'), 'metadata': {'time_zone': 'America/Los_Angeles', 'plugin': 'none', 'write_ts': 1655149751.958808, 'platform': 'ios', 'read_ts': 0, 'key': 'statemachine/transition', 'type': 'message'}, 'user_id': UUID('711fccd1-826a-4fd7-8b24-ebb14a4c7166'), 'data': {'currState': 'STATE_START', 'transition': 'T_GEOFENCE_CREATION_ERROR', 'ts': 1655149751.9585361}}) -> None
Got error 'AttrDict' instance has no attribute 'currState' while saving entry AttrDict({'_id': ObjectId('62a7954b4fc0b5ba624ae4bb'), 'metadata': {'time_zone': 'America/Los_Angeles', 'plugin': 'none', 'write_ts': 1655149899.071107, 'platform': 'ios', 'read_ts': 0, 'key': 'statemachine/transition', 'type': 'message'}, 'user_id': UUID('711fccd1-826a-4fd7-8b24-ebb14a4c7166'), 'data': {'curr_state': 'STATE_START', 'transition': 'T_EXITED_GEOFENCE', 'ts': 1655149899}}) -> None
Got error 'AttrDict' instance has no attribute 'currState' while saving entry AttrDict({'_id': ObjectId('62a7954b4fc0b5ba624ae4bd'), 'metadata': {'time_zone': 'America/Los_Angeles', 'plugin': 'none', 'write_ts': 1655149899.0749469, 'platform': 'ios', 'read_ts': 0, 'key': 'statemachine/transition', 'type': 'message'}, 'user_id': UUID('711fccd1-826a-4fd7-8b24-ebb14a4c7166'), 'data': {'curr_state': 'STATE_ONGOING_TRIP', 'transition': 'T_TRIP_ENDED', 'ts': 1655149899}}) -> None
2022-06-13T12:53:39.128779-07:00**********UUID 711fccd1-826a-4fd7-8b24-ebb14a4c7166: updating incoming user inputs**********
```

**And it is in the timeseries**

```
>>> edb.get_timeseries_db().find({"metadata.key": "config/app_ui_config"}).count()
1
```

**And it is correct**

```
>>> edb.get_timeseries_db().find_one({"metadata.key": "config/app_ui_config"})
{'_id': ObjectId('62a7954b4fc0b5ba624ae4a0'), 'user_id': UUID('711fccd1-826a-4fd7-8b24-ebb14a4c7166'), 'metadata': {'time_zone': 'America/Los_Angeles', 'plugin': 'none', 'write_ts': 1655149751.753663, 'platform': 'ios', 'read_ts': 0, 'key': 'config/app_ui_config', 'type': 'rw-document', 'write_local_dt': {'year': 2022, 'month': 6, 'day': 13, 'hour': 12, 'minute': 49, 'second': 11, 'weekday': 0, 'timezone': 'America/Los_Angeles'}, 'write_fmt_time': '2022-06-13T12:49:11.753663-07:00'}, 'data': {'ts': 1655143472, 'display_config': {'use_imperial': False}, 'profile_controls': {'support_upload': True, 'trip_end_notification': True}, 'intro': {'deployment_partner_name': 'National Renewable Energy Laboratory (NREL)', 'program_admin_contact': 'K. Shankari (k.shankari@nrel.gov)', 'program_or_study': 'program', 'translated_text': {'support_autogen_token': False, 'en': {'summary_line_3': 'and ensure that end-to-end features work.', 'summary_line_2': 'connect to a local server', 'why_we_collect': 'So that you can see how OpenPATH works', 'summary_line_1': 'allows developers to work on the OpenPATH app', 'deployment_name': 'Development environment', 'short_textual_description': 'OpenPATH is the only open source platform for instrumenting mobility patterns. We welcome contributions and pull requests.'}}}, 'version': 1, 'local_dt': {'year': 2022, 'month': 6, 'day': 13, 'hour': 11, 'minute': 4, 'second': 32, 'weekday': 0, 'timezone': 'America/Los_Angeles'}, 'fmt_time': '2022-06-13T11:04:32-07:00'}}
```