### PR TITLE
Create a script to automatically reset the pipeline to the correct va…

### DIFF
--- a/bin/monitor/reset_invalid_pipeline_states.py
+++ b/bin/monitor/reset_invalid_pipeline_states.py
@@ -1,0 +1,25 @@
+import arrow
+import logging
+import argparse
+import pandas as pd
+
+import emission.core.wrapper.pipelinestate as ecwp
+import emission.core.get_database as edb
+import emission.pipeline.reset as epr
+
+# Run in containers using:
+# sudo docker exec $CONTAINER bash -c 'cd e-mission-server; source setup/activate.sh; ./e-mission-py.bash bin/debug/reset_invalid_pipeline_state.py'
+
+def reset_all_invalid_state(args):
+    # all_invalid_states = [ecwp.PipelineState(p) for p in edb.get_pipeline_state_db().find({"curr_run_ts": {"$ne": None}})]
+    epr.auto_reset(args.dry_run, args.only_calc)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    parser = argparse.ArgumentParser(prog="reset_invalid_pipeline_stage")
+    parser.add_argument("-c", "--only_calc", action="store_true", default=False,
+                        help="only calculate the reset timestamps, don't launch the reset process")
+    parser.add_argument("-n", "--dry_run", action="store_true", default=False,
+                        help="do everything except actually perform the operations")
+    args = parser.parse_args()
+    reset_all_invalid_state(args)


### PR DESCRIPTION
…lue for each user

This replaces the current, cumbersome method in which I get a list of users with an invalid pipeline state, and then reset them manually.

This automates that manual algorithm, while also making it more sophisticated.

The algorithm essentially finds all invalid states for a current user, groups them, and then resets to the oldest timestamp. This will ensure that we don't skip some data by moving the pointer ahead to a time that is not yet processed.

This fixes https://github.com/e-mission/e-mission-docs/issues/805