### PR TITLE
Fixed latest Docker vulnerabilities

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -21,6 +21,9 @@ rm -rf /root/miniconda-23.1.0/pkgs/wheel-0.37.1-pyhd3eb1b0_0
 rm -rf /root/miniconda-23.5.2/pkgs/cryptography-39.0.1-py39h9ce1e76_2
 rm -rf /root/miniconda-23.5.2/pkgs/certifi-2023.5.7-py39h06a4308_0
 rm -rf /root/miniconda-23.5.2/pkgs/conda-23.5.2-py39h06a4308_0/lib/python3.9/site-packages/tests/
+rm -rf /root/miniconda-23.5.2/pkgs/urllib3-1.26.16-py39h06a4308_0
+rm -rf /root/miniconda-23.5.2/pkgs/urllib3-1.26.17-pyhd8ed1ab_0
+rm -rf /root/miniconda-23.5.2/envs/emission/lib/python3.9/site-packages/urllib3-1.26.17.dist-info
 
 # Clean up the conda install
 conda clean -t


### PR DESCRIPTION
Found 2 additional vulnerabilities in Docker images:
- urllib3 - [FIXED] by removing stale versions; latest new fixed version was already present.
- libc6 - buffer overflow issue mentioned - however no remediation provided as yet.