### PR TITLE
Log and resolve errors in uploading data due to Firebase API changes

### DIFF
--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -51,14 +51,19 @@ def sync_phone_to_server(uuid, data_from_phone):
                         'metadata.type': data["metadata"]["type"],
                         'metadata.write_ts': data["metadata"]["write_ts"],
                         'metadata.key': data["metadata"]["key"]}
-        result = usercache_db.update_one(update_query,
-                                           document,
-                                           upsert=True)
-        logging.debug("Updated result for user = %s, key = %s, write_ts = %s = %s" % 
-            (uuid, data["metadata"]["key"], data["metadata"]["write_ts"], result.raw_result))
+        try:
+            result = usercache_db.update_one(update_query,
+                                               document,
+                                               upsert=True)
+            logging.debug("Updated result for user = %s, key = %s, write_ts = %s = %s" %
+                (uuid, data["metadata"]["key"], data["metadata"]["write_ts"], result.raw_result))
 
-        # I am not sure how to trigger a writer error to test this
-        # and whether this is the format expected from the server in the rawResult
-        if 'ok' in result.raw_result and result.raw_result['ok'] != 1.0:
-            logging.error("In sync_phone_to_server, err = %s" % result.raw_result['writeError'])
-            raise Exception()
+            # I am not sure how to trigger a writer error to test this
+            # and whether this is the format expected from the server in the rawResult
+            if 'ok' in result.raw_result and result.raw_result['ok'] != 1.0:
+                logging.error("In sync_phone_to_server, err = %s" % result.raw_result['writeError'])
+                raise Exception()
+        except pymongo.errors.PyMongoError as e:
+            logging.error(f"In sync_phone_to_server, while executing {update_query=} on {document=}")
+            logging.exception(e)
+            raise


### PR DESCRIPTION
While investigating user-reported issues about trips not visible in the admin dashboard, we found

We got several `T_RECEIVED_SILENT_PUSH` on Jan 1.

```
2025-01-01T09:52:46.052520-08:00	In TripDiaryStateMachine, received transition T_RECEIVED_SILENT_PUSH in state STATE_WAITING_FOR_TRIP_START
```

but 1154 transitions are still stuck on the phone and none on the server

```
2025-01-02T09:48:21.513590-08:00	"getRawEntries, args: [[""statemachine/transition""],1735275600,1735880399.999]; got 0 entries"
2025-01-02T09:48:21.524160-08:00	Found 1154 transitions. yay!
```

We investigated this in an internal issue; I'm copying over the relevant messages here