### PR TITLE
🚑️ Do not iterate over map keys while modifying them

### DIFF
--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -30,17 +30,26 @@ def sync_server_to_phone(uuid):
     return retrievedData
 
 def _remove_dots(entry_doc):
+    keys_to_munge = []
     for key in entry_doc:
         # print(f"Checking {key=}")
         if isinstance(entry_doc[key], dict):
             # print(f"Found dict for {key=}, recursing")
             _remove_dots(entry_doc[key])
         if '.' in key:
-            munged_key = key.replace(".", "_")
-            logging.info(f"Found {key=} with dot, munged to {munged_key=}")
-            # Get and delete in one swoop
-            # https://stackoverflow.com/a/11277439
-            entry_doc[munged_key] = entry_doc.pop(key, None)
+            logging.info(f"Found {key=} with dot, adding to {keys_to_munge=}")
+            keys_to_munge.append(key)
+
+    logging.info(f"Before modifying, {keys_to_munge=}")
+
+    for ktm in keys_to_munge:
+        munged_key = ktm.replace(".", "_")
+        # Get and delete in one swoop
+        # https://stackoverflow.com/a/11277439
+        logging.info(f"Replacing original dotted key {ktm} with {munged_key=}")
+        entry_doc[munged_key] = entry_doc.pop(ktm, None)
+
+    logging.info(f"(After modifying, {entry_doc.keys()=}")
 
 def sync_phone_to_server(uuid, data_from_phone):
     """

--- a/emission/tests/netTests/TestBuiltinUserCacheHandlerInput.py
+++ b/emission/tests/netTests/TestBuiltinUserCacheHandlerInput.py
@@ -345,6 +345,122 @@ class TestBuiltinUserCacheHandlerInput(unittest.TestCase):
         self.assertEqual(len(self.uc1.getMessage()), 0)
         self.assertEqual(len(list(self.ts1.find_entries())), 33)
 
+    def testRemoteDotsIterateWhileModifyingSingleKey(self):
+        test_with_single_key = {'ts': 1734661726.167,
+            'client_app_version': '1.9.4',
+            'name': 'open_notification',
+            'client_os_version': '18.1.1',
+            'reading': {'message': 'Please label your recent trips',
+            'title': 'Trip labels requested',
+            'additionalData': {
+                'coldstart': True, 'title': 'Trip labels requested',
+                'message': 'Please label your recent trips',
+                'foreground': False,
+                'google.c.fid': 'TEST_FID',
+                'gcm_message_id': 'TEST_MESSAGE',
+                'google_c_sender_id': 'TEST_SENDER',
+                'google_c_a_e': '1'}}}
+        self.assertEqual(len(test_with_single_key["reading"]["additionalData"]), 8)
+        self.assertIn("google.c.fid",
+            test_with_single_key["reading"]["additionalData"])
+        mauc._remove_dots(test_with_single_key)
+        self.assertEqual(len(test_with_single_key["reading"]["additionalData"]), 8)
+        self.assertIn("google_c_fid",
+            test_with_single_key["reading"]["additionalData"])
+        self.assertNotIn("google.c.fid",
+            test_with_single_key["reading"]["additionalData"])
+
+    def testRemoteDotsIterateWhileModifyingMultiKey(self):
+        test_with_multiple_keys = {'ts': 1734661726.167,
+            'client_app_version': '1.9.4',
+            'name': 'open_notification',
+            'client_os_version': '18.1.1',
+            'reading': {'message': 'Please label your recent trips',
+            'title': 'Trip labels requested',
+            'additionalData': {'coldstart': True,
+                'title': 'Trip labels requested',
+                'message': 'Please label your recent trips',
+                'foreground': False,
+                'gcm.message_id': 'TEST_MESSAGE',
+                'google.c.sender.id': 'TEST_SENDER',
+                'google.c.a.e': '1',
+                'google.c.fid': 'TEST_FID'}}}
+
+        self.assertEqual(len(test_with_multiple_keys["reading"]["additionalData"]), 8)
+        self.assertIn("gcm.message_id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google.c.sender.id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google.c.a.e",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google.c.fid",
+            test_with_multiple_keys["reading"]["additionalData"])
+        mauc._remove_dots(test_with_multiple_keys)
+        self.assertEqual(len(test_with_multiple_keys["reading"]["additionalData"]), 8)
+        self.assertIn("gcm_message_id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google_c_sender_id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google_c_a_e",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google_c_fid",
+            test_with_multiple_keys["reading"]["additionalData"])
+
+        self.assertNotIn("google.c.fid",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertNotIn("gcm.message_id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertNotIn("google.c.sender.id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertNotIn("google.c.a.e",
+            test_with_multiple_keys["reading"]["additionalData"])
+
+    def testRemoteDotsIterateWhileModifyingMultiKey2(self):
+        test_with_multiple_keys = {'ts': 1738001143.67,
+            'client_app_version': '1.9.6',
+            'name': 'open_notification',
+            'client_os_version': '18.1.1',
+            'reading': {'message': 'Please label your recent trips',
+            'title': 'Trip labels requested',
+            'additionalData': {'coldstart': True,
+                'title': 'Trip labels requested',
+                'message': 'Please label your recent trips',
+                'foreground': False,
+                'gcm.message_id': 'TEST_MESSAGE',
+                'google.c.sender.id': 'TEST_SENDER',
+                'google.c.a.e': '1',
+                'google.c.fid': 'TEST_FID'}}}
+
+        self.assertEqual(len(test_with_multiple_keys["reading"]["additionalData"]), 8)
+        self.assertIn("gcm.message_id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google.c.sender.id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google.c.a.e",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google.c.fid",
+            test_with_multiple_keys["reading"]["additionalData"])
+        mauc._remove_dots(test_with_multiple_keys)
+        self.assertEqual(len(test_with_multiple_keys["reading"]["additionalData"]), 8)
+        self.assertIn("gcm_message_id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google_c_sender_id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google_c_a_e",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertIn("google_c_fid",
+            test_with_multiple_keys["reading"]["additionalData"])
+
+        self.assertNotIn("google.c.fid",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertNotIn("gcm.message_id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertNotIn("google.c.sender.id",
+            test_with_multiple_keys["reading"]["additionalData"])
+        self.assertNotIn("google.c.a.e",
+            test_with_multiple_keys["reading"]["additionalData"])
+
+
 if __name__ == '__main__':
     import emission.tests.common as etc
 


### PR DESCRIPTION
🐛 Do not iterate over map keys while modifying them

In https://github.com/e-mission/e-mission-server/pull/1008 (and in particular, https://github.com/e-mission/e-mission-server/commit/1ec706e7e0d51cee3dd5942f87b45f3a9b9dd86d), we munged incoming keys with dots so that we could store them properly in mongodb.

We did this by iterating over all the keys, "popping" the one with dots and
storing the value into the munged key, consistent with https://stackoverflow.com/a/11277439

However, this lead to an issue where apparently the key order is also changed,
so that modified keys are iterated over twice, and some keys are not even
checked. And since they are not checked, they are not munged.

This refactors the code to two stages:
- find the `keys_to_munge` (aka `ktm`) by iterating over the map
- iterate over the `keys_to_munge` list and munge the keys

Testing done:

- Before this, the tests in e94140ea55a78c201d3f4c10d4833841769d4cac were failing

```
----------------------------------------------------------------------
Ran 8 tests in 28.153s

FAILED (failures=2, errors=1)
```

- After this, the tests in e94141ea55a78c201d3f4c10d4833841769d4cac were passing

```
----------------------------------------------------------------------
Ran 8 tests in 28.969s

OK
```