### PR TITLE
Fix file handling to prevent ValueError 

### DIFF
--- a/emission/net/ext_service/transit_matching/match_stops.py
+++ b/emission/net/ext_service/transit_matching/match_stops.py
@@ -15,12 +15,12 @@ except:
     url = "https://lz4.overpass-api.de/"
 
 try:
-    query_file = open('conf/net/ext_service/overpass_transit_stops_query_template')
-except:
+    with open('conf/net/ext_service/overpass_transit_stops_query_template', 'r', encoding='UTF-8') as query_file:
+        query_string = "".join(query_file.readlines())
+except FileNotFoundError:
     print("transit stops query not configured, falling back to default")
-    query_file = open('conf/net/ext_service/overpass_transit_stops_query_template.sample')
-
-query_string = "".join(query_file.readlines())
+    with open('conf/net/ext_service/overpass_transit_stops_query_template.sample', 'r', encoding='UTF-8') as query_file:
+        query_string = "".join(query_file.readlines())
 
 RETRY = -1
 


### PR DESCRIPTION
## Summary
This PR resolves an issue where improper file handling caused the following error:
`ValueError: I/O operation on closed file`
when running `runAllTests.sh`


The error occurred because the code attempted to read from a file after it had already been closed. The issue was present both in the original code, which didn’t explicitly close the file, and in a later version where a redundant file read was placed after the file had been closed by a `with` statement.

## Changes Made
- Updated file handling to use `with` statements for proper resource management and automatic file closing.
- Removed redundant `query_string = "".join(query_file.readlines())` line that attempted to read the file after it had been closed.
- Ensured `query_string` is fully assigned within the scope of the `with` block.

## Impact
- Fixes `ValueError: I/O operation on closed file`.

## How to Test
1. Run the script that previously caused the terminal to crash.
2. Verify that there are no `ValueError` exceptions in the logs.

Affected #993 

