### PR TITLE
Bulk deletion of site-package/tests

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -20,7 +20,7 @@ rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0
 rm -rf /root/miniconda-23.1.0/pkgs/wheel-0.37.1-pyhd3eb1b0_0
 rm -rf /root/miniconda-23.5.2/pkgs/cryptography-39.0.1-py39h9ce1e76_2
 rm -rf /root/miniconda-23.5.2/pkgs/certifi-2023.5.7-py39h06a4308_0
-rm -rf /root/miniconda-23.5.2/pkgs/conda-23.5.2-py39h06a4308_0/lib/python3.9/site-packages/tests/
+rm -rf /root/miniconda-23.5.2/pkgs/conda-23.5.2-py39h06a4308_0/lib/python3.9/site-packages/tests
 rm -rf /root/miniconda-23.5.2/pkgs/urllib3-1.26.16-py39h06a4308_0
 rm -rf /root/miniconda-23.5.2/pkgs/urllib3-1.26.17-pyhd8ed1ab_0
 rm -rf /root/miniconda-23.5.2/envs/emission/lib/python3.9/site-packages/urllib3-1.26.17.dist-info
@@ -30,6 +30,7 @@ rm -rf /root/miniconda-23.5.2/lib/python3.9/site-packages/tests
 # Clean up the conda install
 conda clean -t
 find /root/miniconda-*/pkgs -wholename \*info/test\* -type d | xargs rm -rf
+find ~/miniconda-23.5.2 -name \*tests\* -path '*/site-packages/*' | grep ".*/site-packages/tests" | xargs rm -rf
 
 if [ -d "webapp/www/" ]; then
     cp /index.html webapp/www/index.html


### PR DESCRIPTION
Added a one line pipe command to remove all occurrences of site-packages/tests occurring in miniconda main directory.
The pipeline works like:
1. Find all packages containing "tests" and having path as "site-packages/tests".
2. Grep only those which have tests immediately below site-package as a subfolder.
3. Remove these folders.