### PR TITLE
🐛 Change the way in which we read the configuration variables

### DIFF
--- a/emission/net/ext_service/push/notify_interface.py
+++ b/emission/net/ext_service/push/notify_interface.py
@@ -24,8 +24,9 @@ push_config = ecbc.get_config('conf/net/ext_service/push.json',
      "PUSH_APP_PACKAGE_NAME": "app_package_name", "PUSH_IOS_TOKEN_FORMAT": "ios_token_format"})
 
 try:
-    logging.info(f"Push configured for app {push_config.get('PUSH_SERVER_AUTH_TOKEN')} using platform {os.getenv('PUSH_PROVIDER')} with token {os.getenv('PUSH_SERVER_AUTH_TOKEN')[:10]}... of length {len(os.getenv('PUSH_SERVER_AUTH_TOKEN'))}")
-except:
+    logging.warning(f"Push configured for app {push_config.get('PUSH_APP_PACKAGE_NAME')} using platform {push_config.get('PUSH_PROVIDER')} with token {push_config.get('PUSH_SERVER_AUTH_TOKEN')[:10]}... of length {len(push_config.get('PUSH_SERVER_AUTH_TOKEN'))}")
+except Exception as e:
+    logging.exception(e)
     logging.warning("push service not configured, push notifications not supported")
 
 class NotifyInterfaceFactory(object):


### PR DESCRIPTION
The changes made to support the new configuration methodology failed with this error

```
ERROR:root:name 'os' is not defined
Traceback (most recent call last):
  File "/usr/src/app/emission/net/ext_service/push/notify_interface.py", line 27, in <module>
    logging.warning(f"Push configured for app {push_config.get('PUSH_APP_PACKAGE_NAME')} using platform {os.getenv('PUSH_PROVIDER')} with token {os.getenv('PUSH_SERVER_AUTH_TOKEN')[:10]}... of length {len(os.getenv('PUSH_SERVER_AUTH_TOKEN'))}")
NameError: name 'os' is not defined
```

The fix is simply to use `push_config.get` instead of `os.getenv`. Also logged the full exception instead of simply generating a warning that the functionality is not supported.

Testing done:
- Before: error above
- After:

```
Found configuration, overriding...
Activating the environment...
Run trip labeling reminder...
WARNING:root:About to read push configuration...
WARNING:root:Push configured for app gov.nrel.cims.openpath using platform firebase with token ... of length 152
```