### PR TITLE
Updating fixes to vulnerabilities after new observations in Docker image

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -20,7 +20,7 @@ rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0
 rm -rf /root/miniconda-23.1.0/pkgs/wheel-0.37.1-pyhd3eb1b0_0
 rm -rf /root/miniconda-23.5.2/pkgs/cryptography-39.0.1-py39h9ce1e76_2
 rm -rf /root/miniconda-23.5.2/pkgs/certifi-2023.5.7-py39h06a4308_0
-rm -rf /root/miniconda-23.5.2/pkgs/conda-23.5.2-py39h06a4308_0/lib/python3.9/site-packages/tests/conda_env/support/requirements.txt
+rm -rf /root/miniconda-23.5.2/pkgs/conda-23.5.2-py39h06a4308_0/lib/python3.9/site-packages/tests/
 
 # Clean up the conda install
 conda clean -t

--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -19,6 +19,7 @@ conda install -c conda-forge cryptography=41.0.4 wheel=0.40.0
 rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0
 rm -rf /root/miniconda-23.1.0/pkgs/wheel-0.37.1-pyhd3eb1b0_0
 rm -rf /root/miniconda-23.5.2/pkgs/cryptography-39.0.1-py39h9ce1e76_2
+rm -rf /root/miniconda-23.5.2/pkgs/certifi-2023.5.7-py39h06a4308_0
 
 # Clean up the conda install
 conda clean -t

--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -20,6 +20,7 @@ rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0
 rm -rf /root/miniconda-23.1.0/pkgs/wheel-0.37.1-pyhd3eb1b0_0
 rm -rf /root/miniconda-23.5.2/pkgs/cryptography-39.0.1-py39h9ce1e76_2
 rm -rf /root/miniconda-23.5.2/pkgs/certifi-2023.5.7-py39h06a4308_0
+rm -rf /root/miniconda-23.5.2/pkgs/conda-23.5.2-py39h06a4308_0/lib/python3.9/site-packages/tests/conda_env/support/requirements.txt
 
 # Clean up the conda install
 conda clean -t


### PR DESCRIPTION
Creating this Commit / PR to fix observed vulnerabilities after updating in [earlier PR](https://github.com/e-mission/e-mission-server/pull/939).

- Cryptography vulnerability fixed and not being detected in latest image.
- Certifi is also updated to recommended version but a slightly older version also exists which will be removed in this commit.
- Flask still shows up as a vulnerability, but unable to find the package actually being installed when using find ~/miniconda-23.5.2/ -name flask*

For handling the flask vulnerability,
- Observed that the flask package isn't actually installed but just a part of a requirements.txt file in the file path in a conda tests directory.
- Deleting this file since it doesn't seem to be of use in our codebase.