### PR TITLE
🛂 Fix authorization while mapping APNS tokens to FCM

### DIFF
--- a/bin/push/silent_ios_push.py
+++ b/bin/push/silent_ios_push.py
@@ -7,6 +7,7 @@ standard_library.install_aliases()
 from builtins import *
 import json
 import logging
+logging.basicConfig(level=logging.DEBUG)
 import argparse
 
 import emission.net.ext_service.push.notify_usage as pnu


### PR DESCRIPTION
FCM is doubling down on the "I'm going to change my API and break everything" approach. We made one round of fixes in: https://github.com/e-mission/e-mission-docs/issues/1094#issuecomment-2395599699
at which time the mapping to convert APNS tokens to FCM was working
    
However, in the ~ 2 months since, that has also regressed, and we are now getting a 401 error with the old code.

The new requirements include:
- using an OAuth2 token instead of the server API key
- passing in `"access_token_auth": "true"` as a header

https://developers.google.com/instance-id/reference/server
> <img width="1097" alt="Screenshot 2024-12-16 at 2 32 42 PM" src="https://github.com/user-attachments/assets/7c901ddf-7807-4247-8923-664a730f6c67" />

The current headers don't match these requirements

```
        importHeaders = {"Authorization": "key=%s" % self.server_auth_token,
                         "Content-Type": "application/json"}
```

We already use an OAuth2 token to log in and actually send the messages
    
```
DEBUG:google.auth.transport.requests:Making request: POST https://oauth2.googleapis.com/token
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): oauth2.googleapis.com:443
DEBUG:urllib3.connectionpool:https://oauth2.googleapis.com:443 "POST /token HTTP/1.1" 200 None
DEBUG:urllib3.connectionpool:Starting new HTTPS connection (1): fcm.googleapis.com:443
```
    
So it seems like it would be best to just reuse it for this call as well. However, that token is retrieved from within the pyfcm library and is not easily exposed outside the library.

<details>
<summary>The token is retrieved using in `_get_access_token`</summary>

```
    def _get_access_token(self):
        """
        Generates access token from credentials.
        If token expires then new access token is generated.
        Returns:
             str: Access token
        """
        # get OAuth 2.0 access token
        try:
            if self.service_account_file:
                credentials = service_account.Credentials.from_service_account_file(
                    self.service_account_file,
                    scopes=["https://www.googleapis.com/auth/firebase.messaging"],
                )
            else:
                credentials = self.credentials
            request = google.auth.transport.requests.Request()
            credentials.refresh(request)
            return credentials.token
        except Exception as e:
            raise InvalidDataError(e)
```

</details>

<details>
<summary>which is called automatically in `requests_session` </summary>

```
    @property
    def requests_session(self):
        if getattr(self.thread_local, "requests_session", None) is None:
            retries = Retry(
                backoff_factor=1,
                status_forcelist=[502, 503],
                allowed_methods=(Retry.DEFAULT_ALLOWED_METHODS | frozenset(["POST"])),
            )
            adapter = self.custom_adapter or HTTPAdapter(max_retries=retries)
            self.thread_local.requests_session = requests.Session()
            self.thread_local.requests_session.mount("http://", adapter)
            self.thread_local.requests_session.mount("https://", adapter)
            self.thread_local.token_expiry = 0

        current_timestamp = time.time()
        if self.thread_local.token_expiry < current_timestamp:
            self.thread_local.requests_session.headers.update(self.request_headers())
            self.thread_local.token_expiry = current_timestamp + 1800
        return self.thread_local.requests_session
```

</details>

However, the `requests_session` only caches a property on when the token expires, it does not cache the token itself.
It does cache the headers and update them periodically, so instead of retrieving the token, this change retrieves the entire authorization header. This header includes the token, but is also formatted correctly with the `Bearer` prefix, so we can use it directly.
    
With this change, the mapping is successful and both silent and visible push notification are sent to iOS phones.
Please see testing details in 
400f9fa95f9cd1d8e64e8217cf27e7bfa8361112

