### PR TITLE
:white_check_mark: Enable pipeline tests

### DIFF
--- a/emission/tests/pipelineTests/TestExpectationNotificationConfig.py
+++ b/emission/tests/pipelineTests/TestExpectationNotificationConfig.py
@@ -9,7 +9,7 @@ import emission.tests.common as etc
 # Exhaustive (and exhausting) tests of expectation_notification_config, including the behind-the-scenes rules algorithms and timey-wimey stuff
 class TestExpectationNotificationConfig(unittest.TestCase):
     def setUp(self):
-        self.test_options_stash = eace._test_options
+        self.test_options_stash = copy.copy(eace._test_options)
         eace._test_options = {
             "use_sample": True,
             "override_keylist": ["label1", "label2"]

--- a/emission/tests/pipelineTests/TestExpectationPipeline.py
+++ b/emission/tests/pipelineTests/TestExpectationPipeline.py
@@ -2,6 +2,7 @@ import unittest
 import numpy as np
 import time
 import arrow
+import copy
 
 import emission.storage.timeseries.timequery as estt
 import emission.core.wrapper.labelprediction as ecwl
@@ -33,7 +34,7 @@ class TestExpectationPipeline(unittest.TestCase):
         return trip["data"]["start_local_dt"]["hour"]*60+trip["data"]["start_local_dt"]["minute"]
 
     def setUp(self):
-        self.test_options_stash = eace._test_options
+        self.test_options_stash = copy.copy(eace._test_options)
         eace._test_options = {
             "use_sample": True,
             "override_keylist": ["mode_confirm", "purpose_confirm"]
@@ -57,7 +58,7 @@ class TestExpectationPipeline(unittest.TestCase):
     def run_pipeline(self, algorithms):
         primary_algorithms_stash = eacilp.primary_algorithms
         eacilp.primary_algorithms = algorithms
-        test_options_stash = eaue._test_options
+        test_options_stash = copy.copy(eaue._test_options)
         eaue._test_options["preprocess_trip"] = lambda trip: self.preprocess(trip)
         etc.runIntakePipeline(self.testUUID)
         eacilp.primary_algorithms = primary_algorithms_stash

--- a/emission/tests/pipelineTests/TestExpectationPipeline.py
+++ b/emission/tests/pipelineTests/TestExpectationPipeline.py
@@ -36,7 +36,7 @@ class TestExpectationPipeline(unittest.TestCase):
         self.test_options_stash = eace._test_options
         eace._test_options = {
             "use_sample": True,
-            "override_keylist": None
+            "override_keylist": ["mode_confirm", "purpose_confirm"]
         }
         eace.reload_config()
         
@@ -51,7 +51,6 @@ class TestExpectationPipeline(unittest.TestCase):
 
     def tearDown(self):
         self.reset_all()
-        
         eace._test_options = self.test_options_stash
         eace.reload_config()
 
@@ -93,7 +92,8 @@ class TestExpectationPipeline(unittest.TestCase):
             960: {"type": "randomFraction", "value": 0.05}
         }
         for trip in self.expected_trips:
-            self.assertEqual(eace.get_expectation(trip), answers[self.fingerprint(trip)])
+            self.assertEqual(eace.get_expectation(trip), answers[self.fingerprint(trip)],
+                "trip: %s with fingerprint %s" % (trip, self.fingerprint(trip)))
 
     def testProcessedAgainstAnswers(self):
         answers = {
@@ -106,7 +106,7 @@ class TestExpectationPipeline(unittest.TestCase):
         }
         for trip in self.expected_trips:
             ans = answers[self.fingerprint(trip)]
-            if ans is not None: self.assertEqual(trip["data"]["expectation"]["to_label"], ans)
+            if ans is not None: self.assertEqual(trip["data"]["expectation"]["to_label"], ans, "trip: %s with fingerprint %s" % (trip, self.fingerprint(trip)))
 
     def testProcessedAgainstRaw(self):
         for trip in self.expected_trips:

--- a/emission/tests/pipelineTests/TestExpectationPipeline.py
+++ b/emission/tests/pipelineTests/TestExpectationPipeline.py
@@ -8,13 +8,14 @@ import emission.core.wrapper.labelprediction as ecwl
 import emission.analysis.userinput.expectations as eaue
 import emission.storage.decorations.analysis_timeseries_queries as esda
 import emission.analysis.classification.inference.labels.pipeline as eacilp
+import emission.analysis.classification.inference.labels.inferrers as eacili
 import emission.core.get_database as edb
 import emission.tests.common as etc
 import emission.analysis.configs.expectation_notification_config as eace
 
 class TestExpectationPipeline(unittest.TestCase):
     test_algorithms = {
-            ecwl.AlgorithmTypes.PLACEHOLDER_3: eacilp.placeholder_predictor_3
+            ecwl.AlgorithmTypes.PLACEHOLDER_3: eacili.placeholder_predictor_3
     }
     tz = "America/Chicago"
     contrived_dates = {  # Reused from TestExpectationNotificationConfig

--- a/emission/tests/pipelineTests/TestPipelineStageNonrepetition.py
+++ b/emission/tests/pipelineTests/TestPipelineStageNonrepetition.py
@@ -4,6 +4,7 @@
 
 import unittest
 import numpy as np
+import copy
 
 import emission.tests.common as etc
 import emission.core.get_database as edb
@@ -31,7 +32,7 @@ class TestPipelineStageNonrepetition(unittest.TestCase):
     ]
 
     def setUp(self):
-        self.test_options_stash = eace._test_options
+        self.test_options_stash = copy.copy(eace._test_options)
         eace._test_options = {
             "use_sample": True,
             "override_keylist": None
@@ -51,7 +52,7 @@ class TestPipelineStageNonrepetition(unittest.TestCase):
     def run_pipeline(self, algorithms={ecwl.AlgorithmTypes.PLACEHOLDER_2: eacili.placeholder_predictor_2}):
         primary_algorithms_stash = eacilp.primary_algorithms
         eacilp.primary_algorithms = algorithms
-        test_options_stash = eaue._test_options
+        test_options_stash = copy.copy(eaue._test_options)
         etc.runIntakePipeline(self.testUUID)  # testUUID is set in setupRealExample
         eacilp.primary_algorithms = primary_algorithms_stash
         eaue._test_options = test_options_stash


### PR DESCRIPTION
We always had the pipeline tests checked in, but they were not enabled in the CI since we hadn't checked in an `__init__.py`. Doh!

Fixing the two regressions in the tests + checking in an __init__.py so that they are included in the automated tests.