### PR TITLE
Latest vulnerability fixes

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -13,7 +13,7 @@ source setup/setup.sh
 ## 10/02 - Mukul
 ## - Above comments talk about manually updating cryptography to version 40
 ## - I have upgraded to 41.0.4 as per latest vulnerability fixes.
-conda install -c conda-forge cryptography=41.0.7 wheel=0.40.0
+conda install -c conda-forge cryptography=42.0.0 wheel=0.40.0
 
 ## Remove the old, unused packages to avoid tripping up the checker
 rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0
@@ -26,11 +26,16 @@ rm -rf /root/miniconda-23.5.2/pkgs/urllib3-1.26.17-pyhd8ed1ab_0
 rm -rf /root/miniconda-23.5.2/envs/emission/lib/python3.9/site-packages/urllib3-1.26.17.dist-info
 rm -rf /root/miniconda-23.5.2/lib/python3.9/site-packages/urllib3-1.26.16.dist-info
 rm -rf /root/miniconda-23.5.2/lib/python3.9/site-packages/tests
+rm -rf /root/miniconda-23.5.2/lib/python3.9/site-packages/cryptography-41.0.7.dist-info
 
 # Clean up the conda install
 conda clean -t
 find /root/miniconda-*/pkgs -wholename \*info/test\* -type d | xargs rm -rf
 find ~/miniconda-23.5.2 -name \*tests\* -path '*/site-packages/*' | grep ".*/site-packages/tests" | xargs rm -rf
+
+# Updating bash package to latest version manually 
+apt-get update
+apt-get install bash=5.1-6ubuntu1.1
 
 if [ -d "webapp/www/" ]; then
     cp /index.html webapp/www/index.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # python 3
-FROM ubuntu:jammy-20231211.1
+FROM ubuntu:jammy-20240227
 
 MAINTAINER K. Shankari (shankari@eecs.berkeley.edu)
 


### PR DESCRIPTION
Summary

4 HIGH severity vulnerabilities: cryptography, libgnutls30 (2), bash 


1. libgnutls30: Updated ubuntu version to latest version.
2. cryptography: package updated to suggested version.
3. bash: Updated bash package to latest version manually. Latest Ubuntu version still contains vulnerable package so had to manually upgrade.

-------------

DETAILED 

------------

**1. bash**
Installed: 0:5.1-6ubuntu1.AMD64
Fixed: 0:5.1-6ubuntu1.1

```
# Gives Ubuntu version
$ ldd --version 

Check package version using:
$ dpkg -l | grep bash
```


**Findings:**
- Latest Ubuntu Docker image (jammy 22.04 LTS) was released a month ago and has 19 vulnerabilities including the bash vulnerability.
- Vulnerabilities on Docker website are tagged as Medium but some of these like bash are tagged as High in AWS.
So, cannot risk downloading this image.
- Next latest image is for Noble 24.04 LTS, but not sure if doing a major Ubuntu version upgrade is a good idea or that it might break some code, packages.
- Even the package versions for the vulnerable packages like bash, libgnutls30 are different compared to the jammy version.

**Approach planned:** 
- So, thinking of manually upgrading the libraries if possible using apt-get update && apt-get upgrade.
- But blanket upgrades not recommended ([see this](https://github.com/e-mission/e-mission-server/pull/942/files#r1367561003))

**Actions taken:**
- Using versioned upgrade to install latest [bash package version](https://packages.ubuntu.com/jammy/bash))
Resources: [1](https://askubuntu.com/questions/44122/how-to-upgrade-a-single-package-using-apt-get), [2](https://askubuntu.com/questions/92019/how-to-install-specific-ubuntu-deb-packages-with-exact-version)

`$ apt-get install bash=5.1-6ubuntu1.1 `

Failed initially with error: 
> Package bash is not available, but is referred to by another package. This may mean that the package is missing, has been obsoleted, or is only available from another source
> E: Version '5.1-6ubuntu1.1' for 'bash' was not found

Solved this by running apt-get update ([read here](https://askubuntu.com/a/878509))

Then ran the install command again. 
Working now. "bash" package successfully updated.

—————

**2. libgnutls30**
2 vulnerabilities present for this library.

Installed: 0:3.7.3-4ubuntu1.3.AMD64
Fixed: 0:3.7.3-4ubuntu1.4

```
# Gives Ubuntu version
$ ldd --version 

Check version using:
$ dpkg -l | grep libgnutls30
```

Upgrading to `ubuntu:jammy-20240227` for now, which has the fixed libgnutls30 version.
But this has bash vulnerability which was handled manually (see 1 above)

————————

3. cryptography

Upgraded version from 41.0.7 to 42.0.0
`$ conda install -c conda-forge cryptography=42.0.0 wheel=0.40.0`

Removed older version files
`$ rm -rf /root/miniconda-23.5.2/lib/python3.9/site-packages/cryptography-41.0.7.dist-info`

Tested by “cd” ing into folder, verified that 41.0.7 no longer present, 42.0.0 is the latest version in these locations:
- /root/miniconda-23.5.2/pkgs
- /root/miniconda-23.5.2/lib/python3.9/site-packages


