### PR TITLE
Use e-mission-common in the dashboard notebooks

### DIFF
--- a/setup/environment36.notebook.additions.yml
+++ b/setup/environment36.notebook.additions.yml
@@ -9,3 +9,7 @@ dependencies:
 - jedi=0.18.2
 - jupyterlab=3.6.3
 - matplotlib=3.7.1
+- pip=23.3.1
+- git
+- pip:
+  - git+https://github.com/JGreenlee/e-mission-common@0.4.0


### PR DESCRIPTION
We need to add [https://github.com/JGreenlee/e-mission-common/tree/0.4.0](https://github.com/JGreenlee/e-mission-common/tree/0.4.0) so we can leverage the shared code in the dashboard

This needs more testing before I'll be ready for merge, I'm worried it may only work for me locally because of all of the back and forth I did finding the right configuration. 