### PR TITLE
:back: Run validation check for the next trip only when it is expecte…

### DIFF
--- a/emission/analysis/plotting/composite_trip_creation.py
+++ b/emission/analysis/plotting/composite_trip_creation.py
@@ -52,7 +52,7 @@ def create_composite_trip(ts, ct):
         # CREATE_CONFIRMED_OBJECTS stage, so it must be the start place for a new-style
         # confirmed trip
         existing_end_confirmed_place = edb.get_analysis_timeseries_db().find_one({"data.cleaned_place": ct["data"]["end_place"]})
-        if existing_end_confirmed_place is not None:
+        if existing_end_confirmed_place is not None and "starting_trip" in existing_end_confirmed_place["data"]:
             next_trip = edb.get_analysis_timeseries_db().find_one({"data.start_place": existing_end_confirmed_place["_id"]})
             assert next_trip is not None and next_trip["metadata"]["key"] == "analysis/confirmed_trip" \
                 and "additions" in next_trip["data"] and "trip_addition" not in next_trip["data"],\


### PR DESCRIPTION
…d to exist

In 624082e71543f201e581af506deda956acbd17ba, we added a check that

> if we have an end confirmed place, the place should be the start place of a
"new style" confirmed trip

This is generally true EXCEPT if the confirmed place is the end of the confirmed timeline. In that case, there is no next trip.

So we only check for the next trip if the place has a "starting_trip" field and we know that it is not the end of the chain.

This fixes
https://github.com/e-mission/e-mission-docs/issues/898#issuecomment-1528932432