### PR TITLE
🐳 Install jq properly so that we can use it later

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN apt-get install -y -qq wget
 # RUN apt-get -y install nano vim
 
 # install jq to parse json within bash scripts
-RUN curl -o /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq && \
-  chmod +x /usr/local/bin/jq
+RUN apt-get install jq
 
 # cleanup
 RUN apt-get -y remove --purge build-essential

--- a/emission/analysis/plotting/composite_trip_creation.py
+++ b/emission/analysis/plotting/composite_trip_creation.py
@@ -183,7 +183,7 @@ def get_sections_for_confirmed_trip(ct):
     # on the phone, we don't need lists of 'speeds' and 'distances'
     # for every section, and they can get big - so let's save some bandwidth
     for section in sections:
-        section["sensed_mode_str"] = sel_section_mapper(section["data"]["sensed_mode"])
+        section["data"]["sensed_mode_str"] = sel_section_mapper(section["data"]["sensed_mode"])
         del section["data"]["speeds"]
         del section["data"]["distances"]
     return sections


### PR DESCRIPTION
Before this, we were installing `jq` directly from GitHub. That is no longer supported. That location now returns a 403

```
cat /usr/local/bin/jq
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx</center>
</body>
</html>
```
The `jq` documentation now suggests using apt directly https://jqlang.github.io/jq/download/

Changing this to use the newer install method so that we can actually deploy