### PR TITLE
Disable aggregate access to the spatio-temporal data

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -105,7 +105,13 @@ def _fill_aggregate_backward_compat(request):
 @post("/result/heatmap/pop.route/<time_type>")
 def getPopRoute(time_type):
   _fill_aggregate_backward_compat(request)
-  user_uuid = get_user_or_aggregate_auth(request)
+  # Disable aggregate access for the spatio-temporal data temporarily
+  # until we can figure out how to prevent malicious users from signing up for studies,
+  # pulling data using automated scripts, and using repeated queries on a
+  # sparse dataset to reconstruct trajectories
+  # re-enable when we add heatmaps back
+  # https://github.nrel.gov/kshankar/openpath-phone/issues/2#issuecomment-44111
+  user_uuid = getUUID(request)
 
   if 'from_local_date' in request.json and 'to_local_date' in request.json:
       start_time = request.json['from_local_date']
@@ -129,7 +135,13 @@ def getPopRoute(time_type):
 @post("/result/heatmap/incidents/<time_type>")
 def getStressMap(time_type):
     _fill_aggregate_backward_compat(request)
-    user_uuid = get_user_or_aggregate_auth(request)
+    # Disable aggregate access for the spatio-temporal data temporarily
+    # until we can figure out how to prevent malicious users from signing up for studies,
+    # pulling data using automated scripts, and using repeated queries on a
+    # sparse dataset to reconstruct trajectories
+    # re-enable when we add heatmaps back
+    # https://github.nrel.gov/kshankar/openpath-phone/issues/2#issuecomment-44111
+    user_uuid = getUUID(request)
 
     # modes = request.json['modes']
     # hardcode modes to None because we currently don't store


### PR DESCRIPTION
- Disable aggregate access to the spatio-temporal data for now until we can
  ensure that we don't share trajectories when there are too few people
  participating in the program.
- This was not an issue until now, because we:
  - required gmail to login
  - required a program token to login

But now that we open up enrollment via anonymous token, we can run into the
issue where malicious users sign up for studies, don't contribute anything, and
simply pull aggregate spatio-temporal data at will using an automated script.
If we don't have a lot of users in the study, this can run into issues with
tracking trajectories through repeated queries.

We can consider multiple potential fixes for the future:
- apply k-modularity for the trajectories (which will require map matching)
- require a client secret for access to the spatio-temporal data so that only
  the phone app can retrieve the data
- change the granularity of the data to ensure privacy

But let's wait and pick one later.

For now, we disable the aggregate spatio-temporal queries and remove the heatmap
from the UI
https://github.nrel.gov/kshankar/openpath-phone/issues/2#issuecomment-44111