### PR TITLE
Fix for redesigned CI/CD pipeline: Added branch in matrix

### DIFF
--- a/.github/workflows/image_build_push.yml
+++ b/.github/workflows/image_build_push.yml
@@ -61,7 +61,11 @@ jobs:
 
     strategy:
       matrix:
-        repo: ['e-mission/op-admin-dashboard', 'e-mission/em-public-dashboard']
+        include:
+          - repo: e-mission/op-admin-dashboard
+            branch: master
+          - repo: e-mission/em-public-dashboard
+            branch: main
 
     steps:
     - uses: actions/checkout@v4
@@ -75,4 +79,4 @@ jobs:
           -H "Authorization: Bearer ${{ secrets.GH_FG_PAT_TAGS }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/${{ matrix.repo }}/actions/workflows/image_build_push.yml/dispatches \
-          -d '{"ref":"master", "inputs": {"docker_image_tag" : "${{ env.DOCKER_IMAGE_TAG }}"}}'
+          -d '{"ref":"${{ matrix.branch }}", "inputs": {"docker_image_tag" : "${{ env.DOCKER_IMAGE_TAG }}"}}'


### PR DESCRIPTION
This branch refers to the target branch in the repos where the workflows are to be triggered. 

For public-dash branch name: main
For admin-dash branch name: master