### PR TITLE
Bump emcommon to 0.6.2

### DIFF
--- a/setup/environment36.yml
+++ b/setup/environment36.yml
@@ -19,7 +19,7 @@ dependencies:
 - scipy=1.10.0
 - utm=0.7.0
 - pip:
-  - git+https://github.com/JGreenlee/e-mission-common@0.6.1
+  - git+https://github.com/JGreenlee/e-mission-common@0.6.2
   - pyfcm==2.0.1
   - pygeocoder==1.2.5
   - pymongo==4.3.3


### PR DESCRIPTION
e-mission-common 0.6.2:
> - fix unprocessed trips not being used for footprint metrics
> - fix typo in ntd.ipynb and update intensities JSONs