### PR TITLE
⚡️ Specify the appropriate hints on the indices to use for various qu…

### DIFF
--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install and start MongoDB
       uses: supercharge/mongodb-github-action@1.3.0
       with:
-        mongodb-version: 4.4.0
+        mongodb-version: 8.0.4
 
     - name: Check existing version of miniconda
       shell: bash -l {0}

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -195,6 +195,7 @@ def get_timeseries_db():
     TimeSeries.create_index([("metadata.key", pymongo.ASCENDING)])
     TimeSeries.create_index([("metadata.write_ts", pymongo.DESCENDING)])
     TimeSeries.create_index([("data.ts", pymongo.DESCENDING)], sparse=True)
+    TimeSeries.create_index([("data.start_ts", pymongo.DESCENDING)], sparse=True)
     _migrate_sparse_to_dense(TimeSeries, "data.loc_2dsphere")
     TimeSeries.create_index([("data.loc", pymongo.GEOSPHERE)])
     return TimeSeries

--- a/emission/integrationTests/docker-compose.yml
+++ b/emission/integrationTests/docker-compose.yml
@@ -23,7 +23,7 @@ services:
        - emission
 
   db:
-    image: mongo:4.4.0
+    image: mongo:8.0.4
     deploy:
       replicas: 1
       restart_policy:

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -231,8 +231,9 @@ class BuiltinTimeSeries(esta.TimeSeries):
         if key_list is None or len(key_list) > 0:
             ts_query = self._get_query(key_list, time_query, geo_query,
                                 extra_query_list)
-            ts_db_cursor = tsdb.find(ts_query)
-            ts_db_count = tsdb.count_documents(ts_query)
+            hint_arr =  [("metadata.key", 1)] if (sort_key is None) or ("metadata" in sort_key) else [(sort_key, -1)]
+            ts_db_cursor = tsdb.find(ts_query).hint(hint_arr)
+            ts_db_count = tsdb.count_documents(ts_query, hint=hint_arr)
             if sort_key is None:
                 ts_db_result = ts_db_cursor
             else:
@@ -248,7 +249,7 @@ class BuiltinTimeSeries(esta.TimeSeries):
             # Out[593]: 449869
             ts_db_result.limit(edb.result_limit)
         else:
-            ts_db_result = tsdb.find(INVALID_QUERY)
+            ts_db_result = tsdb.find(INVALID_QUERY).hint([("metadata.key", 1)])
             ts_db_count = 0
 
         logging.debug("finished querying values for %s, count = %d" % (key_list, ts_db_count))

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -15,10 +15,13 @@ import emission.storage.timeseries.abstract_timeseries as esta
 
 import emission.core.wrapper.entry as ecwe
 
-ts_enum_map = {
-    esta.EntryType.DATA_TYPE: edb.get_timeseries_db(),
-    esta.EntryType.ANALYSIS_TYPE: edb.get_analysis_timeseries_db()
-}
+def _get_enum_map():
+    return {
+        esta.EntryType.DATA_TYPE: edb.get_timeseries_db(),
+        esta.EntryType.ANALYSIS_TYPE: edb.get_analysis_timeseries_db()
+    }
+
+ts_enum_map = _get_enum_map()
 
 INVALID_QUERY = {'metadata.key': 'invalid'}
 
@@ -232,6 +235,7 @@ class BuiltinTimeSeries(esta.TimeSeries):
             ts_query = self._get_query(key_list, time_query, geo_query,
                                 extra_query_list)
             hint_arr =  [("metadata.key", 1)] if (sort_key is None) or ("metadata" in sort_key) else [(sort_key, -1)]
+            # print(f"for query {ts_query=}, when indices are {tsdb.index_information()}, {sort_key=} so {hint_arr=}")
             ts_db_cursor = tsdb.find(ts_query).hint(hint_arr)
             ts_db_count = tsdb.count_documents(ts_query, hint=hint_arr)
             if sort_key is None:

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -48,6 +48,12 @@ def dropAllCollections(db):
     else: 
       print("Dropping collection %s" % coll)
       db.drop_collection(coll)
+ 
+  import emission.storage.timeseries.builtin_timeseries as bits
+  bits.ts_enum_map = bits._get_enum_map()
+  # we expect to see [7, 51]
+  print(f"After restoring indices on cached collections, we see {[len(bits.ts_enum_map[k].index_information().keys()) for k in bits.ts_enum_map]}")
+
 
 def purgeSectionData(Sections, userName):
     """

--- a/setup/docker-compose.tests.yml
+++ b/setup/docker-compose.tests.yml
@@ -17,7 +17,7 @@ services:
     networks:
        - emission
   db:
-    image: mongo:4.4.0
+    image: mongo:8.0.4
     deploy:
       replicas: 1
       restart_policy:


### PR DESCRIPTION
…eries

While looking into an upgrade to mongo 8.0.4, we found that the queries were super slow. So running the pipeline after reset for a specified set of three users took ~ 15 mins against mongo 4.4.0 but over a day against mongo 8.0.4 https://github.com/e-mission/e-mission-docs/issues/1109#issuecomment-2676415132

Investigating further, including by looking at the slow queries, we saw that this was due to the `metadata.key` index being used for several of the queries. Using the `metadata.key` instead of `data.ts` index for location queries, for example, took 3x the time.
https://github.com/e-mission/e-mission-docs/issues/1109#issuecomment-2677074300

I think that the medium-term fix is to use a composite index. However, we can also specify a "hint" while running the query, which will encourage mongodb to use the correct index.
https://github.com/e-mission/e-mission-docs/issues/1109#issuecomment-2677093069

However, the `data.ts` hint only seems to work if used with a `data.ts` filter in the query - e.g. for `background/location`. While reading the `manual/*` entries, the filter query works with `metadata.write_ts`, and then, querying by both `data.ts` and `metadata.write_ts` is slow. The only index that is moderately fast is `metadata.key`. As an aside, I assume that is why the default index was set to `metadata.key` in the first place; the query plan was optimized for the first set of queries and then subsequent calls with the same "shape" used the same index.
https://github.com/e-mission/e-mission-docs/issues/1109#issuecomment-2677474876

Note that I still don't understand why `metadata.write_ts` is slow for the `manual/*` series.

Regardless, a fairly simple fix which says

> But for now, we can just say that if the sort key is `metadata.write_ts` we can
> make the hint be `metadata.key`.

With this fix, the run against mongodb 8.0.4 is also < 15 mins https://github.com/e-mission/e-mission-docs/issues/1109#issuecomment-2677583319

Testing done:
https://github.com/e-mission/e-mission-docs/issues/1109#issuecomment-2677583319