### PR TITLE
feat: Add timeseries purge script

### DIFF
--- a/bin/purge_user_timeseries.py
+++ b/bin/purge_user_timeseries.py
@@ -1,0 +1,35 @@
+import logging
+import argparse
+import uuid
+from datetime import datetime
+import emission.core.wrapper.user as ecwu
+import emission.core.get_database as edb
+import emission.core.wrapper.pipelinestate as ecwp
+import emission.core.wrapper.pipelinestate as ecwp
+import emission.storage.pipeline_queries as esp
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+
+    parser = argparse.ArgumentParser(prog="purge_user_timeseries")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-e", "--user_email")
+    group.add_argument("-u", "--user_uuid")
+
+    args = parser.parse_args()
+
+    if args.user_uuid:
+        user_id = uuid.UUID(args.user_uuid)
+    else:
+        user_id = ecwu.User.fromEmail(args.user_email).uuid
+
+    cstate = esp.get_current_state(user_id, ecwp.PipelineStages.CREATE_CONFIRMED_OBJECTS)
+    last_ts_run = cstate['last_ts_run']
+
+    if not last_ts_run:
+        logging.warning("No processed timeserie for user {}".format(user_id))
+        exit(1)
+
+    res = edb.get_timeseries_db().delete_many({"user_id": user_id, "metadata.write_ts": { "$lt": last_ts_run}})
+    logging.info("{} deleted entries since {}".format(res.deleted_count, datetime.fromtimestamp(last_ts_run)))
+    


### PR DESCRIPTION
When operating a server with a lot of users, the `Stage_timeseries` database can quickly become quite big.
In the case where only the `Stage_analysis_timeseries` is actually useful after the pipeline execution, the user's timeseries can be deleted to speed up the pipeline and gain some disk space.

@shankari I have concerns about the dates handling. As far as I understand, the `metadata.write_ts` is written by the device for the docs coming from ios/android. If a user edits a trip, the date will change, right?
Now let's assume the following events:
- T0: a user edits a trip on the mobile, with a `metadata.write_ts = T0`
- T1: the pipeline is run on the server, producing a  `last_ts_run = T1`
- T2: the data from the user mobile is sync on the server
- T3: this purge script is run, removing all the timeseries with a `metadata.write_ts  < T1`

But in this scenario, the edited trip with T0 < T1 is not deleted, because it is in the usercache collection, right? It will be moved in the timeseries collection only at the first step of the pipeline. And if a problem occurs during the pipeline execution, the `last_ts_run` date won't be updated for the `CREATE_CONFIRMED_OBJECTS` step.

Hope I understood correctly, please correct me if I'm not!
