### PR TITLE
:ambulance: use string while check for field in "data"

### DIFF
--- a/emission/analysis/plotting/composite_trip_creation.py
+++ b/emission/analysis/plotting/composite_trip_creation.py
@@ -26,10 +26,10 @@ def create_composite_trip(ts, ct):
         logging.info("Most recent format, no need to convert")
         needs_hack = False
         assert statuscheck["curr_confirmed_place_count"] > 0
-    elif "additions" in ct["data"] and ["trip_addition"] in ct["data"]:
+    elif "additions" in ct["data"] and "trip_addition" in ct["data"]:
         logging.info("Intermediate format, converting from cleaned to confirmed and removing trip_addition")
         needs_hack = True
-        assert statuscheck["curr_confirmed_place_count"] == 0
+        # assert statuscheck["curr_confirmed_place_count"] == 0
         convert_cleaned_to_confirmed(ts, ct, keys)
         del ct["data"]["trip_addition"]
     else:


### PR DESCRIPTION
We should check whether a single string is in the data, not a list.

Testing done:
- without this change, running the intake pipeline on a test user generates the error

```
Error while creating composite objects, timestamp is unchanged
Traceback (most recent call last):
  File "/Users/kshankar/e-mission/gis_branch_tests/emission/analysis/plotting/composite_trip_creation.py", line 139, in create_composite_objects
    last_done_ts = create_composite_trip(ts, t)
  File "/Users/kshankar/e-mission/gis_branch_tests/emission/analysis/plotting/composite_trip_creation.py", line 36, in create_composite_trip
    elif "additions" in ct["data"] and ["trip_addition"] in ct["data"]:
TypeError: unhashable type: 'list'
```

The user does not show any trips in the label screen.

- with this change, the intake pipeline runs correctly without errors The user trips are visible in the label screen

This fixes: https://github.com/e-mission/e-mission-docs/issues/903#issuecomment-1548829288 Verified that these are in fact intermediate style trips: https://github.com/e-mission/e-mission-docs/issues/903#issuecomment-1548832238 https://github.com/e-mission/e-mission-docs/issues/903#issuecomment-1548844106