### PR TITLE
↔️ 🛖 ✅ ✨ Back-fill section summaries in composite trips and section objects in composite trips

### DIFF
--- a/bin/debug/change_deployment_name.py
+++ b/bin/debug/change_deployment_name.py
@@ -1,0 +1,18 @@
+import argparse
+import emission.storage.decorations.user_queries as esdu
+import emission.core.get_database as edb
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("old_deployment_name",
+                        help="the deployment name that the data was copied from")
+    parser.add_argument("new_deployment_name",
+                        help="the deployment name that we want to rename to")
+    args = parser.parse_args()
+
+    all_users = edb.get_uuid_db().find()
+    for u in all_users:
+        u["user_email"] = u["user_email"].replace(args.old_deployment_name, args.new_deployment_name)
+        update_result = edb.get_uuid_db().replace_one({"_id": u["_id"]}, u)
+        if update_result.matched_count != 1 and update_result.modified_count != 1:
+            logging.error("Result %s while updating entry for %s" % (update_result.raw_result, u["user_email"]))

--- a/bin/historical/migrations/add_sections_and_summaries_to_trips.py
+++ b/bin/historical/migrations/add_sections_and_summaries_to_trips.py
@@ -1,0 +1,70 @@
+import logging
+import arrow
+import argparse
+
+import emission.core.get_database as edb
+import emission.core.wrapper.entry as ecwe
+
+import emission.pipeline.scheduler as eps
+
+import emission.storage.timeseries.abstract_timeseries as esta
+import emission.storage.decorations.user_queries as esdu
+import emission.storage.decorations.analysis_timeseries_queries as esda
+import emission.analysis.plotting.composite_trip_creation as eapc
+import emission.analysis.userinput.matcher as eaum
+
+def add_sections_to_trips(process_number, uuid_list):
+    import logging
+    logging.basicConfig(level=logging.DEBUG, filename="/var/tmp/add_section_summary_%s.log" % process_number,
+        force=True)
+    logging.info("processing UUID list = %s" % uuid_list)
+
+    for uuid in uuid_list:
+        if uuid is None:
+            continue
+
+        try:
+            add_sections_to_trips_for_user(uuid)
+        except Exception as e:
+            print("Found error %s while processing pipeline for user %s, check log files for details"
+                % (e, uuid))
+            logging.exception("Found error %s while processing pipeline "
+                              "for user %s, skipping" % (e, uuid))
+    
+def add_sections_to_trips_for_user(uuid):
+    ts = esta.TimeSeries.get_time_series(uuid)
+    cleaned_trips = list(ts.find_entries([esda.CLEANED_TRIP_KEY]))
+    confirmed_trips = list(ts.find_entries([esda.CONFIRMED_TRIP_KEY]))
+    composite_trips =  list(ts.find_entries([esda.COMPOSITE_TRIP_KEY]))
+    cleaned_trips_map = dict((t["_id"], t) for t in cleaned_trips)
+    composite_trips_map = dict((t["data"]["confirmed_trip"], t) for t in composite_trips)
+    # This script is slow due to DB queries
+    # so let's read all the trips upfront, and reuse the section information where possible
+    # don't want to optimize too much, though, since this is a one-off script
+    for t in confirmed_trips:
+        matching_composite_trip = composite_trips_map[t["_id"]]
+        matching_cleaned_trip = cleaned_trips_map[t["data"]["cleaned_trip"]]
+        logging.debug("Processing confirmed trip %s with matching cleaned trip %s, and composite trip %s" %
+            (t["_id"], matching_cleaned_trip["_id"], matching_composite_trip["_id"]))
+        if "inferred_section_summary" not in t["data"]:
+            # we need to add the summary to both the confirmed trip and the associated composite trip
+            t["data"]['inferred_section_summary'] = eaum.get_section_summary(ts, matching_cleaned_trip, "analysis/inferred_section")
+            t["data"]['cleaned_section_summary'] = eaum.get_section_summary(ts, matching_cleaned_trip, "analysis/cleaned_section")
+            matching_composite_trip["data"]["inferred_section_summary"] = t["data"]["inferred_section_summary"]
+            matching_composite_trip["data"]["cleaned_section_summary"] = t["data"]["cleaned_section_summary"]
+            matching_composite_trip["data"]["sections"] = eapc.get_sections_for_confirmed_trip(t)
+
+            import emission.storage.timeseries.builtin_timeseries as estbt
+            estbt.BuiltinTimeSeries.update(ecwe.Entry(t))
+            estbt.BuiltinTimeSeries.update(ecwe.Entry(matching_composite_trip))
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("n_workers", type=int,
+                        help="the number of worker processors to use")
+    args = parser.parse_args()
+    split_lists = eps.get_split_uuid_lists(args.n_workers)
+    logging.info("Finished generating split lists %s" % split_lists)
+    eps.dispatch(split_lists, target_fn=add_sections_to_trips)
+
+

--- a/emission/analysis/plotting/composite_trip_creation.py
+++ b/emission/analysis/plotting/composite_trip_creation.py
@@ -183,7 +183,7 @@ def get_sections_for_confirmed_trip(ct):
     # on the phone, we don't need lists of 'speeds' and 'distances'
     # for every section, and they can get big - so let's save some bandwidth
     for section in sections:
-        section["sensed_mode_str"] = sel_section_mapper(section["data"]["sensed_mode"])
+        section["data"]["sensed_mode_str"] = sel_section_mapper(section["data"]["sensed_mode"])
         del section["data"]["speeds"]
         del section["data"]["distances"]
     return sections

--- a/emission/pipeline/scheduler.py
+++ b/emission/pipeline/scheduler.py
@@ -60,13 +60,15 @@ def get_split_uuid_lists(n_splits):
     logging.debug("Split values are %s" % ret_splits)
     return ret_splits
 
-def dispatch(split_lists):
+def dispatch(split_lists, target_fn=None):
     ctx = mp.get_context('spawn')
     process_list = []
     for i, uuid_list in enumerate(split_lists):
         logging.debug("Dispatching list %s" % uuid_list)
         pid = i
-        p = ctx.Process(target=epi.run_intake_pipeline, args=(pid, uuid_list))
+        if target_fn is None:
+            target_fn = epi.run_intake_pipeline
+        p = ctx.Process(target=target_fn, args=(pid, uuid_list))
         logging.info("Created process %s to process %s list of size %s" %
                      (p, i, len(uuid_list)))
         p.start()

--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -727,6 +727,8 @@ class TestPipelineRealData(unittest.TestCase):
             [s['data']['start_ts'] for s in et['data']['sections']])
         self.assertEqual([s['data']['sensed_mode'] for s in  ct['data']['sections']],
             [l['data']['sensed_mode'] for l in et['data']['sections']])
+        self.assertEqual([s['data']['sensed_mode_str'] for s in  ct['data']['sections']],
+            [l['data']['sensed_mode_str'] for l in et['data']['sections']])
 
     def testJackUntrackedTimeMar12(self):
         dataFile = "emission/tests/data/real_examples/jack_untracked_time_2023-03-12"

--- a/emission/tests/data/real_examples/jack_untracked_time_2023-03-12.expected_composite_trips
+++ b/emission/tests/data/real_examples/jack_untracked_time_2023-03-12.expected_composite_trips
@@ -5802,9 +5802,9 @@
                         },
                         "duration": 8604.69083404541,
                         "distance": 291529.0171651621,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -11850,9 +11850,9 @@
                         },
                         "duration": 8895.362483739853,
                         "distance": 192292.6194098783,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -14015,9 +14015,9 @@
                         },
                         "duration": 788.0030000209808,
                         "distance": 5365.3076466935945,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/jack_untracked_time_2023-03-12.inferred_section.expected_composite_trips
+++ b/emission/tests/data/real_examples/jack_untracked_time_2023-03-12.inferred_section.expected_composite_trips
@@ -5811,9 +5811,9 @@
                         "sensed_mode": 3,
                         "cleaned_section": {
                             "$oid": "649288d8c1bda5e8e4555c76"
-                        }
-                    },
-                    "sensed_mode_str": "BUS"
+                        },
+                        "sensed_mode_str": "BUS"
+                    }
                 }
             ]
         }
@@ -11868,9 +11868,9 @@
                         "sensed_mode": 3,
                         "cleaned_section": {
                             "$oid": "649288d9c1bda5e8e4555d98"
-                        }
-                    },
-                    "sensed_mode_str": "BUS"
+                        },
+                        "sensed_mode_str": "BUS"
+                    }
                 }
             ]
         }
@@ -14042,9 +14042,9 @@
                         "sensed_mode": 3,
                         "cleaned_section": {
                             "$oid": "649288d9c1bda5e8e4555ec5"
-                        }
-                    },
-                    "sensed_mode_str": "BUS"
+                        },
+                        "sensed_mode_str": "BUS"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2016-08-04.all-match-last-place.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2016-08-04.all-match-last-place.expected_composite_trips
@@ -3972,9 +3972,9 @@
                         },
                         "duration": 1880.7650001049042,
                         "distance": 24806.987825634333,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -9453,9 +9453,9 @@
                         },
                         "duration": 8056.584614753723,
                         "distance": 157827.54864780518,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -11064,9 +11064,9 @@
                         },
                         "duration": 605.260315656662,
                         "distance": 299.07376498948594,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -11760,9 +11760,9 @@
                         },
                         "duration": 135.75,
                         "distance": 202.4315483599345,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -13593,9 +13593,9 @@
                         },
                         "duration": 745.4381992816925,
                         "distance": 1401.0643734125963,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -14574,9 +14574,9 @@
                         },
                         "duration": 280.5680000782013,
                         "distance": 149.38151426404383,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -16803,9 +16803,9 @@
                         },
                         "duration": 936.7305357456207,
                         "distance": 1316.3118354165358,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -20973,9 +20973,9 @@
                         },
                         "duration": 5956.420205116272,
                         "distance": 48630.60382206579,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -22257,9 +22257,9 @@
                         },
                         "duration": 232.60321807861328,
                         "distance": 346.3349064026148,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2016-08-04.before-user-inputs.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2016-08-04.before-user-inputs.expected_composite_trips
@@ -3972,9 +3972,9 @@
                         },
                         "duration": 1880.7650001049042,
                         "distance": 24806.987825634333,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -9453,9 +9453,9 @@
                         },
                         "duration": 8056.584614753723,
                         "distance": 157827.54864780518,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -11064,9 +11064,9 @@
                         },
                         "duration": 605.260315656662,
                         "distance": 299.07376498948594,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -11760,9 +11760,9 @@
                         },
                         "duration": 135.75,
                         "distance": 202.4315483599345,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -13593,9 +13593,9 @@
                         },
                         "duration": 745.4381992816925,
                         "distance": 1401.0643734125963,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -14574,9 +14574,9 @@
                         },
                         "duration": 280.5680000782013,
                         "distance": 149.38151426404383,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -16803,9 +16803,9 @@
                         },
                         "duration": 936.7305357456207,
                         "distance": 1316.3118354165358,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -20973,9 +20973,9 @@
                         },
                         "duration": 5956.420205116272,
                         "distance": 48630.60382206579,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -21821,9 +21821,9 @@
                         },
                         "duration": 232.60321807861328,
                         "distance": 346.3349064026148,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2016-08-04.spread-across-aug-5.alt.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2016-08-04.spread-across-aug-5.alt.expected_composite_trips
@@ -3972,9 +3972,9 @@
                         },
                         "duration": 1880.7650001049042,
                         "distance": 24806.987825634333,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -9453,9 +9453,9 @@
                         },
                         "duration": 8056.584614753723,
                         "distance": 157827.54864780518,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -11064,9 +11064,9 @@
                         },
                         "duration": 605.260315656662,
                         "distance": 299.07376498948594,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -11760,9 +11760,9 @@
                         },
                         "duration": 135.75,
                         "distance": 202.4315483599345,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -13593,9 +13593,9 @@
                         },
                         "duration": 745.4381992816925,
                         "distance": 1401.0643734125963,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -14574,9 +14574,9 @@
                         },
                         "duration": 280.5680000782013,
                         "distance": 149.38151426404383,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -16803,9 +16803,9 @@
                         },
                         "duration": 936.7305357456207,
                         "distance": 1316.3118354165358,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -20973,9 +20973,9 @@
                         },
                         "duration": 5956.420205116272,
                         "distance": 48630.60382206579,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -21924,9 +21924,9 @@
                         },
                         "duration": 232.60321807861328,
                         "distance": 346.3349064026148,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -27899,9 +27899,9 @@
                         "sensed_mode": 11,
                         "end_stop": {
                             "$oid": "64928665840476818c3462fc"
-                        }
-                    },
-                    "sensed_mode_str": "AIR_OR_HSR"
+                        },
+                        "sensed_mode_str": "AIR_OR_HSR"
+                    }
                 },
                 {
                     "_id": {
@@ -27978,9 +27978,9 @@
                         },
                         "end_stop": {
                             "$oid": "64928665840476818c3462fd"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 },
                 {
                     "_id": {
@@ -28057,9 +28057,9 @@
                         },
                         "end_stop": {
                             "$oid": "64928665840476818c3462fe"
-                        }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        },
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -28136,9 +28136,9 @@
                         },
                         "end_stop": {
                             "$oid": "64928665840476818c3462ff"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 },
                 {
                     "_id": {
@@ -28215,9 +28215,9 @@
                         },
                         "end_stop": {
                             "$oid": "64928665840476818c346300"
-                        }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        },
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -28291,9 +28291,9 @@
                         "sensed_mode": 2,
                         "start_stop": {
                             "$oid": "64928665840476818c346300"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -29365,9 +29365,9 @@
                         },
                         "duration": 257.169686794281,
                         "distance": 470.39370803512986,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2016-08-04.spread-across-aug-5.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2016-08-04.spread-across-aug-5.expected_composite_trips
@@ -3972,9 +3972,9 @@
                         },
                         "duration": 1880.7650001049042,
                         "distance": 24806.987825634333,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -9453,9 +9453,9 @@
                         },
                         "duration": 8056.584614753723,
                         "distance": 157827.54864780518,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -11064,9 +11064,9 @@
                         },
                         "duration": 605.260315656662,
                         "distance": 299.07376498948594,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -11760,9 +11760,9 @@
                         },
                         "duration": 135.75,
                         "distance": 202.4315483599345,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -13593,9 +13593,9 @@
                         },
                         "duration": 745.4381992816925,
                         "distance": 1401.0643734125963,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -14574,9 +14574,9 @@
                         },
                         "duration": 280.5680000782013,
                         "distance": 149.38151426404383,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -16803,9 +16803,9 @@
                         },
                         "duration": 936.7305357456207,
                         "distance": 1316.3118354165358,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -20973,9 +20973,9 @@
                         },
                         "duration": 5956.420205116272,
                         "distance": 48630.60382206579,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -21924,9 +21924,9 @@
                         },
                         "duration": 232.60321807861328,
                         "distance": 346.3349064026148,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -27777,11 +27777,11 @@
                         "duration": 8543.897000074387,
                         "distance": 497264.4339927665,
                         "sensed_mode": 11,
+                        "sensed_mode_str": "AIR_OR_HSR",
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b33"
                         }
-                    },
-                    "sensed_mode_str": "AIR_OR_HSR"
+                    }
                 },
                 {
                     "_id": {
@@ -27853,14 +27853,14 @@
                         "duration": 880.835000038147,
                         "distance": 894.9272207077103,
                         "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT",
                         "start_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b33"
                         },
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b34"
                         }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                    }
                 },
                 {
                     "_id": {
@@ -27932,14 +27932,14 @@
                         "duration": 630.0,
                         "distance": 5652.850530358306,
                         "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE",
                         "start_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b34"
                         },
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b35"
                         }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -28011,14 +28011,14 @@
                         "duration": 169.0,
                         "distance": 40.61340531827146,
                         "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT",
                         "start_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b35"
                         },
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b36"
                         }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                    }
                 },
                 {
                     "_id": {
@@ -28090,14 +28090,14 @@
                         "duration": 1285.7880001068115,
                         "distance": 12874.534062760293,
                         "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE",
                         "start_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b36"
                         },
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b37"
                         }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -28169,11 +28169,11 @@
                         "duration": 1116.0,
                         "distance": 1382.758453460398,
                         "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT",
                         "start_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b37"
                         }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -29245,9 +29245,9 @@
                         },
                         "duration": 257.169686794281,
                         "distance": 470.39370803512986,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2016-08-04.trip-matches-check-aug-4.alt.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2016-08-04.trip-matches-check-aug-4.alt.expected_composite_trips
@@ -3972,9 +3972,9 @@
                         },
                         "duration": 1880.7650001049042,
                         "distance": 24806.987825634333,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -9541,9 +9541,9 @@
                         },
                         "duration": 8056.584614753723,
                         "distance": 157827.54864780518,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -11240,9 +11240,9 @@
                         },
                         "duration": 605.260315656662,
                         "distance": 299.07376498948594,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -12024,9 +12024,9 @@
                         },
                         "duration": 135.75,
                         "distance": 202.4315483599345,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -14118,9 +14118,9 @@
                         },
                         "duration": 745.4381992816925,
                         "distance": 1401.0643734125963,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -15272,9 +15272,9 @@
                         },
                         "duration": 280.5680000782013,
                         "distance": 149.38151426404383,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -17586,9 +17586,9 @@
                         },
                         "duration": 936.7305357456207,
                         "distance": 1316.3118354165358,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -21756,9 +21756,9 @@
                         },
                         "duration": 5956.420205116272,
                         "distance": 48630.60382206579,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -22707,9 +22707,9 @@
                         },
                         "duration": 232.60321807861328,
                         "distance": 346.3349064026148,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -28682,9 +28682,9 @@
                         "sensed_mode": 11,
                         "end_stop": {
                             "$oid": "64928665840476818c3462fc"
-                        }
-                    },
-                    "sensed_mode_str": "AIR_OR_HSR"
+                        },
+                        "sensed_mode_str": "AIR_OR_HSR"
+                    }
                 },
                 {
                     "_id": {
@@ -28761,9 +28761,9 @@
                         },
                         "end_stop": {
                             "$oid": "64928665840476818c3462fd"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 },
                 {
                     "_id": {
@@ -28840,9 +28840,9 @@
                         },
                         "end_stop": {
                             "$oid": "64928665840476818c3462fe"
-                        }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        },
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -28919,9 +28919,9 @@
                         },
                         "end_stop": {
                             "$oid": "64928665840476818c3462ff"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 },
                 {
                     "_id": {
@@ -28998,9 +28998,9 @@
                         },
                         "end_stop": {
                             "$oid": "64928665840476818c346300"
-                        }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        },
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -29074,9 +29074,9 @@
                         "sensed_mode": 2,
                         "start_stop": {
                             "$oid": "64928665840476818c346300"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -30148,9 +30148,9 @@
                         },
                         "duration": 257.169686794281,
                         "distance": 470.39370803512986,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2016-08-04.trip-matches-check-aug-4.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2016-08-04.trip-matches-check-aug-4.expected_composite_trips
@@ -3972,9 +3972,9 @@
                         },
                         "duration": 1880.7650001049042,
                         "distance": 24806.987825634333,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -9541,9 +9541,9 @@
                         },
                         "duration": 8056.584614753723,
                         "distance": 157827.54864780518,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -11240,9 +11240,9 @@
                         },
                         "duration": 605.260315656662,
                         "distance": 299.07376498948594,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -12024,9 +12024,9 @@
                         },
                         "duration": 135.75,
                         "distance": 202.4315483599345,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -14118,9 +14118,9 @@
                         },
                         "duration": 745.4381992816925,
                         "distance": 1401.0643734125963,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -15272,9 +15272,9 @@
                         },
                         "duration": 280.5680000782013,
                         "distance": 149.38151426404383,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -17586,9 +17586,9 @@
                         },
                         "duration": 936.7305357456207,
                         "distance": 1316.3118354165358,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -21756,9 +21756,9 @@
                         },
                         "duration": 5956.420205116272,
                         "distance": 48630.60382206579,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -22707,9 +22707,9 @@
                         },
                         "duration": 232.60321807861328,
                         "distance": 346.3349064026148,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -28562,9 +28562,9 @@
                         "sensed_mode": 11,
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b33"
-                        }
-                    },
-                    "sensed_mode_str": "AIR_OR_HSR"
+                        },
+                        "sensed_mode_str": "AIR_OR_HSR"
+                    }
                 },
                 {
                     "_id": {
@@ -28641,9 +28641,9 @@
                         },
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b34"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 },
                 {
                     "_id": {
@@ -28720,9 +28720,9 @@
                         },
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b35"
-                        }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        },
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -28799,9 +28799,9 @@
                         },
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b36"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 },
                 {
                     "_id": {
@@ -28878,9 +28878,9 @@
                         },
                         "end_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b37"
-                        }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        },
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -28954,9 +28954,9 @@
                         "sensed_mode": 2,
                         "start_stop": {
                             "$oid": "6491c6d6e4d284fa6c397b37"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -30028,9 +30028,9 @@
                         },
                         "duration": 257.169686794281,
                         "distance": 470.39370803512986,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2023-04-13.all-match-last-place.alt.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2023-04-13.all-match-last-place.alt.expected_composite_trips
@@ -1983,9 +1983,9 @@
                         },
                         "duration": 736.5729999542236,
                         "distance": 4203.60183233713,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -4104,9 +4104,9 @@
                         },
                         "duration": 795.4838781356812,
                         "distance": 405.42749579207134,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -5628,9 +5628,9 @@
                         },
                         "duration": 421.3231294155121,
                         "distance": 237.26692970607118,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -6894,9 +6894,9 @@
                         },
                         "duration": 331.9889998435974,
                         "distance": 251.2941296800962,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -10116,9 +10116,9 @@
                         },
                         "duration": 714.5734598636627,
                         "distance": 4906.45313823509,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2023-04-13.all-match-last-place.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2023-04-13.all-match-last-place.expected_composite_trips
@@ -1983,9 +1983,9 @@
                         "sensed_mode": 0,
                         "end_stop": {
                             "$oid": "6491cccde4d284fa6c397f7d"
-                        }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        },
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -2059,9 +2059,9 @@
                         "sensed_mode": 2,
                         "start_stop": {
                             "$oid": "6491cccde4d284fa6c397f7d"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -4174,9 +4174,9 @@
                         },
                         "duration": 795.4838781356812,
                         "distance": 405.42749579207134,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -5692,9 +5692,9 @@
                         },
                         "duration": 421.3231294155121,
                         "distance": 237.26692970607118,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -6952,9 +6952,9 @@
                         },
                         "duration": 331.9889998435974,
                         "distance": 251.2941296800962,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -10168,9 +10168,9 @@
                         },
                         "duration": 714.5734598636627,
                         "distance": 4906.45313823509,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2023-04-13.before-user-inputs.alt.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2023-04-13.before-user-inputs.alt.expected_composite_trips
@@ -1812,9 +1812,9 @@
                         },
                         "duration": 736.5729999542236,
                         "distance": 4203.60183233713,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -3762,9 +3762,9 @@
                         },
                         "duration": 795.4838781356812,
                         "distance": 405.42749579207134,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -5028,9 +5028,9 @@
                         },
                         "duration": 421.3231294155121,
                         "distance": 237.26692970607118,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -6123,9 +6123,9 @@
                         },
                         "duration": 331.9889998435974,
                         "distance": 251.2941296800962,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -7883,9 +7883,9 @@
                         },
                         "duration": 714.5734598636627,
                         "distance": 4906.45313823509,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2023-04-13.before-user-inputs.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2023-04-13.before-user-inputs.expected_composite_trips
@@ -1810,11 +1810,11 @@
                         "duration": 676.5729999542236,
                         "distance": 4163.979971299704,
                         "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE",
                         "end_stop": {
                             "$oid": "6491cccde4d284fa6c397f7d"
                         }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -1886,11 +1886,11 @@
                         "duration": 28.996999979019165,
                         "distance": 41.170096253577036,
                         "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT",
                         "start_stop": {
                             "$oid": "6491cccde4d284fa6c397f7d"
                         }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -3832,9 +3832,9 @@
                         },
                         "duration": 795.4838781356812,
                         "distance": 405.42749579207134,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -5092,9 +5092,9 @@
                         },
                         "duration": 421.3231294155121,
                         "distance": 237.26692970607118,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -6181,9 +6181,9 @@
                         },
                         "duration": 331.9889998435974,
                         "distance": 251.2941296800962,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -7935,9 +7935,9 @@
                         },
                         "duration": 714.5734598636627,
                         "distance": 4906.45313823509,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2023-04-13.retained-last-place.alt.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2023-04-13.retained-last-place.alt.expected_composite_trips
@@ -1983,9 +1983,9 @@
                         },
                         "duration": 736.5729999542236,
                         "distance": 4203.60183233713,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -4104,9 +4104,9 @@
                         },
                         "duration": 795.4838781356812,
                         "distance": 405.42749579207134,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -5628,9 +5628,9 @@
                         },
                         "duration": 421.3231294155121,
                         "distance": 237.26692970607118,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -6894,9 +6894,9 @@
                         },
                         "duration": 331.9889998435974,
                         "distance": 251.2941296800962,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -10131,9 +10131,9 @@
                         },
                         "duration": 714.5734598636627,
                         "distance": 4906.45313823509,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -13833,9 +13833,9 @@
                         "sensed_mode": 0,
                         "end_stop": {
                             "$oid": "649311f301b03be640ab22b9"
-                        }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        },
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -13909,9 +13909,9 @@
                         "sensed_mode": 2,
                         "start_stop": {
                             "$oid": "649311f301b03be640ab22b9"
-                        }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        },
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -15004,9 +15004,9 @@
                         },
                         "duration": 344.70130729675293,
                         "distance": 344.300169162875,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -17220,9 +17220,9 @@
                         },
                         "duration": 930.1962714195251,
                         "distance": 9357.3566188629,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }

--- a/emission/tests/data/real_examples/shankari_2023-04-13.retained-last-place.expected_composite_trips
+++ b/emission/tests/data/real_examples/shankari_2023-04-13.retained-last-place.expected_composite_trips
@@ -1981,11 +1981,11 @@
                         "duration": 676.5729999542236,
                         "distance": 4163.979971299704,
                         "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE",
                         "end_stop": {
                             "$oid": "6491cccde4d284fa6c397f7d"
                         }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -2057,11 +2057,11 @@
                         "duration": 28.996999979019165,
                         "distance": 41.170096253577036,
                         "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT",
                         "start_stop": {
                             "$oid": "6491cccde4d284fa6c397f7d"
                         }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -4174,9 +4174,9 @@
                         },
                         "duration": 795.4838781356812,
                         "distance": 405.42749579207134,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -5692,9 +5692,9 @@
                         },
                         "duration": 421.3231294155121,
                         "distance": 237.26692970607118,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -6952,9 +6952,9 @@
                         },
                         "duration": 331.9889998435974,
                         "distance": 251.2941296800962,
-                        "sensed_mode": 4
-                    },
-                    "sensed_mode_str": "UNKNOWN"
+                        "sensed_mode": 4,
+                        "sensed_mode_str": "UNKNOWN"
+                    }
                 }
             ]
         }
@@ -10183,9 +10183,9 @@
                         },
                         "duration": 714.5734598636627,
                         "distance": 4906.45313823509,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }
@@ -14048,11 +14048,11 @@
                         "duration": 654.7706747055054,
                         "distance": 2100.999034859527,
                         "sensed_mode": 1,
+                        "sensed_mode_str": "BICYCLING",
                         "end_stop": {
                             "$oid": "6491cdeee4d284fa6c39804d"
                         }
-                    },
-                    "sensed_mode_str": "BICYCLING"
+                    }
                 },
                 {
                     "_id": {
@@ -14124,14 +14124,14 @@
                         "duration": 249.00099992752075,
                         "distance": 4913.9869985030455,
                         "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE",
                         "start_stop": {
                             "$oid": "6491cdeee4d284fa6c39804d"
                         },
                         "end_stop": {
                             "$oid": "6491cdeee4d284fa6c39804e"
                         }
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                    }
                 },
                 {
                     "_id": {
@@ -14203,14 +14203,14 @@
                         "duration": 70.99900007247925,
                         "distance": 194.44143194063557,
                         "sensed_mode": 1,
+                        "sensed_mode_str": "BICYCLING",
                         "start_stop": {
                             "$oid": "6491cdeee4d284fa6c39804e"
                         },
                         "end_stop": {
                             "$oid": "6491cdeee4d284fa6c39804f"
                         }
-                    },
-                    "sensed_mode_str": "BICYCLING"
+                    }
                 },
                 {
                     "_id": {
@@ -14282,11 +14282,11 @@
                         "duration": 29.996000051498413,
                         "distance": 12.990334409243507,
                         "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT",
                         "start_stop": {
                             "$oid": "6491cdeee4d284fa6c39804f"
                         }
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -15373,9 +15373,9 @@
                         },
                         "duration": 344.70130729675293,
                         "distance": 344.300169162875,
-                        "sensed_mode": 2
-                    },
-                    "sensed_mode_str": "ON_FOOT"
+                        "sensed_mode": 2,
+                        "sensed_mode_str": "ON_FOOT"
+                    }
                 }
             ]
         }
@@ -17583,9 +17583,9 @@
                         },
                         "duration": 930.1962714195251,
                         "distance": 9357.3566188629,
-                        "sensed_mode": 0
-                    },
-                    "sensed_mode_str": "IN_VEHICLE"
+                        "sensed_mode": 0,
+                        "sensed_mode_str": "IN_VEHICLE"
+                    }
                 }
             ]
         }


### PR DESCRIPTION
This is a follow on to 
https://github.com/e-mission/e-mission-server/pull/922
in which we back-fill the new fields into existing composite and confirmed trips

Summary of changes:
[↔️ Support running custom functions in the multi-threaded scaffolding](https://github.com/e-mission/e-mission-server/commit/212b8a87910e8486c33d8cd71ca1aa92f8f9e8d8)
[🛖 Migrate old-style trips to include sections and section summaries](https://github.com/e-mission/e-mission-server/commit/4081e54fb69870c86e7934985a0a805c686a70d5)
[🛖 Put the string version of section's sensed mode into the data when …](https://github.com/e-mission/e-mission-server/commit/ad9473531ed1765d1dc7bdb491607bfe0641240f)
[✅ Check for sensed_mode_str in the composite trip tests](https://github.com/e-mission/e-mission-server/commit/d405cfa93ce6e1862418360255be6ffdcd8d293b)
[✨ Utility script to change deployment names](https://github.com/e-mission/e-mission-server/commit/c65cdfb9d29cd1d6fe9b02eca537412944807695)

Testing done:
- loaded fake data, ran pipeline while synced to 88a6e27d2a31edbaadadf6c6d7bd54d792393655, synced to HEAD, ran migration script, checked via the UI
- pulled production data (so it was already without the new fields), ran migration script, checked via the UI