### PR TITLE
add MONITOR_DB option to record stats for all commands to DB

### DIFF
--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -16,7 +16,7 @@ config = ecbc.get_config('conf/storage/db.conf',
     {"DB_HOST": "timeseries.url", "DB_RESULT_LIMIT": "timeseries.result_limit"})
 
 db_config = {}
-for key in ["DB_HOST", "DB_RESULT_LIMIT", "USE_HINTS"]:
+for key in ["DB_HOST", "DB_RESULT_LIMIT", "USE_HINTS", "MONITOR_DB"]:
     if key in config:
         db_config[key] = config.get(key)
     else:
@@ -32,6 +32,10 @@ try:
     use_hints = bool(config.get("USE_HINTS", False))
 except ValueError:
     use_hints = False
+
+if db_config.get("MONITOR_DB"):
+    import emission.storage.timeseries.db_query_monitor as estd
+    estd.register_db_query_monitor()
 
 try:
     parsed=pymongo.uri_parser.parse_uri(url)

--- a/emission/storage/timeseries/db_query_monitor.py
+++ b/emission/storage/timeseries/db_query_monitor.py
@@ -1,0 +1,32 @@
+# For debugging DB locally
+# Record a stat every time the DB is queried by monitoring the MongoDB client
+
+
+import inspect
+import time
+from pymongo.monitoring import register, CommandListener
+
+
+class QueryMonitor(CommandListener):
+    def started(self, event):
+        event_cmd = str(event.command)
+        if ('stats/pipeline_time' not in event_cmd):
+            call_stack = [f.function for f in inspect.stack()][11:]
+            try:
+                import emission.storage.decorations.stats_queries as esds
+                esds.store_pipeline_time(None,
+                                         f'db_call/{event.command_name}',
+                                         time.time(),
+                                         str(call_stack))
+            except AttributeError:
+                # timeseries not initialized yet, skip
+                pass
+
+    def __init__(self): pass
+    def succeeded(self, _): pass
+    def failed(self, _): pass
+
+
+def register_db_query_monitor():
+    print("Registering DB query monitor")
+    register(QueryMonitor())


### PR DESCRIPTION
For local development, we have been using this QueryMonitor to identify spots in the pipeline with excessive DB calls. For every command to the DB, this records an entry with the type of command and the list of functions in the current stack trace (to identify where the DB call originated from)

It is only enabled when MONITOR_DB environment variable is set. We will not enable this on production since it causes thousands of extra entries to be recorded to the DB