### PR TITLE
Set -e to catch errors in conda install Resolves e-mission/e-mission-server#926

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -1,3 +1,4 @@
+set -e
 echo "About to start conda update, this may take some time..."
 source setup/setup_conda.sh Linux-x86_64
 # now install the emission environment


### PR DESCRIPTION
`Set -e` at the top of the file causes setup_config.sh to error out when the conda install runs out of memory. See[ issue #926](https://github.com/e-mission/e-mission-docs/issues/926). 

Testing done:
https://github.com/e-mission/e-mission-docs/issues/926#issuecomment-1626304186