### PR TITLE
Add trolleybus support

### DIFF
--- a/emission/analysis/classification/inference/mode/rule_engine.py
+++ b/emission/analysis/classification/inference/mode/rule_engine.py
@@ -219,7 +219,7 @@ def collapse_modes(section_entry, modes):
     if len(unique_modes) == 1:
         return list(unique_modes)[0]
 
-    supported_modes = set(['BUS', 'TRAIN', 'LIGHT_RAIL', 'SUBWAY', 'TRAM'])
+    supported_modes = set(['BUS', 'TRAIN', 'LIGHT_RAIL', 'SUBWAY', 'TRAM', 'TROLLEYBUS'])
 
     if not unique_modes.issubset(supported_modes):
         logging.error("unique_modes = %s, but we support only %s" %

--- a/emission/core/wrapper/modeprediction.py
+++ b/emission/core/wrapper/modeprediction.py
@@ -25,6 +25,7 @@ class PredictedModeTypes(enum.Enum):
     SUBWAY = 7
     TRAM = 8
     LIGHT_RAIL = 9
+    TROLLEYBUS = 10
 
 class Modeprediction(ecwb.WrapperBase):
     props = {"trip_id":     ecwb.WrapperBase.Access.WORM,     # the trip that this is part of

--- a/emission/net/ext_service/transit_matching/match_stops.py
+++ b/emission/net/ext_service/transit_matching/match_stops.py
@@ -295,6 +295,8 @@ def extract_railway_modes(stop):
             p_modes.append("TRAM")
         if "light_rail" in stop:
             p_modes.append("LIGHT_RAIL")
+        if "trolleybus" in stop:
+            p_modes.append("TROLLEYBUS")
 
     logging.debug("After extracting data from tags, potential modes = %s" %
         [p for p in p_modes])


### PR DESCRIPTION
Hi!
We are making nice progress at Cozy Cloud by using the e-mission-server architecture. One missing point for us is the support of trolleybus: https://en.wikipedia.org/wiki/Trolleybus, which is a public transportation mode supported by OSM:
https://wiki.openstreetmap.org/wiki/Public_transport
We met many cases of users using such mode, resulting in a pipeline error.

I based my contribution on this commit: https://github.com/e-mission/e-mission-server/commit/b0e7217bed58e3cf4b1db7445a08ecc1a736baf4
Please let me know if it lacks anything!