### PR TITLE
fix EnvironmentLocationNotFound error during test-with-manual-install

### DIFF
--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -70,4 +70,6 @@ jobs:
 
     - name: Teardown the test environment
       shell: bash -l {0}
-      run: source setup/teardown_tests.sh
+      run: |
+        source setup/activate_conda.sh
+        source setup/teardown_tests.sh


### PR DESCRIPTION
"Teardown the test environment" has been consistently failing for the last month or so.
```
Run source setup/teardown_tests.sh
Removing environment from
CondaError: Run 'conda init' before 'conda deactivate'
EnvironmentLocationNotFound: Not a conda environment: /usr/share/miniconda/envs/emissiontest
Error: Process completed with exit code 1.
```

I noticed that test-with-manual-install.yml follows a similar teardown procedure (with 'emission' as the environment instead of 'emissiontest') I saw that test-with-manual-install.yml invokes activates_conda.sh again right before calling the teardown script