### PR TITLE
Fix Docker images vulnerabilities in server base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get install -y -qq wget
 # install jq to parse json within bash scripts
 RUN apt-get install -y jq
 
+RUN apt-get -y -qq update && apt-get -y -qq upgrade
+
 # cleanup
 RUN apt-get -y remove --purge build-essential
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Latest fixes for two newer vulnerabilities - urllib3, libc6.

- urllib3 - Previous commit contains fixes by removing stale package versions. However, vulnerability still exists which is unusual since locally run docker image doesn't contain vulnerable file path. Possibly, next commit resolves this by using latest image.

- libc6 - No remediation available when vulnerability was just found. Remediation is provided now which suggests upgrading all installed packages in base ubuntu image.