### PR TITLE
Configuring PYTHON_LEGACY UUID representation in cfc_webapp.py

### DIFF
--- a/emission/net/api/bottle.py
+++ b/emission/net/api/bottle.py
@@ -14,6 +14,8 @@ License: MIT (see LICENSE for details)
 """
 
 import sys
+import bson.json_util as bju
+from bson.binary import UuidRepresentation
 
 __author__ = 'Marcel Hellkamp'
 __version__ = '0.13-dev'
@@ -2001,7 +2003,7 @@ class JSONPlugin(object):
 
             if isinstance(rv, dict):
                 #Attempt to serialize, raises exception on failure
-                json_response = dumps(rv)
+                json_response = bju.dumps(rv, json_options = bju.LEGACY_JSON_OPTIONS.with_options(uuid_representation= UuidRepresentation.PYTHON_LEGACY))
                 #Set content type only if serialization successful
                 response.content_type = 'application/json'
                 return json_response

--- a/emission/net/api/bottle.py
+++ b/emission/net/api/bottle.py
@@ -14,8 +14,6 @@ License: MIT (see LICENSE for details)
 """
 
 import sys
-import bson.json_util as bju
-from bson.binary import UuidRepresentation
 
 __author__ = 'Marcel Hellkamp'
 __version__ = '0.13-dev'
@@ -2003,7 +2001,7 @@ class JSONPlugin(object):
 
             if isinstance(rv, dict):
                 #Attempt to serialize, raises exception on failure
-                json_response = bju.dumps(rv, json_options = bju.LEGACY_JSON_OPTIONS.with_options(uuid_representation= UuidRepresentation.PYTHON_LEGACY))
+                json_response = dumps(rv)
                 #Set content type only if serialization successful
                 response.content_type = 'application/json'
                 return json_response

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -30,6 +30,7 @@ import requests
 import traceback
 import urllib.request, urllib.error, urllib.parse
 import bson.json_util
+from bson.binary import UuidRepresentation
 
 # Our imports
 import emission.net.api.visualize as visualize
@@ -533,7 +534,7 @@ if __name__ == '__main__':
     for plugin in app.plugins:
         if isinstance(plugin, JSONPlugin):
             print("Replaced json_dumps in plugin with the one from bson")
-            plugin.json_dumps = bson.json_util.dumps
+            plugin.json_dumps = lambda s: bson.json_util.dumps(s, json_options = bson.json_util.LEGACY_JSON_OPTIONS.with_options(uuid_representation= UuidRepresentation.PYTHON_LEGACY))
 
     print("Changing bt.json_loads from %s to %s" % (bt.json_loads, bson.json_util.loads))
     bt.json_loads = bson.json_util.loads


### PR DESCRIPTION
We cannot encode native uuid.UUID with UuidRepresentation.UNSPECIFIED therefore defining uuid_representation as PYTHON_LEGACY fixes the issue 
Contains fix for - https://github.com/e-mission/e-mission-docs/issues/856#issuecomment-1464579523