### PR TITLE
Fix 404 redirect

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -70,8 +70,7 @@ socket_timeout = config_data["server"]["timeout"]
 log_base_dir = config_data["paths"]["log_base_dir"]
 auth_method = config_data["server"]["auth"]
 aggregate_call_auth = config_data["server"]["aggregate_call_auth"]
-# not_found_redirect = "foo" if len(config_data["paths"]) == 5 else "bar"
-not_found_redirect = config_data["paths"]["404_redirect"] if "404_redirect" in config_data["paths"] else OPENPATH_URL
+not_found_redirect = config_data["paths"].get("404_redirect", OPENPATH_URL)
 
 BaseRequest.MEMFILE_MAX = 1024 * 1024 * 1024 # Allow the request size to be 1G
 # to accomodate large section sizes
@@ -414,7 +413,7 @@ def habiticaProxy():
 @error(404)
 def error404(error):
     response.status = 301
-    response.set_header('Location', "https://www.nrel.gov/transportation/openpath.html")
+    response.set_header('Location', not_found_redirect)
 
 @app.hook('before_request')
 def before_request():

--- a/emission/tests/netTests/TestWebserver.py
+++ b/emission/tests/netTests/TestWebserver.py
@@ -1,0 +1,73 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+# Standard imports
+from future import standard_library
+
+standard_library.install_aliases()
+from builtins import *
+import unittest
+import json
+import sys
+import os
+import uuid
+import logging
+import time
+
+# Our imports
+import emission.tests.common as etc
+
+
+class TestWebserver(unittest.TestCase):
+    def setUp(self):
+        import shutil
+
+        self.webserver_conf_path = "conf/net/api/webserver.conf"
+        shutil.copyfile(
+            "%s.sample" % self.webserver_conf_path, self.webserver_conf_path
+        )
+        with open(self.webserver_conf_path, "w") as fd:
+            fd.write(
+                json.dumps(
+                    {
+                        "paths": {
+                            "static_path": "webapp/www",
+                            "python_path": "main",
+                            "log_base_dir": ".",
+                            "log_file": "debug.log",
+                            "404_redirect": "http://somewhere.else",
+                        },
+                        "server": {
+                            "host": "0.0.0.0",
+                            "port": "8080",
+                            "timeout": "3600",
+                            "auth": "skip",
+                            "aggregate_call_auth": "no_auth",
+                        },
+                    }
+                )
+            )
+        logging.debug("Finished setting up %s" % self.webserver_conf_path)
+        with open(self.webserver_conf_path) as fd:
+            logging.debug("Current values are %s" % json.load(fd))
+
+    def tearDown(self):
+        os.remove(self.webserver_conf_path)
+
+    def test404Redirect(self):
+        from emission.net.api.bottle import response
+        import emission.net.api.cfc_webapp as enacw
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_header("Location"), None)
+
+        enacw.error404("")
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.get_header("Location"), "http://somewhere.else")
+
+
+if __name__ == "__main__":
+    etc.configLogging()
+    unittest.main()


### PR DESCRIPTION
This PR fixes 404 redirect by replacing hardcoded redirect URI with configured redirect URI, should it exist in configuration.

I also simplified how redirect_uri is retrieved from configuration with getter and default value.