### PR TITLE
replace conda clean command

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -2,7 +2,7 @@ echo "About to start conda update, this may take some time..."
 source setup/setup_conda.sh Linux-x86_64
 source setup/setup.sh
 conda clean -t
-conda clean -p
+find /root/miniconda-*/pkgs -wholename \*info/test\* -type d | xargs rm -rf
 
 if [ -d "webapp/www/" ]; then
     cp /index.html webapp/www/index.html


### PR DESCRIPTION
replace `conda clean -p` command with a `rm -rf`, consistent with public dashboard Dockerfile.

As referenced in https://github.com/e-mission/e-mission-server/pull/876 and https://github.com/e-mission/em-public-dashboard/issues/37