### PR TITLE
fix quantile "numeric_only" warning

### DIFF
--- a/emission/analysis/intake/cleaning/cleaning_methods/speed_outlier_detection.py
+++ b/emission/analysis/intake/cleaning/cleaning_methods/speed_outlier_detection.py
@@ -24,7 +24,7 @@ class BoxplotOutlier(object):
             df_to_use = with_speeds_df[with_speeds_df.speed > 0]
         else:
             df_to_use = with_speeds_df
-        quartile_vals = df_to_use.quantile([0.25, 0.75]).speed
+        quartile_vals = df_to_use["speed"].quantile([0.25, 0.75])
         logging.debug("quartile values are %s" % quartile_vals)
         iqr = quartile_vals.iloc[1] - quartile_vals.iloc[0]
         logging.debug("iqr %s" % iqr)


### PR DESCRIPTION
This warning has been cluttering up the pipeline logs:
> web-server-1  | /src/e-mission-server/emission/analysis/intake/cleaning/cleaning_methods/speed_outlier_detection.py:27: FutureWarning: The default value of numeric_only in DataFrame.quantile is deprecated. In a future version, it will default to False. Select only valid columns or specify the value of numeric_only to silence this warning.

Since we just need the IQR of speeds, we can perform .quantile on only the 'speed' column. This avoids the warning message and is also potentially more efficient