### PR TITLE
💩 Have the hints be optional so we can run on DocDB without errors

### DIFF
--- a/.github/workflows/test-with-manual-install.yml
+++ b/.github/workflows/test-with-manual-install.yml
@@ -26,6 +26,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+    env:
+      USE_HINTS: True
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -16,7 +16,7 @@ config = ecbc.get_config('conf/storage/db.conf',
     {"DB_HOST": "timeseries.url", "DB_RESULT_LIMIT": "timeseries.result_limit"})
 
 db_config = {}
-for key in ["DB_HOST", "DB_RESULT_LIMIT"]:
+for key in ["DB_HOST", "DB_RESULT_LIMIT", "USE_HINTS"]:
     if key in config:
         db_config[key] = config.get(key)
     else:
@@ -27,6 +27,11 @@ try:
     result_limit = int(config.get("DB_RESULT_LIMIT", 250000))
 except ValueError:
     result_limit = 250000
+
+try:
+    use_hints = bool(config.get("USE_HINTS", False))
+except ValueError:
+    use_hints = False
 
 try:
     parsed=pymongo.uri_parser.parse_uri(url)

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -235,9 +235,14 @@ class BuiltinTimeSeries(esta.TimeSeries):
             ts_query = self._get_query(key_list, time_query, geo_query,
                                 extra_query_list)
             hint_arr =  [("metadata.key", 1)] if (sort_key is None) or ("metadata" in sort_key) else [(sort_key, -1)]
+
             # print(f"for query {ts_query=}, when indices are {tsdb.index_information()}, {sort_key=} so {hint_arr=}")
-            ts_db_cursor = tsdb.find(ts_query).hint(hint_arr)
-            ts_db_count = tsdb.count_documents(ts_query, hint=hint_arr)
+            if edb.use_hints:
+                ts_db_cursor = tsdb.find(ts_query).hint(hint_arr)
+                ts_db_count = tsdb.count_documents(ts_query, hint=hint_arr)
+            else:
+                ts_db_cursor = tsdb.find(ts_query)
+                ts_db_count = tsdb.count_documents(ts_query)
             if sort_key is None:
                 ts_db_result = ts_db_cursor
             else:


### PR DESCRIPTION
In https://github.com/e-mission/e-mission-server/pull/1028 I added some hints to indicate which indices MongoDB should use for specific queries. When deploying this to staging/production, however, it turns out that DocDB does not support hints on sparse indices.
https://github.com/e-mission/e-mission-docs/issues/1109#issuecomment-2686341450

If we attempt to specify a hint on a sparse index, it is not just ignored, but the operation fails. So this is a blocker for testing out any other changes (unrelated to hints) on staging/production.

To unblock testing against real data while exploring a migration from DocDB to MongoDB, we need to remove hints on DocDB and only on DocDB. I could simply revert the previous change , but that would distort our experimentation with scalability improvements on dev against MongoDB

So I instead plumb through a option (`USE_HINTS`), defaulting to false, that controls this. While running against MongoDB in a dev environment, we should set this to True. Since we will not change the environment variables on production, we will not use hints there.

All the related changes are in this single commit so it can be reverted later.

Testing done:
- Ran the pipeline against the USAID dataset. No related errors.
- Set USE_HINTS=True and then re-ran the pipeline against the USAID dataset. No related errors.
- Set USE_HINTS=True in one of the testing workflows (test-with-manual-install) but leave it as False for the docker testing so we can test both cases.