### PR TITLE
⚡️ Always return an empty `server_to_phone` response

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -235,7 +235,8 @@ def getFromCache():
   logging.debug("Called userCache.get")
   user_uuid=getUUID(request)
   logging.debug("user_uuid %s" % user_uuid)
-  to_phone = usercache.sync_server_to_phone(user_uuid)
+  # to_phone = usercache.sync_server_to_phone(user_uuid)
+  to_phone = []
   return {'server_to_phone': to_phone}
 
 @post('/usercache/put')


### PR DESCRIPTION
We don't actually use the server_to_phone response on the phone since we always retrieve data from the server. This comments out the data that is returned from the server so that we don't waste time reading data that we don't use.

We still get the calls as a coarse ping to know that the app is installed and is working correctly, even if the user is not contributing data. But we don't burn up bandwidth reading unused data from the server.

This cleanup is part of removing the NEW_DATA implicit intent https://github.com/e-mission/e-mission-docs/issues/1079#issuecomment-2309440938

Testing done:
- Before: `08-27 17:26:02.802 11959 12158 I CommunicationHelper: Result Summary JSON = {"server_to_phone": [{"metadata": {"write_ts": 1687907246.5748034, "type": "document", "key": "diary/trips-2016-07-27"}, "data": [{"type": "FeatureCollection", "properties": {"source": "DwellSegmentat length 295649`
- After:  `08-27 18:39:10.918 15925 16081 I CommunicationHelper: Result Summary JSON = {"server_to_phone": []}`