### PR TITLE
add 'geocoded_address' to cleanedplace

### DIFF
--- a/emission/analysis/intake/cleaning/clean_and_resample.py
+++ b/emission/analysis/intake/cleaning/clean_and_resample.py
@@ -254,6 +254,7 @@ def get_filtered_place(raw_place):
         reverse_geocoded_json = eco.Geocoder.get_json_reverse(filtered_place_data.location.coordinates[1],
                                                               filtered_place_data.location.coordinates[0])
         if reverse_geocoded_json is not None:
+            filtered_place_data['geocoded_address'] = reverse_geocoded_json['address']
             filtered_place_data.display_name = format_result(reverse_geocoded_json)
     except KeyError as e:
         logging.info("nominatim result does not have an address, skipping")

--- a/emission/core/wrapper/cleanedplace.py
+++ b/emission/core/wrapper/cleanedplace.py
@@ -12,6 +12,7 @@ class Cleanedplace(ecwp.Place):
     props = ecwp.Place.props
     props.update(
         {"raw_places": ecwb.WrapperBase.Access.WORM, # raw places that were combined to from this cleaned place
+         "geocoded_address": ecwb.WrapperBase.Access.WORM, # the 'address' field of the OSM reverse geocoding result
          "display_name": ecwb.WrapperBase.Access.WORM # The human readable name for this place
     })
 

--- a/emission/individual_tests/TestNominatim.py
+++ b/emission/individual_tests/TestNominatim.py
@@ -62,9 +62,13 @@ class NominatimTest(unittest.TestCase):
     def test_get_filtered_place(self):
         fake_place_raw = self.fake_place
         fake_place_data = clean.get_filtered_place(fake_place_raw).__getattr__("data")
-        actual_result = fake_place_data.__getattr__("display_name")
-        expected_result = "Dorrance Street, Providence"
-        self.assertEqual(expected_result, actual_result)
+        actual_display_name = fake_place_data.__getattr__("display_name")
+        expected_display_name = "Dorrance Street, Providence"
+        self.assertEqual(expected_display_name, actual_display_name)
+        actual_geocoded_address = fake_place_data["geocoded_address"]
+        expected_geocoded_address = {'road': 'Dorrance Street', 'city': 'Providence', 'postcode': '02903'}
+        for k in expected_geocoded_address:
+            self.assertEqual(expected_geocoded_address[k], actual_geocoded_address[k])
 
     #Testing make_url_geo, which creates a query URL from the input string. 
     def test_make_url_geo(self):


### PR DESCRIPTION
We already query the OSM / Nominatim API for places in order to reverse-lookup the location. We use this to extract a short "display_name" (e.g. "Vine Street, Cincinnati"). However, this is all we have been using it for; the rest of the response was discarded

For looking up the mix of energy on the grid at a location (https://github.com/e-mission/e-mission-docs/issues/954), we'd like to have the ZIP code. In addition, other fields in the 'address' section of the response may prove useful down the line