### PR TITLE
Store the model in a new model_db instead of in the analysis_db

### DIFF
--- a/emission/analysis/modelling/trip_model/model_storage.py
+++ b/emission/analysis/modelling/trip_model/model_storage.py
@@ -6,9 +6,7 @@ import json
 import emission.analysis.modelling.trip_model.model_type as eamum
 import emission.core.wrapper.tripmodel as ecwu
 import emission.storage.decorations.analysis_timeseries_queries as esda
-import emission.storage.timeseries.abstract_timeseries as esta
-import emission.storage.timeseries.builtin_timeseries as estb
-import pymongo
+import emission.storage.modifiable.abstract_model_storage as esma
 
 
 class ModelStorage(Enum):
@@ -51,14 +49,8 @@ def load_model(user_id, model_type: eamum.ModelType, model_storage: ModelStorage
         
         # retrieve stored model with timestamp that matches/exceeds the most
         # recent PipelineState.TRIP_MODEL entry        
-        ts = esda.get_timeseries_for_user(user_id)
-        if not isinstance(ts, estb.BuiltinTimeSeries):
-            raise Exception('user model storage requires BuiltInTimeSeries')
-        latest_model_entry = ts.get_first_entry(
-            key=esda.TRIP_MODEL_STORE_KEY,
-            field='metadata.write_ts',
-            sort_order=pymongo.DESCENDING
-        )
+        ms = esma.ModelStorage.get_model_storage(user_id)
+        latest_model_entry = ms.get_current_model(key=esda.TRIP_MODEL_STORE_KEY)
 
         if latest_model_entry is None:
             logging.debug(f'no {model_type.name} model found for user {user_id}')
@@ -125,8 +117,8 @@ def save_model(
         row.model = model_data
 
         try:
-            ts = esta.TimeSeries.get_time_series(user_id)
-            ts.insert_data(user_id, esda.TRIP_MODEL_STORE_KEY, row)
+            ms = esma.ModelStorage.get_model_storage(user_id)
+            ms.upsert_model(esda.TRIP_MODEL_STORE_KEY, row)
         except Exception as e:
             msg = (
                 f"failure storing model for user {user_id}, model {model_type.name} "

--- a/emission/storage/modifiable/abstract_model_storage.py
+++ b/emission/storage/modifiable/abstract_model_storage.py
@@ -1,0 +1,31 @@
+import logging
+import enum as enum
+from typing import Dict, Optional
+import emission.core.wrapper.wrapperbase as ecwb
+
+class ModelStorage(object):
+    @staticmethod
+    def get_model_storage(user_id):
+        """
+        :param user_id: the user_id that we want the timeseries for
+        :returns: a model storage for that particular user
+        """
+        import emission.storage.modifiable.builtin_model_storage as bims
+        return bims.BuiltinModelStorage(user_id)
+
+    def __init__(self, user_id):
+        self.user_id = user_id
+
+    def upsert_model(self, key: str, model: ecwb.WrapperBase):
+        """
+        :param: the metadata key for the entries, used to identify the model type
+        :model: a wrapper for the model
+        """
+        pass
+
+    def get_current_model(self, key:str) -> Optional[Dict]:
+        """
+        : param key: the metadata key for the entries, used to identify the model type
+        : return: the most recent database entry for this key
+        """
+        pass

--- a/emission/storage/modifiable/builtin_model_storage.py
+++ b/emission/storage/modifiable/builtin_model_storage.py
@@ -34,7 +34,7 @@ class BuiltinModelStorage(esma.ModelStorage):
         :return: the most recent database entry for this key
         """
         find_query = {"user_id": self.user_id, "metadata.key": key}
-        result_it = edb.get_model_db().find(find_query).limit(1)
+        result_it = edb.get_model_db().find(find_query).sort("metadata.write_ts", -1).limit(1)
         # this differs from the timeseries `get_first_entry` only in the find query
         # and the fact that the sort key and sort order are hardcoded
         # everything below this point is identical

--- a/emission/storage/modifiable/builtin_model_storage.py
+++ b/emission/storage/modifiable/builtin_model_storage.py
@@ -1,0 +1,50 @@
+import logging
+import pandas as pd
+import pymongo
+import itertools
+from typing import Dict, Optional
+
+import emission.core.get_database as edb
+import emission.storage.modifiable.abstract_model_storage as esma
+
+import emission.core.wrapper.entry as ecwe
+import emission.core.wrapper.wrapperbase as ecwb
+
+class BuiltinModelStorage(esma.ModelStorage):
+    def __init__(self, user_id):
+        super(BuiltinModelStorage, self).__init__(user_id)
+        self.key_query = lambda key: {"metadata.key": key}
+        self.user_query = {"user_id": self.user_id} # UUID is mandatory for this version
+
+    def upsert_model(self, key:str, model: ecwb.WrapperBase):
+        """
+        :param: the metadata key for the entries, used to identify the model type
+        :model: a wrapper for the model
+        """
+        logging.debug("upsert_doc called with key %s" % key)
+        entry = ecwe.Entry.create_entry(self.user_id, key, model)
+        logging.debug("Inserting entry %s into model DB" % entry)
+        ins_result = edb.get_model_db().insert_one(entry)
+        ## TODO: Cleanup old/obsolete models
+        return ins_result.inserted_id
+
+    def get_current_model(self, key:str) -> Optional[Dict]:
+        """
+        :param key: the metadata key for the entries, used to identify the model type
+        :return: the most recent database entry for this key
+        """
+        find_query = {"user_id": self.user_id, "metadata.key": key}
+        result_it = edb.get_model_db().find(find_query).limit(1)
+        # this differs from the timeseries `get_first_entry` only in the find query
+        # and the fact that the sort key and sort order are hardcoded
+        # everything below this point is identical
+        # but it is also fairly trivial, so I am not sure it is worth pulling
+        # out into common code at this point
+        result_list = list(result_it)
+        if len(result_list) == 0:
+            return None
+        else:
+            first_entry = result_list[0]
+            del first_entry["_id"]
+            return first_entry 
+

--- a/emission/tests/modellingTests/TestRunGreedyIncrementalModel.py
+++ b/emission/tests/modellingTests/TestRunGreedyIncrementalModel.py
@@ -136,6 +136,7 @@ class TestRunGreedyModel(unittest.TestCase):
         clean up database entries related to this test
         """
         edb.get_analysis_timeseries_db().delete_many({'user_id': self.user_id})
+        edb.get_model_db().delete_many({'user_id': self.user_id})
         edb.get_pipeline_state_db().delete_many({'user_id': self.user_id})
 
     def testIncrementalRun(self):
@@ -195,4 +196,3 @@ class TestRunGreedyModel(unittest.TestCase):
             'the second bin should have exactly one entry (an outlier)')
         self.assertEqual(len(updated_model.bins['2']['feature_rows']), 1,
             'the third bin should have exactly one entry (an outlier)')
-        

--- a/emission/tests/modellingTests/TestRunGreedyModel.py
+++ b/emission/tests/modellingTests/TestRunGreedyModel.py
@@ -83,6 +83,7 @@ class TestRunGreedyModel(unittest.TestCase):
         clean up database
         """
         edb.get_analysis_timeseries_db().delete_many({'user_id': self.user_id})
+        edb.get_model_db().delete_many({'user_id': self.user_id})
         edb.get_pipeline_state_db().delete_many({'user_id': self.user_id})
 
     def testBuildGreedyModelFromConfig(self):


### PR DESCRIPTION
Unlike the user inputs, which are read-only from an analysis perspective, or
analysis results, which are write once (except for confirmed trips), the models
are updated frequently, every time they are re-calibrated.

So we create a new interface to match this new access pattern.
Unlike the timeseries, which focuses on reading data for a particular range,
the new interface focuses on updating models and retrieving the most recent model

We still need to write code to purge obsolete models so that the database does
not grow unboundedly.

Changes:
- new database
- new abstract interface in `emission/storage/modifiable`
- new concrete implmentation in `emission/storage/modifiable`
- change the `model_storage` to use the new interface instead of the timeseries
    - bonus, don't need to use the concrete implementation any more since this
      implementation is all about the most recent version
- change the test to delete the model db in addition to the analysis DB
    - we need to now delete both since the trips are in the analysis DB while
      the models are in the separate model DB