### PR TITLE
Fix `DB_RESULT_LIMIT` Parsing to Allow Integer Configuration

### DIFF
--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -23,7 +23,7 @@ for key in ["DB_HOST", "DB_RESULT_LIMIT"]:
         db_config[key] = None
 print("Retrieved config: %s" % db_config)
 url = config.get("DB_HOST", "localhost")
-result_limit = config.get("DB_RESULT_LIMIT", 250000)
+result_limit = int(config.get("DB_RESULT_LIMIT", 250000))
 
 try:
     parsed=pymongo.uri_parser.parse_uri(url)

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -23,7 +23,10 @@ for key in ["DB_HOST", "DB_RESULT_LIMIT"]:
         db_config[key] = None
 print("Retrieved config: %s" % db_config)
 url = config.get("DB_HOST", "localhost")
-result_limit = int(config.get("DB_RESULT_LIMIT", 250000))
+try:
+    result_limit = int(config.get("DB_RESULT_LIMIT", 250000))
+except ValueError:
+    result_limit = 250000
 
 try:
     parsed=pymongo.uri_parser.parse_uri(url)


### PR DESCRIPTION
## Summary

Fixes an issue where the `DB_RESULT_LIMIT` configuration was being treated as a string, preventing it from being set as an integer dynamically. The update ensures the value is properly parsed as an integer, enabling correct configuration usage.

## Changes

- Ensures `DB_RESULT_LIMIT` is parsed as an integer.
- Retains the default value of `250000` if the configuration is not explicitly set.

## Why This Fix?

- Previously, the value of `DB_RESULT_LIMIT` was treated as a string, leading to unexpected behavior when attempting to use or override it.
- This change resolves the type mismatch and ensures the value can be correctly parsed and used as an integer.

## Testing
- Tested with no `DB_RESULT_LIMIT` set: defaults to `250000`.
- Tested with `DB_RESULT_LIMIT` set to a valid integer: properly reflects the configured value.
- Tested with invalid `DB_RESULT_LIMIT` (non-numeric string): verified that it raises an appropriate error -- defaults to 250,000 if error


<img width="827" alt="image" src="https://github.com/user-attachments/assets/da84c367-df5c-4743-b43e-213ef6c1d710">

