### PR TITLE
 Reduce Timing Measurement Scope to Bottom 80% of Tracked Functions

### DIFF
--- a/emission/analysis/intake/segmentation/trip_segmentation.py
+++ b/emission/analysis/intake/segmentation/trip_segmentation.py
@@ -51,37 +51,27 @@ class TripSegmentationMethod(object):
         pass
     
 def segment_current_trips(user_id):
-    with ect.Timer() as t_get_time_series:
-        ts = esta.TimeSeries.get_time_series(user_id)
-    esds.store_pipeline_time(user_id, ecwp.PipelineStages.TRIP_SEGMENTATION.name + "/get_time_series", time.time(), t_get_time_series.elapsed)
+    ts = esta.TimeSeries.get_time_series(user_id)
 
-    with ect.Timer() as t_get_time_range:
-        time_query = epq.get_time_range_for_segmentation(user_id)
-    esds.store_pipeline_time(user_id, ecwp.PipelineStages.TRIP_SEGMENTATION.name + "/get_time_range_for_segmentation", time.time(), t_get_time_range.elapsed)
+    time_query = epq.get_time_range_for_segmentation(user_id)
 
     import emission.analysis.intake.segmentation.trip_segmentation_methods.dwell_segmentation_time_filter as dstf
     import emission.analysis.intake.segmentation.trip_segmentation_methods.dwell_segmentation_dist_filter as dsdf
 
-    with ect.Timer() as t_create_time_filter:
-        dstfsm = dstf.DwellSegmentationTimeFilter(time_threshold=5 * 60,  # 5 mins
-                                                 point_threshold=9,
-                                                 distance_threshold=100)  # 100 m
-    esds.store_pipeline_time(user_id, ecwp.PipelineStages.TRIP_SEGMENTATION.name + "/create_time_filter", time.time(), t_create_time_filter.elapsed)
+    dstfsm = dstf.DwellSegmentationTimeFilter(time_threshold=5 * 60,  # 5 mins
+                                                point_threshold=9,
+                                                distance_threshold=100)  # 100 m
 
-    with ect.Timer() as t_create_dist_filter:
-        dsdfsm = dsdf.DwellSegmentationDistFilter(time_threshold=10 * 60,  # 10 mins
-                                                 point_threshold=9,
-                                                 distance_threshold=50)  # 50 m
-    esds.store_pipeline_time(user_id, ecwp.PipelineStages.TRIP_SEGMENTATION.name + "/create_dist_filter", time.time(), t_create_dist_filter.elapsed)
+    dsdfsm = dsdf.DwellSegmentationDistFilter(time_threshold=10 * 60,  # 10 mins
+                                                point_threshold=9,
+                                                distance_threshold=50)  # 50 m
 
     filter_methods = {"time": dstfsm, "distance": dsdfsm}
     filter_method_names = {"time": "DwellSegmentationTimeFilter", "distance": "DwellSegmentationDistFilter"}
 
     # We need to use the appropriate filter based on the incoming data
     # So let's read in the location points for the specified query
-    with ect.Timer() as t_get_data_df:
-        loc_df = ts.get_data_df("background/filtered_location", time_query)
-    esds.store_pipeline_time(user_id, ecwp.PipelineStages.TRIP_SEGMENTATION.name + "/get_data_df", time.time(), t_get_data_df.elapsed)
+    loc_df = ts.get_data_df("background/filtered_location", time_query)
 
     if len(loc_df) == 0:
         # no new segments, no need to keep looking at these again
@@ -89,24 +79,21 @@ def segment_current_trips(user_id):
         epq.mark_segmentation_done(user_id, None)
         return
 
-    with ect.Timer() as t_handle_out_of_order:
-        out_of_order_points = loc_df[loc_df.ts.diff() < 0]
-        if len(out_of_order_points) > 0:
-            logging.info("Found out of order points!")
-            logging.info("%s" % out_of_order_points)
-            # drop from the table
-            loc_df = loc_df.drop(out_of_order_points.index.tolist())
-            loc_df.reset_index(inplace=True)
-            # invalidate in the database.
-            out_of_order_id_list = out_of_order_points["_id"].tolist()
-            logging.debug("out_of_order_id_list = %s" % out_of_order_id_list)
-            for ooid in out_of_order_id_list:
-                ts.invalidate_raw_entry(ooid)
-    esds.store_pipeline_time(user_id, ecwp.PipelineStages.TRIP_SEGMENTATION.name + "/handle_out_of_order_points", time.time(), t_handle_out_of_order.elapsed)
+    out_of_order_points = loc_df[loc_df.ts.diff() < 0]
+    if len(out_of_order_points) > 0:
+        logging.info("Found out of order points!")
+        logging.info("%s" % out_of_order_points)
+        # drop from the table
+        loc_df = loc_df.drop(out_of_order_points.index.tolist())
+        loc_df.reset_index(inplace=True)
+        # invalidate in the database.
+        out_of_order_id_list = out_of_order_points["_id"].tolist()
+        logging.debug("out_of_order_id_list = %s" % out_of_order_id_list)
+        for ooid in out_of_order_id_list:
+            ts.invalidate_raw_entry(ooid)
 
-    with ect.Timer() as t_get_filters:
-        filters_in_df = loc_df["filter"].dropna().unique()
-    esds.store_pipeline_time(user_id, ecwp.PipelineStages.TRIP_SEGMENTATION.name + "/get_filters_in_df", time.time(), t_get_filters.elapsed)
+
+    filters_in_df = loc_df["filter"].dropna().unique()
 
     logging.debug("Filters in the dataframe = %s" % filters_in_df)
     if len(filters_in_df) == 1:


### PR DESCRIPTION
## Summary
Focuses on reducing the scope of timing measurements to only the bottom 80% of tracked functions. The changes remove measurement for functions contributing less significantly to overall execution time.

## Changes
- Functions removed from timing measurement (bottom 80%):
  - `TRIP_SEGMENTATION/create_dist_filter`
  - `TRIP_SEGMENTATION/create_time_filter`
  - `TRIP_SEGMENTATION/get_data_df`
  - `TRIP_SEGMENTATION/get_filters_in_df`
  - `TRIP_SEGMENTATION/get_time_range_for_segmentation`
  - `TRIP_SEGMENTATION/get_time_series`
  - `TRIP_SEGMENTATION/handle_out_of_order_points`
  - `TRIP_SEGMENTATION/segment_into_trips_dist/check_transitions_post_loop`
  - `TRIP_SEGMENTATION/segment_into_trips_dist/continue_just_ended`
  - `TRIP_SEGMENTATION/segment_into_trips_dist/get_transition_df`
  - `TRIP_SEGMENTATION/segment_into_trips_dist/mark_valid`
  - `TRIP_SEGMENTATION/segment_into_trips_dist/post_loop`
  - `TRIP_SEGMENTATION/segment_into_trips_dist/set_new_trip_start_point`

- Retained function timings for:
  - `ACCURACY_FILTERING`
  - `CLEAN_RESAMPLING`
  - `CREATE_COMPOSITE_OBJECTS`
  - `CREATE_CONFIRMED_OBJECTS`
  - `EXPECTATION_POPULATION`
  - `JUMP_SMOOTHING`
  - `LABEL_INFERENCE`
  - `MODE_INFERENCE`
  - `STORE_USER_STATS`
  - `USER_INPUT_MATCH_INCOMING`
  - `TRIP_SEGMENTATION/segment_into_trips_dist/get_filtered_points_df`

## Context
Currently, only the `dist_filter` function was triggered in the staging dataset. I'll test locally to determine if the `time_filter` function can be triggered in additional scenarios. 

The focus of this PR is exclusively on functions in the bottom 80% of tracked execution times. An exploration of the top 20% will follow in a subsequent PR.

## Testing Plan
- Conduct local testing to confirm:
  - Functionality is unaffected by the removal of timing measurements.
  - Triggers for `time_filter` and other functions behave as expected in local and staging environments.

## Next Steps
- Monitor performance in staging with reduced scope.
- Prepare a follow-up PR to address timing measurements for the top 20% of tracked functions.
