### PR TITLE
Faster Trip Invalidation

### DIFF
--- a/emission/analysis/intake/segmentation/trip_segmentation.py
+++ b/emission/analysis/intake/segmentation/trip_segmentation.py
@@ -81,8 +81,7 @@ def segment_current_trips(user_id):
         # invalidate in the database.
         out_of_order_id_list = out_of_order_points["_id"].tolist()
         logging.debug("out_of_order_id_list = %s" % out_of_order_id_list)
-        for ooid in out_of_order_id_list:
-            ts.invalidate_raw_entry(ooid)
+        ts.invalidate_raw_entry(out_of_order_id_list)
 
     filters_in_df = loc_df["filter"].dropna().unique()
     logging.debug("Filters in the dataframe = %s" % filters_in_df)

--- a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py
+++ b/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py
@@ -211,7 +211,7 @@ class DwellSegmentationDistFilter(eaist.TripSegmentationMethod):
                     logging.debug("After dropping %d, filtered points = %s" % 
                         (currPoint.idx, self.filtered_points_df.iloc[currPoint.idx - 5:currPoint.idx + 5][["valid", "fmt_time"]]))
                     logging.debug("remove huge invalid ts offset point = %s" % currPoint)
-                    timeseries.invalidate_raw_entry(currPoint["_id"])
+                    timeseries.invalidate_raw_entry([currPoint["_id"]])
                     # We currently re-retrieve the last point every time, so
                     # searching upwards is good enough but if we use
                     # lastPoint = currPoint, we should update currPoint here

--- a/emission/storage/timeseries/abstract_timeseries.py
+++ b/emission/storage/timeseries/abstract_timeseries.py
@@ -108,5 +108,5 @@ class TimeSeries(object):
     def update_data(user_id, key, obj_id, data):
         pass
 
-    def invalidate_raw_entry(self, obj_id):
+    def invalidate_raw_entry(self, list_obj_id):
         pass


### PR DESCRIPTION
Instead of invalidating one ooid from the list at a time, use UpdateOne and bulkwrite to
 invalidate entire list . This is supported by findings here  https://github.com/e-mission/e-mission-docs/issues/1041#issuecomment-1892868291