### PR TITLE
Fix silent push

### DIFF
--- a/bin/push/push_remind.py
+++ b/bin/push/push_remind.py
@@ -1,6 +1,7 @@
 import arrow
 import json
 import logging
+logging.basicConfig(level=logging.INFO)
 import os
 import requests
 import sys
@@ -55,7 +56,6 @@ def bin_users_by_lang(uuid_list, langs, lang_key='phone_lang'):
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
     logging.debug(f"STUDY_CONFIG is {STUDY_CONFIG}")
 
     STUDY_CONFIG = os.getenv('STUDY_CONFIG', "stage-study")
@@ -68,12 +68,12 @@ if __name__ == '__main__':
         sys.exit(1)
     
     dynamic_config = json.loads(r.text)
-    logging.debug(f"Successfully downloaded config with version {dynamic_config['version']} "\
+    logging.info(f"Successfully downloaded config with version {dynamic_config['version']} "\
         f"for {dynamic_config['intro']['translated_text']['en']['deployment_name']} "\
         f"and data collection URL {dynamic_config['server']['connectUrl']}")
     
     if "reminderSchemes" in dynamic_config:
-        logging.debug("Found flexible notification configuration, skipping server-side push")
+        logging.info("Found flexible notification configuration, skipping server-side push")
         sys.exit(0)
 
     # get push notification config (if not present in dynamic_config, use default)
@@ -99,9 +99,9 @@ if __name__ == '__main__':
     # for each language, send a push notification to the selected users in that language
     for lang, uuids_to_notify in filtered_uuids_by_lang.items():
         if len(uuids_to_notify) == 0:
-            logging.debug(f"No users to notify in lang {lang}")
+            logging.info(f"No users to notify in lang {lang}")
             continue
-        logging.debug(f"Sending push notifications to {len(uuids_to_notify)} users in lang {lang}")
+        logging.info(f"Sending push notifications to {len(uuids_to_notify)} users in lang {lang}")
         json_data = {
             "title": push_config["title"][lang],
             "message": push_config["message"][lang],    

--- a/emission/net/ext_service/push/notify_interface_impl/firebase.py
+++ b/emission/net/ext_service/push/notify_interface_impl/firebase.py
@@ -23,6 +23,7 @@ def get_interface(push_config):
 class FirebasePush(pni.NotifyInterface):
     def __init__(self, push_config):
         self.service_account_file = push_config.get("PUSH_SERVICE_ACCOUNT_FILE")
+        self.server_auth_token = push_config.get("PUSH_SERVER_AUTH_TOKEN")
         self.project_id = push_config.get("PUSH_PROJECT_ID")
         if "PUSH_APP_PACKAGE_NAME" in push_config:
             self.app_package_name = push_config.get("PUSH_APP_PACKAGE_NAME")


### PR DESCRIPTION
In https://github.com/e-mission/e-mission-server/pull/980, we migrated the push code over to HTTP v1 of the FCM API.
This appeared to work then, and is still working now **for some deployments**

#### Working (nrel-commute)

```
Found configuration, overriding...
Activating the environment...
Run trip labeling reminder...
WARNING:root:Push configured for app gov.nrel.cims.openpath using platform firebase with token AAAAsojuOg... of length 152
Config file not found, returning a copy of the environment variables instead...
Retrieved config: {'DB_HOST': '...', 'DB_RESULT_LIMIT': None}
Connecting to database URL ...
after mapping iOS tokens, imported 0 -> processed 0
combo token map has 1 ios entries and 1 android entries
Successfully sent to...
{'success': 1, 'failure': 0, 'results': {'...': 'projects/nrel-openpath/messages/0:1728230420488714%3bcd12ae3bcd12ae'}}
Successfully sent to...
{'success': 1, 'failure': 0, 'results': {'...': 'projects/nrel-openpath/messages/1728230420536046'}}
```

or 

```
Found configuration, overriding...
Activating the environment...
Run silent IOS push...
WARNING:root:Push configured for app gov.nrel.cims.openpath using platform firebase with token AAAAsojuOg... of length 152
Config file not found, returning a copy of the environment variables instead...
Retrieved config: {'DB_HOST': '...', 'DB_RESULT_LIMIT': None}
Connecting to database URL ...
after mapping iOS tokens, imported 0 -> processed 0
combo token map has 24 ios entries and 0 android entries
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Successfully sent to ...
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Successfully sent to ...
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Successfully sent to ...
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Successfully sent to ...
Found error Token not registered while sending to token ... skipping
Found error Token not registered while sending to token ... skipping
Successfully sent to ...
Successfully sent to ...
Successfully sent to ...
{'success': 7, 'failure': 17, 'results': {}
{'ios': {'success': 7, 'failure': 17, 'results': {}}
```

#### Not working (ccebike)

```
Found configuration, overriding...
Activating the environment...
Run silent IOS push...
WARNING:root:Push configured for app ... using platform firebase with token ... of length 152
Config file not found, returning a copy of the environment variables instead...
Retrieved config: {'DB_HOST': '', 'DB_RESULT_LIMIT': None}
Connecting to database URL ...
Traceback (most recent call last):
  File "/usr/src/app/bin/push/silent_ios_push.py", line 24, in <module>
    response = pnu.send_silent_notification_to_ios_with_interval(args.interval, dev=args.dev)
  File "/usr/src/app/emission/net/ext_service/push/notify_usage.py", line 41, in send_silent_notification_to_ios_with_interval
    return __get_default_interface__().send_silent_notification(token_map, 
{}
, dev)
  File "/usr/src/app/emission/net/ext_service/push/notify_interface_impl/firebase.py", line 194, in send_silent_notification
    fcm_token_map = self.convert_to_fcm_if_necessary(token_map, dev)
  File "/usr/src/app/emission/net/ext_service/push/notify_interface_impl/firebase.py", line 137, in convert_to_fcm_if_necessary
    importedResultList = self.retrieve_fcm_tokens(unmapped_token_list, dev)
  File "/usr/src/app/emission/net/ext_service/push/notify_interface_impl/firebase.py", line 98, in retrieve_fcm_tokens
    importHeaders = {"Authorization": "key=%s" % self.server_auth_token,
AttributeError: 'FirebasePush' object has no attribute 'server_auth_token'
```

```
Found configuration, overriding...
Activating the environment...
Run trip labeling reminder...
WARNING:root:Push configured for app ... using platform firebase with token ... of length 152
Config file not found, returning a copy of the environment variables instead...
Traceback (most recent call last):
Retrieved config: {'DB_HOST': '...', 'DB_RESULT_LIMIT': None}
  File "/usr/src/app/bin/push/push_remind.py", line 109, in <module>
Connecting to database URL mongodb://...
    response = pnu.send_visible_notification_to_users(uuids_to_notify,
  File "/usr/src/app/emission/net/ext_service/push/notify_usage.py", line 28, in send_visible_notification_to_users
    return __get_default_interface__().send_visible_notification(token_map, title, message, json_data, dev)
  File "/usr/src/app/emission/net/ext_service/push/notify_interface_impl/firebase.py", line 155, in send_visible_notification
    fcm_token_map = self.convert_to_fcm_if_necessary(token_map, dev)
  File "/usr/src/app/emission/net/ext_service/push/notify_interface_impl/firebase.py", line 137, in convert_to_fcm_if_necessary
    importedResultList = self.retrieve_fcm_tokens(unmapped_token_list, dev)
  File "/usr/src/app/emission/net/ext_service/push/notify_interface_impl/firebase.py", line 98, in retrieve_fcm_tokens
    importHeaders = {"Authorization": "key=%s" % self.server_auth_token,
AttributeError: 'FirebasePush' object has no attribute 'server_auth_token'
```