### PR TITLE
🚀 Section Segmentation Optimization

### DIFF
--- a/emission/analysis/intake/segmentation/section_segmentation_methods/flip_flop_detection.py
+++ b/emission/analysis/intake/segmentation/section_segmentation_methods/flip_flop_detection.py
@@ -88,7 +88,7 @@ class FlipFlopDetection():
             return True
         else:
             streak_locs = self.seg_method.filter_points_for_range(
-                self.seg_method.location_points, start_motion, end_motion)
+                self.seg_method.filtered_loc_df, start_motion, end_motion)
             logging.debug("in is_flip_flop: len(streak_locs) = %d" % len(streak_locs))
             if len(streak_locs) == 0:
                 return True
@@ -227,7 +227,7 @@ class FlipFlopDetection():
 
         ssm, sem = self.motion_changes[streak_start]
         streak_locs = self.seg_method.filter_points_for_range(
-            self.seg_method.location_points, ssm, sem)
+            self.seg_method.filtered_loc_df, ssm, sem)
         streak_unfiltered_locs = self.seg_method.filter_points_for_range(
             self.seg_method.unfiltered_loc_df, ssm, sem)
 
@@ -297,17 +297,17 @@ class FlipFlopDetection():
             return MergeResult(Direction.FORWARD, FinalMode.UNMERGED)
 
         loc_points = self.seg_method.filter_points_for_range(
-                self.seg_method.location_points, ssm, eem)
+                self.seg_method.filtered_loc_df, ssm, eem)
         loc_points.reset_index(inplace=True)
         with_speed_loc_points = eaicl.add_dist_heading_speed(loc_points)
 
         points_before = self.seg_method.filter_points_for_range(
-                self.seg_method.location_points, bsm, bem)
+                self.seg_method.filtered_loc_df, bsm, bem)
         points_before.reset_index(inplace=True)
         with_speed_points_before = eaicl.add_dist_heading_speed(points_before)
 
         points_after = self.seg_method.filter_points_for_range(
-                self.seg_method.location_points, asm, aem)
+                self.seg_method.filtered_loc_df, asm, aem)
         points_after.reset_index(inplace=True)
         with_speed_points_after = eaicl.add_dist_heading_speed(points_after)
 
@@ -407,7 +407,7 @@ class FlipFlopDetection():
 
     def get_median_speed(self, mcs, mce):
         loc_df = self.seg_method.filter_points_for_range(
-                self.seg_method.location_points, mcs, mce)
+                self.seg_method.filtered_loc_df, mcs, mce)
         if len(loc_df) > 0:
             loc_df.reset_index(inplace=True)
             with_speed_df = eaicl.add_dist_heading_speed(loc_df)

--- a/emission/storage/pipeline_queries.py
+++ b/emission/storage/pipeline_queries.py
@@ -77,7 +77,7 @@ def mark_sectioning_done(user_id, last_trip_done):
         mark_stage_done(user_id, ps.PipelineStages.SECTION_SEGMENTATION, None)
     else:
         mark_stage_done(user_id, ps.PipelineStages.SECTION_SEGMENTATION,
-                        last_trip_done.data.end_ts + END_FUZZ_AVOID_LTE)
+                        last_trip_done['data']['end_ts'] + END_FUZZ_AVOID_LTE)
 
 def mark_sectioning_failed(user_id):
     mark_stage_failed(user_id, ps.PipelineStages.SECTION_SEGMENTATION)

--- a/emission/tests/analysisTests/intakeTests/TestSectionSegmentation.py
+++ b/emission/tests/analysisTests/intakeTests/TestSectionSegmentation.py
@@ -155,7 +155,7 @@ class TestSectionSegmentation(unittest.TestCase):
 
         dist_from_place = eaiss._get_distance_from_start_place_to_end(test_trip_entry,
                                                                      [test_place_entry])
-        eaiss.segment_trip_into_sections(
+        entries = eaiss.segment_trip_into_sections(
             ts,
             test_trip_entry,
             dist_from_place,
@@ -165,6 +165,7 @@ class TestSectionSegmentation(unittest.TestCase):
             unfiltered_loc_df,
             filtered_loc_df,
         )
+        ts.bulk_insert(entries, esta.EntryType.ANALYSIS_TYPE)
         
         created_stops_entries = esdt.get_raw_stops_for_trip(self.androidUUID, test_trip_id)
         created_sections_entries = esdt.get_raw_sections_for_trip(self.androidUUID, test_trip_id)


### PR DESCRIPTION
(Continuation of #1031)

### read all entries upfront during section segmentation

Since DB calls are a bottleneck, we can reduce the number of DB calls by making upfront queries for all the required types of entries we'll need across the entire time range we are sectioning.
Then we can filter those down accordingly.

These include: segmentation/raw_place, background/bluetooth_ble, background/motion_activity, background/location, and background/filtered_location
(For some edge cases, statemachine/transition is used – but seeing as it will only be used in those specific cases, it doesn't make sense to load upfront)

The motion activity and locations are used as dataframes later on, so I used get_data_df for those.
trips, places, and ble are queried with find_entries.

Then these are plumbed through to segment_trip_into_sections, filtered to the time range of the current trip, and ultimately passed into each SectionSegmentationMethod's segment_into_sections

With the locations already pre-loaded as dataframes, I was able to remove get_location_streams_for_trip altogether

For _get_distance_from_start_place_to_end, we preload all places in the segmentation range, so we can usually find the trip's start place in memory by its _id. However, unit tests revealed edge cases where the first start place is before the current segmentation time range, so we must fallback to querying the DB via esda.get_object


### insert section segmentation entries in bulk

We create segmentation/raw_section and segmentation/raw_stop entries in segment_trip_into_sections. We have been inserting them as we create them (which sometimes required updating the previous entry if there is a stop), resulting in numerous insert and update DB calls
Instead we can keep a list of entries to be created and then only bulk_insert them at the end of the stage, once we are done updating them