### PR TITLE
Add a top level entry to the wrapper to store the join_study settings

### DIFF
--- a/emission/core/wrapper/appuiconfig.py
+++ b/emission/core/wrapper/appuiconfig.py
@@ -14,6 +14,7 @@ class Location(ecwb.WrapperBase):
              "local_dt": ecwb.WrapperBase.Access.RO, # searchable datetime in local time
              "fmt_time": ecwb.WrapperBase.Access.RO, # formatted version of the timestampst changed
              "version": ecwb.WrapperBase.Access.RO,  # the format version of the document
+             "joined": ecwb.WrapperBase.Access.RO,   # the join settings, including label and source
              "server": ecwb.WrapperBase.Access.RO,       # server customizations, notably the URL
              "intro": ecwb.WrapperBase.Access.RO,        # introduction customizations, notably the text in the summary and consent, and the auth method
              "display_config": ecwb.WrapperBase.Access.RO, # customizations for display/UI screens


### PR DESCRIPTION
This unifies the storage into one location and keeps track of how people joined
the study and when.

Corresponds to https://github.com/e-mission/e-mission-docs/issues/739#issuecomment-1155157111
and https://github.com/e-mission/e-mission-phone/pull/842/commits/9c15d842520332e45daf0a2969b06dbb23d93cf7