### PR TITLE
Add in start_confirmed_place

### DIFF
--- a/emission/analysis/plotting/composite_trip_creation.py
+++ b/emission/analysis/plotting/composite_trip_creation.py
@@ -58,6 +58,7 @@ def create_composite_trip(ts, ct):
     # Thus, we are not going to consider it eligible for additions or user input,
     # and so untracked composite objects will not have a confirmed_place.
     if not isUntrackedTime:
+        composite_trip_data["start_confirmed_place"] = eaum.get_confirmed_place_for_confirmed_trip(ct, "start_place")
         composite_trip_data["end_confirmed_place"] = eaum.get_confirmed_place_for_confirmed_trip(ct, "end_place")
     # later we will want to put section & modes in composite_trip as well
     composite_trip_entry = ecwe.Entry.create_entry(ct["user_id"], "analysis/composite_trip", composite_trip_data)

--- a/emission/core/wrapper/compositetrip.py
+++ b/emission/core/wrapper/compositetrip.py
@@ -12,6 +12,7 @@ import emission.core.wrapper.modeprediction as ecwm
 class Compositetrip(ecwc.Confirmedtrip):
     props = ecwc.Confirmedtrip.props
     props.update({#      # confirmedplace stuff
+                  "start_confirmed_place": ecwb.WrapperBase.Access.WORM, # object contains all properties for the source confirmed_place object
                   "end_confirmed_place": ecwb.WrapperBase.Access.WORM, # object contains all properties for the destination confirmed_place object
                   "confirmed_trip": ecwb.WrapperBase.Access.WORM, # the id of the corresponding confirmed trip
                   "locations": ecwb.WrapperBase.Access.WORM, # object containing cleaned location entries (max 100)


### PR DESCRIPTION
Update from https://github.com/shankari/e-mission-server/pull/14/commits/51563afe5710dd807185e5a1b8d0ee4f887989c5 https://github.com/shankari/e-mission-server/pull/14
composite_trip_creation.py
- Add into the composite_trip_data the start_confirmed_place object

compositetrip.py
- Added in the start_confirmed_place into the object properties definition