### PR TITLE
insert_tokens: fix default message use

### DIFF
--- a/bin/auth/insert_tokens.py
+++ b/bin/auth/insert_tokens.py
@@ -16,16 +16,16 @@ if __name__ == '__main__':
         token_list = (esdt.get_tokens_from_file(args.file))
         esdt.insert_many_tokens(token_list)
 
-    if args.single:
+    elif args.single:
         token = args.single
         esdt.insert({"token":token})
 
-    if args.uuid:
+    elif args.uuid:
         uuid_list = edb.get_uuid_db().find()
         for u in uuid_list:
             esdt.insert({"token":u["user_email"]})
 
-    if args.show:
+    elif args.show:
         token_list = esdt.get_all_tokens()
         for t in token_list:
             print(t)

--- a/emission/tests/storageTests/TestTokenQueries.py
+++ b/emission/tests/storageTests/TestTokenQueries.py
@@ -164,7 +164,7 @@ class TestTokenQueries(unittest.TestCase):
 
     #test that no two options can be used together
     def test_run_script_mutex(self):
-        #code wil be anded with returncode of each subprocess
+        #code will be anded with returncode of each subprocess
         #an unsuccessful run is indicated by some number other than 0
         #a single successful run will force code to be stuck at 0
         code = 1


### PR DESCRIPTION
Originally checked in by @aGuttman but not submitted.
PR created by @shankari for the record

Default message will no longer display when using options other than show

small typo in comment fixed
