### PR TITLE
Libmamba solver Fixes e-mission/e-mission-docs#926

### DIFF
--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -16,6 +16,8 @@ else
     bash miniconda.sh -b -p $INSTALL_PREFIX
     source $SOURCE_SCRIPT
     hash -r
+    conda install -n base conda-libmamba-solver
+    conda config --set solver libmamba
     conda config --set always_yes yes
     # Useful for debugging any issues with conda
     conda info -a


### PR DESCRIPTION
Setting libmamba as the solver in the setup_conda.sh makes both local runs and runs in GH actions almost twice as fast, while fixing the issue of Docker running out of space to run conda.sh. 

While switching to mamba might be another option if different parts of conda start causing issues, this is a fix to the current issue that has the added benefit of making solving the environment much faster.[ See issue info here.](https://github.com/e-mission/e-mission-docs/issues/926)