### PR TITLE
⚡️ preload entries and bulk insert in JUMP_SMOOTHING

### DIFF
--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -243,7 +243,10 @@ class BuiltinTimeSeries(esta.TimeSeries):
             if sort_key is None:
                 ts_db_result = ts_db_cursor
             else:
-                ts_db_result = ts_db_cursor.sort(sort_key, pymongo.ASCENDING)
+                ts_db_result = ts_db_cursor.sort([
+                    (sort_key, pymongo.ASCENDING),
+                    ('_id', pymongo.ASCENDING),
+                ])
             # We send the results from the phone in batches of 10,000
             # And we support reading upto 100 times that amount at a time, so over
             # This is more than the number of entries across all metadata types for
@@ -333,7 +336,13 @@ class BuiltinTimeSeries(esta.TimeSeries):
         :return: a database row, or None if no match is found
         """
         find_query = self._get_query([key], time_query)
-        result_it = self.get_timeseries_db(key).find(find_query).sort(field, sort_order).limit(1)
+        result_it = self.get_timeseries_db(key) \
+                        .find(find_query) \
+                        .sort([
+                            (field, sort_order),
+                            ('_id', pymongo.ASCENDING),
+                        ]) \
+                        .limit(1)
         result_list = list(result_it)
         if len(result_list) == 0:
             return None

--- a/emission/tests/analysisTests/intakeTests/TestLocationSmoothing.py
+++ b/emission/tests/analysisTests/intakeTests/TestLocationSmoothing.py
@@ -268,7 +268,11 @@ class TestLocationSmoothing(unittest.TestCase):
             for j, section_entry in enumerate(curr_sections):
                 logging.debug("-" * 20 + "Considering section %s: %s" %
                               (j, section_entry.data.start_fmt_time) + "-" * 20)
-                eaicl.filter_jumps(self.testUUID, section_entry.get_id())
+                loc_df = self.ts.get_data_df("background/filtered_location",
+                        esda.get_time_query_for_trip_like(esda.RAW_SECTION_KEY,
+                                                          section_entry.get_id()))
+                entry_to_store = eaicl.filter_jumps(self.testUUID, section_entry, loc_df)
+                self.ts.insert(entry_to_store)
                 # TODO: Figure out how to make collections work for the wrappers and then change this to an Entry
                 filtered_points_entry = ad.AttrDict(self.ts.get_entry_at_ts(
                     "analysis/smoothing", "data.section", section_entry.get_id()))


### PR DESCRIPTION
### ⚡️ preload entries and bulk insert in JUMP_SMOOTHING

In JUMP_SMOOTHING, we iterate over all sections and look at the locations in them to identify jumps. Instead of making separate 'find' queries for each section, we can query all locations upfront and filter by time range to look at specific sections (similar to what we have done for trip segmentation and section segmentation: https://github.com/e-mission/e-mission-server/pull/1036 https://github.com/e-mission/e-mission-server/pull/1014)

Additionally, we can reduce the number of 'insert' queries by keeping a list of the "entries to be created" and doing a bulk_insert once we are finished iterating

Overall this reduces the number of DB queries from O(n) where n is # of sections, to O(1)
For a moderately large day of travel this is a reduction of about 10x:
https://github.com/e-mission/e-mission-server/pull/1042#issuecomment-2776979556

<hr>

This currently causes tests to fail but I don't know why. will update later