### PR TITLE
Fix for model-build failure due to presence of survey inputs as a dictionary

### DIFF
--- a/emission/analysis/modelling/trip_model/greedy_similarity_binning.py
+++ b/emission/analysis/modelling/trip_model/greedy_similarity_binning.py
@@ -295,6 +295,9 @@ class GreedySimilarityBinning(eamuu.TripModel):
             # compute unique label sets and their probabilities in one cluster
             # 'p' refers to probability
             group_cols = user_label_df.columns.tolist()
+            # Filtering out rows from the user_label_df if they are dictionary objects which come from the survey inputs provided by the users instead of multilabels
+            if 'trip_user_input' in group_cols:
+                user_label_df = user_label_df.loc[user_label_df['trip_user_input'].apply(lambda x: not isinstance(x, dict))]
             unique_labels = user_label_df.groupby(group_cols).size().reset_index(name='uniqcount')
             unique_labels['p'] = unique_labels.uniqcount / sum_trips
             labels_columns = user_label_df.columns.to_list()

--- a/emission/analysis/modelling/trip_model/greedy_similarity_binning.py
+++ b/emission/analysis/modelling/trip_model/greedy_similarity_binning.py
@@ -288,6 +288,7 @@ class GreedySimilarityBinning(eamuu.TripModel):
         probability is estimated with label_count / total_labels.
         """
         for _, bin_record in self.bins.items():
+            # TODO: Revisit after we have unified label and survey inputs (https://github.com/e-mission/e-mission-docs/issues/1045)
             logging.debug("Filtering out any nested dictionaries from the list of dictionary labels")
             filtered_label_dicts = [label_dict for label_dict in bin_record['labels'] if not any(isinstance(x, dict) for x in label_dict.values())]            
             logging.debug("Number of entries after filtering changed %s -> %s" % (len(bin_record['labels']), len(filtered_label_dicts)))

--- a/emission/analysis/modelling/trip_model/greedy_similarity_binning.py
+++ b/emission/analysis/modelling/trip_model/greedy_similarity_binning.py
@@ -297,6 +297,7 @@ class GreedySimilarityBinning(eamuu.TripModel):
             group_cols = user_label_df.columns.tolist()
             # Filtering out rows from the user_label_df if they are dictionary objects which come from the survey inputs provided by the users instead of multilabels
             if 'trip_user_input' in group_cols:
+                logging.debug("Filtering out any dictionary rows from the dataframe provided as survey inputs")
                 user_label_df = user_label_df.loc[user_label_df['trip_user_input'].apply(lambda x: not isinstance(x, dict))]
             unique_labels = user_label_df.groupby(group_cols).size().reset_index(name='uniqcount')
             unique_labels['p'] = unique_labels.uniqcount / sum_trips


### PR DESCRIPTION
This PR is for fixing the failures identified in the model building pipeline in the AWS Cloudwatch logs as highlighted in [this issue](https://github.com/e-mission/e-mission-docs/issues/1039).

The goal is to fix the "TypeError: unhashable type: 'dict'" error.
The reason for this was that some users had data containing survey inputs in the form of a dictionary instead of multilabels which was breaking the groupby() function applied on a dataframe.

The fix involves checking the data type using isinstance() and then apply this check on the entire data frame as a whole instead of doing it iteratively on each row which is much slower.
These rows are then filtered out of the original dataframe leaving behind only the non-dict rows.
The groupby() then works on this new filtered dataframe which should now work and build models.