### PR TITLE
Update version of e-mission-common

### DIFF
--- a/setup/environment36.yml
+++ b/setup/environment36.yml
@@ -19,7 +19,7 @@ dependencies:
 - scipy=1.10.0
 - utm=0.7.0
 - pip:
-  - git+https://github.com/JGreenlee/e-mission-common@0.5.3
+  - git+https://github.com/JGreenlee/e-mission-common@0.6.0
   - pyfcm==2.0.1
   - pygeocoder==1.2.5
   - pymongo==4.3.3

--- a/setup/environment36.yml
+++ b/setup/environment36.yml
@@ -19,7 +19,7 @@ dependencies:
 - scipy=1.10.0
 - utm=0.7.0
 - pip:
-  - git+https://github.com/JGreenlee/e-mission-common@0.6.0
+  - git+https://github.com/JGreenlee/e-mission-common@0.6.1
   - pyfcm==2.0.1
   - pygeocoder==1.2.5
   - pymongo==4.3.3


### PR DESCRIPTION
Running into issues when trying to import newer functionality to the public dashboard because the version of e-mission-common is `0.5.3` and does not include the functionality that I need