### PR TITLE
⏪ Go back to generating trip statistics from the confirmed trips

### DIFF
--- a/emission/analysis/result/user_stat.py
+++ b/emission/analysis/result/user_stat.py
@@ -41,9 +41,10 @@ def update_user_profile(user_id: str, data: Dict[str, Any]) -> None:
     logging.debug(f"New profile: {user.getProfile()}")
 
 
-def get_and_store_user_stats(user_id: str, trip_key: str) -> None:
+def get_and_store_pipeline_dependent_user_stats(user_id: str, trip_key: str) -> None:
     """
-    Aggregates and stores user statistics into the user profile.
+    Aggregates and stores pipeline dependent into the user profile.
+    These are statistics based on analysed data such as trips or labels.
 
     :param user_id: The UUID of the user.
     :type user_id: str
@@ -52,7 +53,7 @@ def get_and_store_user_stats(user_id: str, trip_key: str) -> None:
     :return: None
     """
     try:
-        logging.info(f"Starting get_and_store_user_stats for user_id: {user_id}, trip_key: {trip_key}")
+        logging.info(f"Starting get_and_store_pipeline_dependent_user_stats for user_id: {user_id}, trip_key: {trip_key}")
 
         ts = esta.TimeSeries.get_time_series(user_id)
         start_ts_result = ts.get_first_value_for_field(trip_key, "data.start_ts", pymongo.ASCENDING)
@@ -68,11 +69,6 @@ def get_and_store_user_stats(user_id: str, trip_key: str) -> None:
         )
 
         logging.info(f"Total trips: {total_trips}, Labeled trips: {labeled_trips}")
-        logging.info(f"user_id type: {type(user_id)}")
-
-        last_call_ts = get_last_call_timestamp(ts)
-        logging.info(f"Last call timestamp: {last_call_ts}")
-
         update_data = {
             "pipeline_range": {
                 "start_ts": start_ts,
@@ -80,12 +76,37 @@ def get_and_store_user_stats(user_id: str, trip_key: str) -> None:
             },
             "total_trips": total_trips,
             "labeled_trips": labeled_trips,
-            "last_call_ts": last_call_ts
         }
 
+        logging.info(f"user_id type: {type(user_id)}")
         update_user_profile(user_id, update_data)
 
         logging.debug("User profile updated successfully.")
 
     except Exception as e:
-        logging.error(f"Error in get_and_store_user_stats for user_id {user_id}: {e}")
+        logging.error(f"Error in get_and_store_dependent_user_stats for user_id {user_id}: {e}")
+
+def get_and_store_pipeline_independent_user_stats(user_id: str) -> None:
+    """
+    Aggregates and stores pipeline indepedent statistics into the user profile.
+    These are statistics based on raw data, such as the last call, last push
+    or last location received.
+
+    :param user_id: The UUID of the user.
+    :type user_id: str
+    :return: None
+    """
+
+    try:
+        logging.info(f"Starting get_and_store_pipeline_independent_user_stats for user_id: {user_id}")
+        ts = esta.TimeSeries.get_time_series(user_id)
+        last_call_ts = get_last_call_timestamp(ts)
+        logging.info(f"Last call timestamp: {last_call_ts}")
+
+        update_data = {
+            "last_call_ts": last_call_ts
+        }
+        update_user_profile(user_id, update_data)
+
+    except Exception as e:
+        logging.error(f"Error in get_and_store_independent_user_stats for user_id {user_id}: {e}")

--- a/emission/pipeline/intake_stage.py
+++ b/emission/pipeline/intake_stage.py
@@ -76,6 +76,12 @@ def run_intake_pipeline(process_number, uuid_list, skip_if_no_new_data=False):
 
         try:
             run_intake_pipeline_for_user(uuid, skip_if_no_new_data)
+            with ect.Timer() as gsr:
+                logging.info("*" * 10 + "UUID %s: storing pipeline independent user stats " % uuid + "*" * 10)
+                print(str(arrow.now()) + "*" * 10 + "UUID %s: storing pipeline independent user stats " % uuid + "*" * 10)
+                eaurs.get_and_store_pipeline_independent_user_stats(uuid)
+            esds.store_pipeline_time(uuid, 'STORE_PIPELINE_INDEPENDENT_USER_STATS',
+                                time.time(), gsr.elapsed)
         except Exception as e:
             esds.store_pipeline_error(uuid, "WHOLE_PIPELINE", time.time(), None)
             logging.exception("Found error %s while processing pipeline "
@@ -203,7 +209,7 @@ def run_intake_pipeline_for_user(uuid, skip_if_no_new_data):
         with ect.Timer() as gsr:
             logging.info("*" * 10 + "UUID %s: storing user stats " % uuid + "*" * 10)
             print(str(arrow.now()) + "*" * 10 + "UUID %s: storing user stats " % uuid + "*" * 10)
-            eaurs.get_and_store_user_stats(uuid, "analysis/composite_trip")
+            eaurs.get_and_store_pipeline_dependent_user_stats(uuid, "analysis/composite_trip")
 
-        esds.store_pipeline_time(uuid, 'STORE_USER_STATS',
+        esds.store_pipeline_time(uuid, 'STORE_PIPELINE_DEPENDENT_USER_STATS',
                                 time.time(), gsr.elapsed)

--- a/emission/pipeline/intake_stage.py
+++ b/emission/pipeline/intake_stage.py
@@ -76,12 +76,6 @@ def run_intake_pipeline(process_number, uuid_list, skip_if_no_new_data=False):
 
         try:
             run_intake_pipeline_for_user(uuid, skip_if_no_new_data)
-            with ect.Timer() as gsr:
-                logging.info("*" * 10 + "UUID %s: storing user stats " % uuid + "*" * 10)
-                print(str(arrow.now()) + "*" * 10 + "UUID %s: storing user stats " % uuid + "*" * 10)
-                eaurs.get_and_store_user_stats(uuid, "analysis/composite_trip")
-            esds.store_pipeline_time(uuid, 'STORE_USER_STATS',
-                                time.time(), gsr.elapsed)
         except Exception as e:
             esds.store_pipeline_error(uuid, "WHOLE_PIPELINE", time.time(), None)
             logging.exception("Found error %s while processing pipeline "
@@ -206,3 +200,10 @@ def run_intake_pipeline_for_user(uuid, skip_if_no_new_data):
         esds.store_pipeline_time(uuid, ecwp.PipelineStages.CREATE_COMPOSITE_OBJECTS.name,
                                  time.time(), crt.elapsed)
 
+        with ect.Timer() as gsr:
+            logging.info("*" * 10 + "UUID %s: storing user stats " % uuid + "*" * 10)
+            print(str(arrow.now()) + "*" * 10 + "UUID %s: storing user stats " % uuid + "*" * 10)
+            eaurs.get_and_store_user_stats(uuid, "analysis/composite_trip")
+
+        esds.store_pipeline_time(uuid, 'STORE_USER_STATS',
+                                time.time(), gsr.elapsed)

--- a/emission/tests/analysisTests/intakeTests/TestUserStat.py
+++ b/emission/tests/analysisTests/intakeTests/TestUserStat.py
@@ -43,8 +43,7 @@ class TestUserStats(unittest.TestCase):
             # Initialize the profile if it does not exist
             edb.get_profile_db().insert_one({"user_id": self.testUUID})
 
-        #etc.runIntakePipeline(self.testUUID)
-        epi.run_intake_pipeline_for_user(self.testUUID, skip_if_no_new_data = False)
+        etc.runIntakePipeline(self.testUUID)
         logging.debug("UUID = %s" % (self.testUUID))
 
     def tearDown(self):

--- a/emission/tests/analysisTests/intakeTests/TestUserStat.py
+++ b/emission/tests/analysisTests/intakeTests/TestUserStat.py
@@ -44,7 +44,7 @@ class TestUserStats(unittest.TestCase):
             edb.get_profile_db().insert_one({"user_id": self.testUUID})
 
         #etc.runIntakePipeline(self.testUUID)
-        etc.runIntakePipeline(self.testUUID)
+        epi.run_intake_pipeline_for_user(self.testUUID, skip_if_no_new_data = False)
         logging.debug("UUID = %s" % (self.testUUID))
 
     def tearDown(self):

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -206,7 +206,8 @@ def runIntakePipeline(uuid):
     eaue.populate_expectations(uuid)
     eaum.create_confirmed_objects(uuid)
     eapcc.create_composite_objects(uuid)
-    eaurs.get_and_store_user_stats(uuid, "analysis/composite_trip")
+    eaurs.get_and_store_pipeline_dependent_user_stats(uuid, "analysis/composite_trip")
+    eaurs.get_and_store_pipeline_independent_user_stats(uuid)
     
 
 def configLogging():

--- a/emission/tests/netTests/TestPipeline.py
+++ b/emission/tests/netTests/TestPipeline.py
@@ -7,7 +7,6 @@ import emission.core.get_database as edb
 import emission.core.wrapper.localdate as ecwl
 import emission.tests.common as etc
 import emission.pipeline.intake_stage as epi
-import emission.analysis.result.user_stat as eaurs
 
 from emission.net.api import pipeline
 
@@ -39,7 +38,6 @@ class TestPipeline(unittest.TestCase):
     def testAnalysisResults(self):
         self.assertEqual(pipeline.get_range(self.testUUID), (None, None))
         epi.run_intake_pipeline_for_user(self.testUUID, skip_if_no_new_data = False)
-        eaurs.get_and_store_user_stats(self.testUUID, "analysis/composite_trip")
         pr = pipeline.get_range(self.testUUID)
         self.assertAlmostEqual(pr[0], 1440688739.672)
         self.assertAlmostEqual(pr[1], 1440729142.709)


### PR DESCRIPTION
We deployed the change to switch to composite trips around Jan 5th, at which time I/O usage tripled. Since it looks like DocumentDB does not use the index, and instead pulls all data into memory to filter there, the switch to composite trips would likely result in more data being read, which may have resulted in greater I/O.

The change was originally to keep the cache warm, but per testing, it looks like it doesn't really help with performance. And it increases the I/O rate, which also affects the overall cost.

So we revert the change, and rely on trimming down object sizes to improve performance instead.

We were always reading composite trips to determine the pipeline range added in https://github.com/e-mission/e-mission-server/commit/0403ae0ecc8985911451f16fac085fcf0d6328de

We then read the number of confirmed trips, (not composite) as part of https://github.com/e-mission/e-mission-server/commit/39a33586e727d6e14ed7d0773723ad4e0d2cbaa8

The change to run the user stats every time instead of only when there was new data was in https://github.com/e-mission/e-mission-server/commit/9d1f414b067cbb8411214fed88d45aaa8c6d5eae

Testing done:
- One liner, no testing