### PR TITLE
Support dynamic conf auth method selection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ENV DB_HOST=''
 ENV WEB_SERVER_HOST=''
 
 ENV LIVERELOAD_SRC=''
+ENV STUDY_CONFIG=''
 RUN chmod u+x ./.docker/docker_start_script.sh
 
 EXPOSE 8080

--- a/emission/tests/netTests/TestWebserver.py
+++ b/emission/tests/netTests/TestWebserver.py
@@ -68,17 +68,19 @@ class TestWebserver(unittest.TestCase):
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response.get_header("Location"), "http://somewhere.else")
 
-    def testResolveAuth(self):
-        self.assertEqual(enacw.resolve_auth("skip"),"skip")
-        self.assertEqual(enacw.resolve_auth("token_list"),"token_list")
-        self.assertEqual(enacw.resolve_auth("dynamic"),"token_list")
-        self.assertNotEqual(enacw.resolve_auth("dynamic"),"skip")
-
     from unittest import mock
     @mock.patch.dict(os.environ, {"STUDY_CONFIG":"nrel-commute"}, clear=True)
     def test_ResolveAuthWithEnvVar(self):
         importlib.reload(enacw)
         self.assertEqual(enacw.resolve_auth("dynamic"),"skip")
+
+
+    def testResolveAuthNoEnvVar(self):
+        importlib.reload(enacw)
+        self.assertEqual(enacw.resolve_auth("skip"),"skip")
+        self.assertEqual(enacw.resolve_auth("token_list"),"token_list")
+        self.assertEqual(enacw.resolve_auth("dynamic"),"token_list")
+        self.assertNotEqual(enacw.resolve_auth("dynamic"),"skip")
 
 
 if __name__ == "__main__":

--- a/emission/tests/netTests/TestWebserver.py
+++ b/emission/tests/netTests/TestWebserver.py
@@ -69,8 +69,6 @@ class TestWebserver(unittest.TestCase):
         self.assertEqual(response.get_header("Location"), "http://somewhere.else")
 
     def testResolveAuth(self):
-        import emission.net.api.cfc_webapp as enacw
-
         self.assertEqual(enacw.resolve_auth("skip"),"skip")
         self.assertEqual(enacw.resolve_auth("token_list"),"token_list")
         self.assertEqual(enacw.resolve_auth("dynamic"),"token_list")

--- a/emission/tests/netTests/TestWebserver.py
+++ b/emission/tests/netTests/TestWebserver.py
@@ -67,6 +67,15 @@ class TestWebserver(unittest.TestCase):
         self.assertEqual(response.status_code, 301)
         self.assertEqual(response.get_header("Location"), "http://somewhere.else")
 
+    def testResolveAuth(self):
+        import emission.net.api.cfc_webapp as enacw
+
+        self.assertEqual(enacw.resolve_auth("skip"),"skip")
+        self.assertEqual(enacw.resolve_auth("token_list"),"token_list")
+        self.assertEqual(enacw.resolve_auth("dynamic"),"token_list")
+        self.assertNotEqual(enacw.resolve_auth("dynamic"),"skip")
+
+
 
 if __name__ == "__main__":
     etc.configLogging()

--- a/emission/tests/netTests/TestWebserver.py
+++ b/emission/tests/netTests/TestWebserver.py
@@ -18,7 +18,8 @@ import time
 
 # Our imports
 import emission.tests.common as etc
-
+import emission.net.api.cfc_webapp as enacw
+import importlib
 
 class TestWebserver(unittest.TestCase):
     def setUp(self):
@@ -58,7 +59,7 @@ class TestWebserver(unittest.TestCase):
 
     def test404Redirect(self):
         from emission.net.api.bottle import response
-        import emission.net.api.cfc_webapp as enacw
+        importlib.reload(enacw)
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_header("Location"), None)
@@ -75,6 +76,11 @@ class TestWebserver(unittest.TestCase):
         self.assertEqual(enacw.resolve_auth("dynamic"),"token_list")
         self.assertNotEqual(enacw.resolve_auth("dynamic"),"skip")
 
+    from unittest import mock
+    @mock.patch.dict(os.environ, {"STUDY_CONFIG":"nrel-commute"}, clear=True)
+    def test_ResolveAuthWithEnvVar(self):
+        importlib.reload(enacw)
+        self.assertEqual(enacw.resolve_auth("dynamic"),"skip")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Support a webapp.conf:server:auth = dynamic case by resolving dynamic into skip or token_list by reading from the online dynamic conf of the given deployment