### PR TITLE
✂️ Add script to purge inactive users from decommissioned deployments

### DIFF
--- a/bin/historical/migrations/_common.py
+++ b/bin/historical/migrations/_common.py
@@ -33,6 +33,10 @@ def run_on_all_deployments(fn_to_run):
     The list of deployments (PROD_LIST) is retrieved from the
       nrel-openpath-deploy-configs repo upon initialization of this module.
     """
+    print(f'About to run {fn_to_run.__name__} on {len(PROD_LIST)} deployments. Proceed? [y/n]')
+    if input() != 'y':
+        print("Aborting")
+        return
     for prod in PROD_LIST:
         prod_db_name = prod.replace("-", "_")
         print(f"Running {fn_to_run.__name__} for {prod} on DB {prod_db_name}")

--- a/bin/historical/migrations/purge_inactive_users.py
+++ b/bin/historical/migrations/purge_inactive_users.py
@@ -1,0 +1,64 @@
+import arrow
+import pymongo
+import emission.core.get_database as edb
+import emission.storage.timeseries.abstract_timeseries as esta
+import bin.debug.common as common
+from _common import run_on_all_deployments
+
+SECONDS_90_DAYS = 60 * 60 * 24 * 90
+
+NOW_SECONDS = arrow.now().timestamp()
+
+def find_inactive_uuids(uuids_entries):
+    '''
+    Users are inactive if:
+     - no API calls in the last 90 days
+      AND
+     - no locations in the last 90 days
+    '''
+    inactive_uuids = []
+    for u in uuids_entries:
+        print(f'Checking activity for user {u["uuid"]}')
+        ts = esta.TimeSeries.get_time_series(u['uuid'])
+
+        last_call_ts = ts.get_first_value_for_field(
+            key='stats/server_api_time',
+            field='data.ts',
+            sort_order=pymongo.DESCENDING
+        )
+        print(f'for user {u["uuid"]}, last call was {last_call_ts}')
+        if last_call_ts > NOW_SECONDS - SECONDS_90_DAYS:
+            continue
+
+        last_loc_ts = ts.get_first_value_for_field(
+            key='background/location',
+            field='data.ts',
+            sort_order=pymongo.DESCENDING
+        )
+        print(f'for user {u["uuid"]}, last location was {last_loc_ts}')
+        if last_loc_ts > NOW_SECONDS - SECONDS_90_DAYS:
+            continue
+
+        print(f'User {u["uuid"]} is inactive')
+        inactive_uuids.append(u['uuid'])
+
+    return inactive_uuids
+
+
+def purge_inactive_users():
+    total_users = edb.get_uuid_db().count_documents({})
+    print(f'Total users: {total_users}')
+    uuids_entries = edb.get_uuid_db().find()
+    print('Finding inactive users...')
+    inactive_uuids = find_inactive_uuids(uuids_entries)
+    print(f'Of {total_users} users, found {len(inactive_uuids)} inactive users:')
+    print(inactive_uuids)
+
+    print("Purging inactive users...")
+    for u in inactive_uuids:
+        print(f'Purging user {u}')
+        common.purge_entries_for_user(u, True)
+
+
+if __name__ == '__main__':
+    run_on_all_deployments(purge_inactive_users)


### PR DESCRIPTION
The following conditions must be met before this script should be run on a program:

- The program’s collection period (per MOU) has passed, and we have confirmed with program admins that it is ok to shut down
- Data has already been archived in TSDC

I tested this on my local dump of `nrel-commute`:

```
(emission) jgreenle@jgreenle-34794s e-mission-server % PROD_LIST=nrel-commute DB_HOST=mongodb://localhost:27017/openpath_prod_nrel_commute PYTHONPATH=. ./e-mission-py.bash bin/historical/migrations/purge_inactive_users.py
Config file not found, returning a copy of the environment variables instead...
Retrieved config: {'DB_HOST': 'mongodb://localhost:27017/openpath_prod_nrel_commute', 'DB_RESULT_LIMIT': None}
Connecting to database URL mongodb://localhost:27017/openpath_prod_nrel_commute
PROD_LIST: ['nrel-commute']
About to run purge_inactive_users on 1 deployments. Proceed? [y/n]
y
Running purge_inactive_users for nrel-commute on DB nrel_commute
Config file not found, returning a copy of the environment variables instead...
Retrieved config: {'DB_HOST': 'mongodb://localhost:27017/openpath_prod_nrel_commute', 'DB_RESULT_LIMIT': None}
Connecting to database URL mongodb://localhost:27017/openpath_prod_nrel_commute
Total users: 51
Finding inactive users...
Checking activity for user (uuid)
for user <uuid>, last call was 1734401813.8308148
(...continued)
Of 51 users, found 46 inactive users:
(list of UUIDs)
Purging inactive users...
Purging user (uuid)
(...continued)
```

I also ran it a second time to ensure nothing bad happened:
```
Of 5 users, found 0 inactive users:
[]
Purging inactive users...
```

I inspected the DB and confirmed that 5 users remain.

Then, I referenced the UUIDs table on the admin dashboard and verified that those 5 users have a recent last_call_ts, while the other 46 users do not.