### PR TITLE
Wrap a mongodb cursor in a list before converting it to a dataframe

### DIFF
--- a/emission/pipeline/reset.py
+++ b/emission/pipeline/reset.py
@@ -329,9 +329,9 @@ def auto_reset(dry_run, only_calc):
     # If we are running the pipeline every hour, then having a run_ts that is
     # more than three hours old indicates that it is likely invalid
     three_hours_ago = arrow.utcnow().shift(hours=-3).timestamp
-    all_invalid_states = pd.json_normalize(edb.get_pipeline_state_db().find({"$and": [
+    all_invalid_states = pd.json_normalize(list(edb.get_pipeline_state_db().find({"$and": [
         {"curr_run_ts": {"$lt": three_hours_ago}},
-        {"pipeline_stage": {"$ne": 9}}]}))
+        {"pipeline_stage": {"$ne": 9}}]})))
     if len(all_invalid_states) == 0:
         logging.info("No invalid states found, returning early")
         return

--- a/emission/tests/pipelineTests/TestPipelineReset.py
+++ b/emission/tests/pipelineTests/TestPipelineReset.py
@@ -676,10 +676,7 @@ class TestPipelineReset(unittest.TestCase):
              arrow.get("2022-09-21").shift(hours=-3).timestamp, # user3, only one entry
              arrow.get("2022-09-22").shift(hours=-3).timestamp]) # user4, only one entry
 
-    def testAutoResetMock(self):
-        # The expectation is that user_5 and user_6 will be stripped out since:
-        # user5 does not have a curr_run_ts
-        # user6 is an output_gen state
+    def testNormalizeWithACursor(self):
         invalid_states_mixed = pd.DataFrame({
             "user_id": ["user_1", "user_1", "user_1", "user_2", "user_3", "user_4",
                 "user_5", "user_6"],
@@ -693,6 +690,36 @@ class TestPipelineReset(unittest.TestCase):
         for index, e in invalid_states_mixed.iterrows():
             edb.get_pipeline_state_db().insert_one(e.to_dict())
 
+        df_from_cursor = pd.json_normalize(edb.get_pipeline_state_db().find())
+        df_from_list = pd.json_normalize(list(edb.get_pipeline_state_db().find()))
+
+        # This is actually incorrect because we saved everything, so we should read back everything
+        # but it is the current behavior, so let's flag if it changes
+        self.assertEqual(len(df_from_cursor), len(invalid_states_mixed) - 1)
+
+        # This is actually incorrect because we saved everything, so we should read back everything
+        # but it is the current behavior, so let's flag if it changes
+        self.assertEqual(len(df_from_list), len(invalid_states_mixed))
+
+    def testAutoResetMock(self):
+        # The expectation is that user_5 and user_6 will be stripped out since:
+        # user5 does not have a curr_run_ts
+        # user6 is an output_gen state
+        invalid_states_mixed = pd.DataFrame({
+            "user_id": ["user_no_missing", "user_1", "user_1", "user_1", "user_2", "user_3", "user_4",
+                "user_5", "user_6"],
+            "curr_run_ts": [arrow.get("2022-09-19").timestamp]+
+                [arrow.get("2022-09-20").timestamp,
+                arrow.get("2022-09-21").timestamp,
+                arrow.get("2022-09-22").timestamp] * 2 +
+                [None, arrow.get("2022-09-09").timestamp],
+            "pipeline_stage": [2] + [0, 6, 13] * 2 + [11, 9] # add an output gen
+        })
+        self.testUUIDList = invalid_states_mixed.user_id.to_list()
+        for index, e in invalid_states_mixed.iterrows():
+            edb.get_pipeline_state_db().insert_one(e.to_dict())
+
+        self.assertEqual(edb.get_pipeline_state_db().count_documents({"user_id": "user_no_missing"}), 1)
         self.assertEqual(edb.get_pipeline_state_db().count_documents({"user_id": "user_1"}), 3)
         self.assertEqual(edb.get_pipeline_state_db().count_documents({"user_id": "user_2"}), 1)
 
@@ -701,6 +728,7 @@ class TestPipelineReset(unittest.TestCase):
         # These entries don't have any data, so there is no last place and we
         # reset to start. Which involves deleting the pipeline states
         # so there won't be any states left.
+        self.assertEqual(edb.get_pipeline_state_db().count_documents({"user_id": "user_no_missing"}), 0)
         self.assertEqual(edb.get_pipeline_state_db().count_documents({"user_id": "user_1"}), 0)
         self.assertEqual(edb.get_pipeline_state_db().count_documents({"user_id": "user_2"}), 0)
 

--- a/emission/tests/pipelineTests/TestPipelineReset.py
+++ b/emission/tests/pipelineTests/TestPipelineReset.py
@@ -697,8 +697,7 @@ class TestPipelineReset(unittest.TestCase):
         # but it is the current behavior, so let's flag if it changes
         self.assertEqual(len(df_from_cursor), len(invalid_states_mixed) - 1)
 
-        # This is actually incorrect because we saved everything, so we should read back everything
-        # but it is the current behavior, so let's flag if it changes
+        # This is the expected behavior in all cases, but let's make sure that it stays as we move through versions of pandas
         self.assertEqual(len(df_from_list), len(invalid_states_mixed))
 
     def testAutoResetMock(self):


### PR DESCRIPTION
Using `pd.json_normalize` directly on a cursor seems to skip the first line. Wrapping the cursor in a list seems to fix it.
Not sure if this is expected behavior or whether it has been fixed now in pandas

This change:
- adds a new test that explicitly tests this functionality - the test passes if the first line is missing in the cursor but not in the list. This does not call any functions in the reset.
- adds a new check to the existing mock test by adding a new user (`no_missing`) to the front of the test data and ensuring that the user is also reset correctly. Without this change, the first entry had multiple repetitions, so even if the first entry was skipped, the user would still be reset
- fixes the issue in the reset code

Testing done:
- tests pass

This re-fixes https://github.com/e-mission/e-mission-docs/issues/805