### PR TITLE
Migrate to the new FCM HTTP v1 API

### DIFF
--- a/conf/net/ext_service/push.json.sample
+++ b/conf/net/ext_service/push.json.sample
@@ -2,5 +2,7 @@
     "provider": "firebase",
     "server_auth_token": "Get from firebase console",
     "app_package_name": "full package name from config.xml. e.g. edu.berkeley.eecs.emission or edu.berkeley.eecs.embase. Defaults to edu.berkeley.eecs.embase",
-    "ios_token_format": "fcm"
+    "ios_token_format": "fcm",
+    "project_id": "Get from the General project settings (https://console.cloud.google.com/project/_/settings/general/) tab of the Firebase console.",
+    "service_account_file": "Download according to the instructions at https://firebase.google.com/docs/cloud-messaging/migrate-v1#provide-credentials-manually and put the path to the file here"
 }

--- a/emission/net/ext_service/push/notify_interface.py
+++ b/emission/net/ext_service/push/notify_interface.py
@@ -21,7 +21,8 @@ import emission.core.backwards_compat_config as ecbc
 
 push_config = ecbc.get_config('conf/net/ext_service/push.json',
     {"PUSH_PROVIDER": "provider", "PUSH_SERVER_AUTH_TOKEN": "server_auth_token",
-     "PUSH_APP_PACKAGE_NAME": "app_package_name", "PUSH_IOS_TOKEN_FORMAT": "ios_token_format"})
+     "PUSH_APP_PACKAGE_NAME": "app_package_name", "PUSH_IOS_TOKEN_FORMAT": "ios_token_format",
+     "PUSH_PROJECT_ID": "project_id", "PUSH_SERVICE_ACCOUNT_FILE": "service_account_file"})
 
 try:
     logging.warning(f"Push configured for app {push_config.get('PUSH_APP_PACKAGE_NAME')} using platform {push_config.get('PUSH_PROVIDER')} with token {push_config.get('PUSH_SERVER_AUTH_TOKEN')[:10]}... of length {len(push_config.get('PUSH_SERVER_AUTH_TOKEN'))}")

--- a/setup/environment36.yml
+++ b/setup/environment36.yml
@@ -20,7 +20,7 @@ dependencies:
 - utm=0.7.0
 - pip:
   - git+https://github.com/JGreenlee/e-mission-common@0.5.3
-  - pyfcm==1.5.4
+  - pyfcm==2.0.1
   - pygeocoder==1.2.5
   - pymongo==4.3.3
   - pykov==0.1


### PR DESCRIPTION
As of July 2024, the FCM legacy API is being decommissioned and performance has been steadily degrading. This was reported by a deployment partner, who highlighted that they were not seeing notifications.
https://firebase.google.com/docs/cloud-messaging/migrate-v1

I fixed this by:
- migrating to the most recent version of `pyfcm`
- switching the authentication method and adding configuration variables for it
- migrating to the new API, the biggest part of which involved creating a backwards compat function since the new version of the library only supports notifying one device at a time

@JGreenlee and @TeachMeTW for visibility. If you do end up implementing push notifications in the admin dashboard, it would be good to clean this up a bit.