### PR TITLE
⚡️ Update the call-specific metrics inline instead of querying the da…

### DIFF
--- a/emission/analysis/result/user_stat.py
+++ b/emission/analysis/result/user_stat.py
@@ -7,12 +7,29 @@ from typing import Optional, Dict, Any
 import emission.storage.timeseries.abstract_timeseries as esta
 import emission.core.wrapper.user as ecwu
 
+def update_upload_timestamp(user_id: str, stat_name: str, ts: float) -> None:
+    """
+    Updates the upload timestamps in the profile
+
+    :param user_id: The user's UUID
+    :type user_id: str
+    :param stat_name: The field name that is updated
+    :type stat_name: str
+    :param ts: The timestamp to store (may not always be 'now')
+    :type ts: float
+    :return: None
+    """
+    update_data = {
+        stat_name: ts
+    }
+    update_user_profile(user_id, update_data)
+
 def update_last_call_timestamp(user_id: str, call_path: str) -> Optional[int]:
     """
     Updates the user profile with server call starts
 
     :param user_id: The user's UUID
-    :type ts: str
+    :type user_id: str
     :param call_path: Can be used to store different call stats
     :type ts: str
     :return: None

--- a/emission/analysis/result/user_stat.py
+++ b/emission/analysis/result/user_stat.py
@@ -13,14 +13,21 @@ def update_last_call_timestamp(user_id: str, call_path: str) -> Optional[int]:
 
     :param user_id: The user's UUID
     :type ts: str
-    :param call_path: Can be used to store different call stats (e.g. last call
-        versus last push, currently a NOP)
+    :param call_path: Can be used to store different call stats
     :type ts: str
     :return: None
     """
+    logging.debug(f"update_last_call_timestamp called with: {user_id=}, {call_path=}")
+    now = arrow.now().timestamp()
     update_data = {
-        "last_call_ts": arrow.now().timestamp()
+        "last_call_ts": now
     }
+    if "usercache" in call_path:
+        update_data["last_sync_ts"] = now
+    if "usercache/put" in call_path:
+        update_data["last_put_ts"] = now
+    if call_path == "/pipeline/get_range_ts":
+        update_data["last_diary_fetch_ts"] = now
     update_user_profile(user_id, update_data)
 
 def update_user_profile(user_id: str, data: Dict[str, Any]) -> None:

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -53,6 +53,8 @@ import emission.core.timer as ect
 import emission.core.get_database as edb
 import emission.core.backwards_compat_config as ecbc
 
+import emission.analysis.result.user_stat as earus
+
 STUDY_CONFIG = os.getenv('STUDY_CONFIG', "stage-program")
 
 # Constants that we don't read from the configuration
@@ -477,6 +479,7 @@ def after_request():
   request.params.timer.__exit__()
   duration = msTimeNow - request.params.start_ts
   new_duration = request.params.timer.elapsed
+  earus.update_last_call_timestamp(request.params.user_uuid, request.path)
   if round(old_div((duration - new_duration), new_duration) > 100) > 0:
     logging.error("old style duration %s != timer based duration %s" % (duration, new_duration))
     stats.store_server_api_error(request.params.user_uuid, "MISMATCH_%s_%s" %

--- a/emission/pipeline/intake_stage.py
+++ b/emission/pipeline/intake_stage.py
@@ -76,12 +76,6 @@ def run_intake_pipeline(process_number, uuid_list, skip_if_no_new_data=False):
 
         try:
             run_intake_pipeline_for_user(uuid, skip_if_no_new_data)
-            with ect.Timer() as gsr:
-                logging.info("*" * 10 + "UUID %s: storing pipeline independent user stats " % uuid + "*" * 10)
-                print(str(arrow.now()) + "*" * 10 + "UUID %s: storing pipeline independent user stats " % uuid + "*" * 10)
-                eaurs.get_and_store_pipeline_independent_user_stats(uuid)
-            esds.store_pipeline_time(uuid, 'STORE_PIPELINE_INDEPENDENT_USER_STATS',
-                                time.time(), gsr.elapsed)
         except Exception as e:
             esds.store_pipeline_error(uuid, "WHOLE_PIPELINE", time.time(), None)
             logging.exception("Found error %s while processing pipeline "

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -207,8 +207,6 @@ def runIntakePipeline(uuid):
     eaum.create_confirmed_objects(uuid)
     eapcc.create_composite_objects(uuid)
     eaurs.get_and_store_pipeline_dependent_user_stats(uuid, "analysis/composite_trip")
-    eaurs.get_and_store_pipeline_independent_user_stats(uuid)
-    
 
 def configLogging():
     """


### PR DESCRIPTION
…tabase

We have made several changes to cache summary information in the user profile. This summary information can be used to improve the scalability of the admin dashboard (https://github.com/e-mission/op-admin-dashboard/issues/145) but will also be used to determine dormant deployment and potentially in a future OpenPATH-wide dashboard.

These changes started by making a single call to cache both trip and call stats https://github.com/e-mission/e-mission-server/pull/1005

This resulted in all the composite trips being read every hour, so we split the stats into pipeline-dependent and pipeline-independent stats, in 88bb35a79fda4026842e1b59d2e2e85a73893b09
(part of https://github.com/e-mission/e-mission-server/pull/1005)

The idea was that, since the composite object query was slow because the composite trips were large, we could run only the queries for the server API stats every hour, and read the composite trips only when they were updated.

However, after the improvements to the trip segmentation pipeline (https://github.com/e-mission/e-mission-server/pull/1014, results in https://github.com/e-mission/e-mission-docs/issues/1105#issuecomment-2631914594) reading the server stats is now the bottleneck.

Checking the computation time on the big deployments (e.g. ccebikes), although the time taken has significantly improved as the database load has gone down, even in the past two days, we see a median of ~ 10 seconds and a max of over two minutes.

And we don't really need to query this data to generate the call summary statistics. Instead of computing them on every run, we can compute them only when _they_ change, which happens when we receive calls to the API.

So, in the API's after_request hook, in addition to adding a new stat, we can also just update the `last_call_ts` in the profile. This potentially makes every API call a teeny bit slower since we are adding one more DB write, but it significantly lowers the DB load, so should make the system as a whole faster.

Testing done:
- the modified `TestUserStat` test for the `last_call_ts` passes