### PR TITLE
wrap call to `generate_summaries` in `asyncio.run()`

### DIFF
--- a/emission/net/api/metrics.py
+++ b/emission/net/api/metrics.py
@@ -7,6 +7,7 @@ standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 import logging
+import asyncio
 
 import emission.analysis.result.metrics.time_grouping as earmt
 import emission.analysis.result.metrics.simple_metrics as earms
@@ -28,7 +29,7 @@ def summarize_by_local_date(user_id, start_ld, end_ld, freq_name, metric_list, i
 def summarize_by_yyyy_mm_dd(user_id, start_ymd, end_ymd, freq, metric_list, include_agg, app_config): 
     time_query = estf.FmtTimeQuery("data.start_fmt_time", start_ymd, end_ymd)
     trips = esda.get_entries(esda.COMPOSITE_TRIP_KEY, None, time_query)
-    return emcms.generate_summaries(metric_list, trips, app_config)
+    return asyncio.run(emcms.generate_summaries(metric_list, trips, app_config))
 
 def _call_group_fn(group_fn, user_id, start_time, end_time, freq, metric_list, include_aggregate):
     summary_fn_list = [earms.get_summary_fn(metric_name)


### PR DESCRIPTION
Because the footprint metrics generation is asynchronous, this call needs to be wrapped in asyncio.run()

Note: `asyncio` is part of the Python standard library since Python 3.4 and does not needs to be added as a dependency