### PR TITLE
Fixing latest Docker image vulnerabilities

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -13,7 +13,7 @@ source setup/setup.sh
 ## 10/02 - Mukul
 ## - Above comments talk about manually updating cryptography to version 40
 ## - I have upgraded to 41.0.4 as per latest vulnerability fixes.
-conda install -c conda-forge cryptography=41.0.4 wheel=0.40.0
+conda install -c conda-forge cryptography=41.0.7 wheel=0.40.0
 
 ## Remove the old, unused packages to avoid tripping up the checker
 rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # python 3
-FROM ubuntu:jammy-20231004
+FROM ubuntu:jammy-20231128
 
 MAINTAINER K. Shankari (shankari@eecs.berkeley.edu)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # python 3
-FROM ubuntu:jammy-20231128
+FROM ubuntu:jammy-20231211.1
 
 MAINTAINER K. Shankari (shankari@eecs.berkeley.edu)
 


### PR DESCRIPTION
AWS Inspector found the following vulnerable packages:

CRITICAL
perl

HIGH
nghttp2, libnghttp2-14
cryptography, libssl3
cryptography
libc6, libc-bin

Upgraded perl, libssl3, nghttp2 packages by upgrading base Ubuntu image to latest of the same LTS version - jammy (22.04).

Cryptography package was fixed by mentioning required version to be installed using conda.

Libc6, Libc-bin can be fixed by using apt-get upgrade but this upgrades all packages which is not recommended as a blanket upgrade fix. Possible that a newer Ubuntu version will have fixes for this, as the same issue was encountered last time around.