### PR TITLE
Addressing vulnerability issues in Docker images

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -9,7 +9,11 @@ source setup/setup.sh
 ## But that doesn't update all packages (e.g. cryptography=38 stays at that
 ## level instead of upgrading to cryptography=40)
 ## So we just manually upgrade the failing dependencies in the base image
-conda install -c conda-forge cryptography=40.0.2 wheel=0.40.0
+## 
+## 10/02 - Mukul
+## - Above comments talk about manually updating cryptography to version 40
+## - I have upgraded to 41.0.4 as per latest vulnerability fixes.
+conda install -c conda-forge cryptography=41.0.4 wheel=0.40.0
 
 ## Remove the old, unused packages to avoid tripping up the checker
 rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0

--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -18,6 +18,7 @@ conda install -c conda-forge cryptography=41.0.4 wheel=0.40.0
 ## Remove the old, unused packages to avoid tripping up the checker
 rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0
 rm -rf /root/miniconda-23.1.0/pkgs/wheel-0.37.1-pyhd3eb1b0_0
+rm -rf /root/miniconda-23.5.2/pkgs/cryptography-39.0.1-py39h9ce1e76_2
 
 # Clean up the conda install
 conda clean -t

--- a/setup/export_versions.sh
+++ b/setup/export_versions.sh
@@ -1,1 +1,2 @@
 export EXP_CONDA_VER=23.5.2
+export EXP_CONDA_VER_SUFFIX=0

--- a/setup/export_versions.sh
+++ b/setup/export_versions.sh
@@ -1,1 +1,1 @@
-export EXP_CONDA_VER=23.1.0
+export EXP_CONDA_VER=23.5.2

--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -7,12 +7,12 @@ if [[ -z $EXP_CONDA_VER || -z $PLATFORM ]]; then
     echo "Usage: setup_conda.sh <platform>"
     echo "   Assumes that the EXP_CONDA_VER variable is set"
     echo "   Platform options are Linux-x86_64, MacOSX-x86_64"
-    echo "   For Windows, manually download and install https://repo.anaconda.com/miniconda/Miniconda3-py39_$EXP_CONDA_VER-1-Windows-x86_64.exe"
+    echo "   For Windows, manually download and install https://repo.anaconda.com/miniconda/Miniconda3-py39_$EXP_CONDA_VER-$EXP_CONDA_VER_SUFFIX-Windows-x86_64.exe"
 else
     INSTALL_PREFIX=$HOME/miniconda-$EXP_CONDA_VER
     SOURCE_SCRIPT="$HOME/miniconda-$EXP_CONDA_VER/etc/profile.d/conda.sh"
     
-    curl -o miniconda.sh -L https://repo.anaconda.com/miniconda/Miniconda3-py39_$EXP_CONDA_VER-0-$PLATFORM.sh;
+    curl -o miniconda.sh -L https://repo.anaconda.com/miniconda/Miniconda3-py39_$EXP_CONDA_VER-$EXP_CONDA_VER_SUFFIX-$PLATFORM.sh;
     bash miniconda.sh -b -p $INSTALL_PREFIX
     source $SOURCE_SCRIPT
     hash -r

--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -12,7 +12,7 @@ else
     INSTALL_PREFIX=$HOME/miniconda-$EXP_CONDA_VER
     SOURCE_SCRIPT="$HOME/miniconda-$EXP_CONDA_VER/etc/profile.d/conda.sh"
     
-    curl -o miniconda.sh -L https://repo.continuum.io/miniconda/Miniconda3-py39_$EXP_CONDA_VER-1-$PLATFORM.sh;
+    curl -o miniconda.sh -L https://repo.anaconda.com/miniconda/Miniconda3-py39_$EXP_CONDA_VER-0-$PLATFORM.sh;
     bash miniconda.sh -b -p $INSTALL_PREFIX
     source $SOURCE_SCRIPT
     hash -r


### PR DESCRIPTION
Fixing CRITICAL and HIGH severity issues detected by AWS Inspector in the Docker images in AWS ECR.

- First off, picking up the certifi package dependency issue.
- Upgrading to a newer version of miniconda which contains the recommended fixed version of certifi.
- Additionally, corrected the curl URL to update the version suffix based on the required miniconda version to be installed.

Working on more vulnerability issues...