### PR TITLE
🐳 Install jq properly so that we can use it later

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y -qq wget
 # RUN apt-get -y install nano vim
 
 # install jq to parse json within bash scripts
-RUN apt-get install jq
+RUN apt-get install -y jq
 
 # cleanup
 RUN apt-get -y remove --purge build-essential


### PR DESCRIPTION
5f68b3be18a2c088bcb2e7ed97c7dd4c763dd114 failed during the docker build because we didn't have `-y`. Adding it back and re-committing