### PR TITLE
🔥 Use the `bulk_write` API to insert the incoming data instead of ins…

### DIFF
--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -13,6 +13,7 @@ from builtins import *
 from past.utils import old_div
 import logging
 import pymongo
+import arrow
 
 # Our imports
 from emission.core.get_database import get_usercache_db
@@ -61,7 +62,12 @@ def sync_phone_to_server(uuid, data_from_phone):
     """
         Puts the blob from the phone into the cache
     """
-    usercache_db = get_usercache_db()
+
+    if len(data_from_phone) == 0:
+        logging.info(f"For {uuid}, sync_phone_to_server called with {len(data_from_phone)=}, should not happen, early return")
+        return
+
+    upsert_op_list = []
 
     last_location_entry = {"data": {"ts": -1}}
     for data in data_from_phone:
@@ -87,26 +93,23 @@ def sync_phone_to_server(uuid, data_from_phone):
                         'metadata.type': data["metadata"]["type"],
                         'metadata.write_ts': data["metadata"]["write_ts"],
                         'metadata.key': data["metadata"]["key"]}
-        try:
-            result = usercache_db.update_one(update_query,
-                                               document,
-                                               upsert=True)
-            logging.debug("Updated result for user = %s, key = %s, write_ts = %s = %s" %
-                (uuid, data["metadata"]["key"], data["metadata"]["write_ts"], result.raw_result))
+        upsert_op_list.append(pymongo.UpdateOne(update_query, document, upsert=True))
 
-            # I am not sure how to trigger a writer error to test this
-            # and whether this is the format expected from the server in the rawResult
-            if 'ok' in result.raw_result and result.raw_result['ok'] != 1.0:
-                logging.error("In sync_phone_to_server, err = %s" % result.raw_result['writeError'])
-                raise Exception()
+        if data["metadata"]["key"] == "background/location":
+            last_location_entry = data
 
-            if data["metadata"]["key"] == "background/location":
-                last_location_entry = data
+    try:
+        first_entry = data_from_phone[0]
+        last_entry = data_from_phone[-1]
+        logging.info(f"For {uuid}, about to perform bulk_write of {len(upsert_op_list)} operations from {arrow.get(first_entry['metadata']['write_ts'])}({first_entry['metadata']['write_ts']}) -> {arrow.get(last_entry['metadata']['write_ts'])}({first_entry['metadata']['write_ts']})")
+        result = get_usercache_db().bulk_write(upsert_op_list)
+        logging.debug("Updated result for user = %s, is %s" %
+            (uuid, result.bulk_api_result))
 
-        except pymongo.errors.PyMongoError as e:
-            logging.error(f"In sync_phone_to_server, while executing {update_query=} on {document=}")
-            logging.exception(e)
-            raise
+    except pymongo.errors.PyMongoError as e:
+        logging.error(f"In sync_phone_to_server, while executing {update_query=} on {document=}")
+        logging.exception(e)
+        raise
 
     earus.update_upload_timestamp(uuid, "last_location_ts", last_location_entry["data"].get("ts", -1))
     earus.update_upload_timestamp(uuid, "last_phone_data_ts", data["metadata"]["write_ts"])


### PR DESCRIPTION
…erting one by one

As we support larger deployments, the webapp is turning into a bottleneck. Looking at the logs, it looks like the bottleneck is again DocumentDB, which seems to take multiple milliseconds for each write, which adds up when we are saving many thousands of entries. In contrast, MongoDB inserts are < 1 ms each

MongoDB:

```
2025-04-16 07:27:58,093:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,093:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['year', 'month', 'day', 'hour', 'minute', 'second', 'weekday', 'timezone'])
2025-04-16 07:27:58,093:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,093:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['time_zone', 'plugin', 'write_ts', 'platform', 'read_ts', 'key', 'type', 'write_local_dt', 'write_fmt_time'])
2025-04-16 07:27:58,093:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,093:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['year', 'month', 'day', 'hour', 'minute', 'second', 'weekday', 'timezone'])
2025-04-16 07:27:58,093:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,093:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['battery_level_pct', 'battery_status', 'ts', 'local_dt', 'fmt_time'])
2025-04-16 07:27:58,093:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,093:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['metadata', 'data', 'user_id'])
2025-04-16 07:27:58,095:DEBUG:140737036695104:Updated result for user = da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3, key = background/battery, write_ts = 1722957271.6881871 = {'n': 1, 'nModified': 0, 'ok': 1.0, 'updatedExisting': True}

2025-04-16 07:27:58,095:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,095:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['year', 'month', 'day', 'hour', 'minute', 'second', 'weekday', 'timezone'])
2025-04-16 07:27:58,095:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,095:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['time_zone', 'plugin', 'write_ts', 'platform', 'read_ts', 'key', 'type', 'write_local_dt', 'write_fmt_time'])
2025-04-16 07:27:58,095:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,095:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['year', 'month', 'day', 'hour', 'minute', 'second', 'weekday', 'timezone'])
2025-04-16 07:27:58,095:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,095:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['battery_level_pct', 'battery_status', 'ts', 'local_dt', 'fmt_time'])
2025-04-16 07:27:58,095:INFO:140737036695104:Before modifying, keys_to_munge=[]
2025-04-16 07:27:58,095:INFO:140737036695104:(After modifying, entry_doc.keys()=dict_keys(['metadata', 'data', 'user_id'])
2025-04-16 07:27:58,095:DEBUG:140737036695104:Updated result for user = da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3, key = background/battery, write_ts = 1722957271.8056412 = {'n': 1, 'nModified':
 0, 'ok': 1.0, 'updatedExisting': True}
```

DocumentDB:

```
2025-04-15T16:23:20.789-07:00 2025-04-15 23:23:20,789:DEBUG:140577872004672:Updated result for user = 6804aa5a-6fab-4a14-9aa5-8b0fb97f38cb, key = background/location, write_ts = 1744736224.032 = {'n': 1, 'nModified': 0, 'ok': 1.0, 'operationTime': Timestamp(1744759400, 1), 'updatedExisting': True}

2025-04-15T16:23:20.790-07:00 2025-04-15 23:23:20,789:INFO:140577872004672:Before modifying, keys_to_munge=[]
2025-04-15T16:23:20.790-07:00 2025-04-15 23:23:20,790:INFO:140577872004672:(After modifying, entry_doc.keys()=dict_keys(['key', 'platform', 'read_ts', 'time_zone', 'type', 'write_ts'])
2025-04-15T16:23:20.790-07:00 2025-04-15 23:23:20,790:INFO:140577872004672:Before modifying, keys_to_munge=[]
2025-04-15T16:23:20.790-07:00 2025-04-15 23:23:20,790:INFO:140577872004672:(After modifying, entry_doc.keys()=dict_keys(['accuracy', 'altitude', 'bearing', 'elapsedRealtimeNanos', 'filter', 'fmt_time', 'latitude', 'longitude', 'sensed_speed', 'ts'])
2025-04-15T16:23:20.790-07:00 2025-04-15 23:23:20,790:INFO:140577872004672:Before modifying, keys_to_munge=[]
2025-04-15T16:23:20.790-07:00 2025-04-15 23:23:20,790:INFO:140577872004672:(After modifying, entry_doc.keys()=dict_keys(['metadata', 'data', 'user_id'])

2025-04-15T16:23:20.797-07:00 2025-04-15 23:23:20,797:DEBUG:140577872004672:Updated result for user = 6804aa5a-6fab-4a14-9aa5-8b0fb97f38cb, key = background/filtered_location, write_ts = 1744736224.088 = {'n': 1, 'nModified': 0, 'ok': 1.0, 'operationTime': Timestamp(1744759400, 1), 'updatedExisting': True}

2025-04-15T16:23:20.798-07:00 2025-04-15 23:23:20,798:INFO:140577872004672:Before modifying, keys_to_munge=[]
2025-04-15T16:23:20.798-07:00 2025-04-15 23:23:20,798:INFO:140577872004672:(After modifying, entry_doc.keys()=dict_keys(['key', 'platform', 'read_ts', 'time_zone', 'type', 'write_ts'])
2025-04-15T16:23:20.799-07:00 2025-04-15 23:23:20,799:INFO:140577872004672:Before modifying, keys_to_munge=[]
2025-04-15T16:23:20.799-07:00 2025-04-15 23:23:20,799:INFO:140577872004672:(After modifying, entry_doc.keys()=dict_keys(['currState', 'transition', 'ts'])
2025-04-15T16:23:20.800-07:00 2025-04-15 23:23:20,800:INFO:140577872004672:Before modifying, keys_to_munge=[]
2025-04-15T16:23:20.800-07:00 2025-04-15 23:23:20,800:INFO:140577872004672:(After modifying, entry_doc.keys()=dict_keys(['metadata', 'data', 'user_id'])

2025-04-15T16:23:20.806-07:00 2025-04-15 23:23:20,806:DEBUG:140577872004672:Updated result for user = 6804aa5a-6fab-4a14-9aa5-8b0fb97f38cb, key = statemachine/transition, write_ts = 1744736224.159 = {'n': 1, 'nModified': 0, 'ok': 1.0, 'operationTime': Timestamp(1744759400, 1), 'updatedExisting': True}
```

This is also reflected in the overall time to save 10k entries.

DocumentDB:

```
2025-04-16T07:28:27.448-07:00 2025-04-16 14:28:27,448:DEBUG:140615831164480:START POST /usercache/put
2025-04-16T07:29:11.666-07:00 2025-04-16 14:29:11,666:DEBUG:140615831164480:END POST /usercache/put 0e98a4f1-91ba-47a4-94a5-1f024fc5098f 44.25499749183655

2025-04-16T07:29:13.601-07:00 2025-04-16 14:29:13,601:DEBUG:140616266860096:START POST /usercache/put
2025-04-16T07:29:57.326-07:00 2025-04-16 14:29:57,326:DEBUG:140616266860096:END POST /usercache/put 0e98a4f1-91ba-47a4-94a5-1f024fc5098f 43.75884938240051

2025-04-16T07:29:59.295-07:00 2025-04-16 14:29:59,295:DEBUG:140615873123904:START POST /usercache/put
2025-04-16T07:30:45.912-07:00 2025-04-16 14:30:45,912:DEBUG:140615873123904:END POST /usercache/put 0e98a4f1-91ba-47a4-94a5-1f024fc5098f 46.65658187866211
```

MongoDB:

```
START 2025-04-16 14:58:54.065030 POST /usercache/put
END 2025-04-16 14:58:58.347547 POST /usercache/put da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3 4.280893802642822
START 2025-04-16 14:58:59.265866 POST /usercache/put
END 2025-04-16 14:59:02.702028 POST /usercache/put da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3 3.4349358081817627
START 2025-04-16 14:59:03.652562 POST /usercache/put
END 2025-04-16 14:59:07.195128 POST /usercache/put da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3 3.5403733253479004
```

We are working on migrating from DocumentDB to mongoDB, but that is a major change and will require significant testing before we go live. However, in the short term, we can try to optimize the existing usage pattern of the database by using a `bulk_write` instead of multiple individual writes.

This is a much more targeted change, and it seems to give significant improvement, even for MongoDB. The overall time dropped from ~ 4 secs to ~ 1 second.

```
START 2025-04-16 15:04:03.372658 POST /usercache/put
END 2025-04-16 15:04:04.267284 POST /usercache/put da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3 0.8934834003448486
START 2025-04-16 15:04:05.133535 POST /usercache/put
END 2025-04-16 15:04:06.171844 POST /usercache/put da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3 1.035712480545044
START 2025-04-16 15:04:07.231908 POST /usercache/put
END 2025-04-16 15:04:08.166894 POST /usercache/put da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3 0.9328651428222656
```

And the update was successful (this was re-running the same workload, so there were all matches, and nothing was inserted/upserted).

```
2025-04-16 15:04:07,609:INFO:140736934696512:For da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3, about to perform bulk_write of 10000 operations from 2024-08-06T15:14:31.688187+00:00(1722957271.68818
71) -> 2024-08-07T00:01:23.792671+00:00(1722957271.6881871)
2025-04-16 15:04:08,160:DEBUG:140736934696512:Updated result for user = da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3, is {'writeErrors': [], 'writeConcernErrors': [], 'nInserted': 0, 'nUpserted': 0
, 'nMatched': 10000, 'nModified': 0, 'nRemoved': 0, 'upserted': []}
2025-04-16 15:04:08,161:DEBUG:140736934696512:Updating user da63d4f7-ff86-4cca-bfc3-5fb60d81d5d3 with fields {'last_location_ts': 1723011084.8418388}
2025-04-16 15:04:08,161:DEBUG:140736934696512:User profile updated with data: {'last_location_ts': 1723011084.8418388}
```

Note that we are using an ordered `bulk_write`, which means that the write will fail as soon as any insert fails.
https://pymongo.readthedocs.io/en/stable/examples/bulk.html

> The first write failure that occurs (e.g. duplicate key error) aborts the remaining operations, and PyMongo raises BulkWriteError. The details attribute of the exception instance provides the execution results up until the failure occurred and details about the failure - including the operation that caused the failure.

This is actually consistent with the previous error handling where we were inserting one-by-one.
- If the result was not `ok`, we raised an exception
- If there was a `PyMongoError`, we also raised an exception

We would always stop processing the batch on the first error, so this change will not alter that behavior.

Actually inserting entries as opposed to just matching them is a bit slower but still much faster than the individual inserts.

```
START 2025-04-16 16:13:41.654027 POST /usercache/put
END 2025-04-16 16:13:43.653301 POST /usercache/put 872ea3ec-bbfb-42e8-8b9a-8675a5ed9e97 1.9958009719848633
START 2025-04-16 16:13:54.819003 POST /usercache/put
END 2025-04-16 16:13:55.992577 POST /usercache/put 872ea3ec-bbfb-42e8-8b9a-8675a5ed9e97 1.1658375263214111
START 2025-04-16 16:14:03.881300 POST /usercache/put
END 2025-04-16 16:14:04.868236 POST /usercache/put 872ea3ec-bbfb-42e8-8b9a-8675a5ed9e97 0.9839518070220947
```

```
2025-04-16 16:13:42,347:INFO:140737036695104:For 872ea3ec-bbfb-42e8-8b9a-8675a5ed9e97, about to perform bulk_write of 10000 operations from 2023-06-09T01:21:29.651001+00:00(1686273689.65100
1) -> 2023-10-11T16:11:43.098583+00:00(1686273689.651001)
2025-04-16 16:13:43,641:DEBUG:140737036695104:Updated result for user = 872ea3ec-bbfb-42e8-8b9a-8675a5ed9e97, is {'writeErrors': [], 'writeConcernErrors': [], 'nInserted': 0, 'nUpserted': 9
901, 'nMatched': 99, 'nModified': 0, 'nRemoved': 0, 'upserted': [{'index': 0, '_id': ObjectId('67ffd736f5b507db559db89d')}, {'index': 1, '_id': ObjectId('67ffd736f5b507db559db89e')}, {'index': 2, '_id': ObjectId('67ffd736f5b507db559db89f')}, {'index': 3, '_id': ObjectId('67ffd736f5b507db559db8a0')}, ...
{'index': 7797, '_id': ObjectId('67ffd737f5b507db559dd6de')}, {'index': 7798, '_id': ObjectId('67ffd737f5b507db559dd6df')}, {'index': 7799, '_id': ObjectId('67ffd737f5b507db559dd6e0')}, {'index': 7800, '_id': ObjectId('67ffd737f5b507db559dd6e1')}, {'index': 7801, '_id': ObjectId('67ffd737f5b507db559dd6e2')}, {'index': 7802, '_id': ObjectId('67ffd737f5b507db559dd6e3')}, {'index': 7803, '_id': ObjectId('67ffd737f5b507db559dd6e4')}, {'index': 7804, '_id': ObjectId('67ffd737f5b507db559dd6e5')}, {'index': 7805, '_id': ObjectId('67ffd737f5b507db559dd6e6')}, {'index': 7806, '_id': ObjectId('67ffd737f5b507db559dd6e7')}, {'index': 7807, '_id': ObjectId('67ffd737f5b507db559dd6e8')}, {'index': 7808, '_id': ObjectId('67ffd737f5b507db559dd6e9')}, {'index': 7809, '_id': ObjectId('67ffd737f5b507db559dd6ea')}, {'index': 7810, '_id': ObjectId('67ffd737f5b507db559dd6eb')}, {'index': 7811, '_id': ObjectId('67ffd737f5b507db559dd6ec')}, {'index': 7812, '_id': ObjectId('67ffd737f5b507db559dd6ed')}, {'index': 7813, '_id': ObjectId('67ffd737f5b507db559dd6ee')}, {'index': 7814, '_id': ObjectId('67ffd737f5b507db559dd6ef')}, {'index': 7815, '_id': ObjectId('67ffd737f5b507db559dd6f0')}, {'index': 7816, '_id': ObjectId('67ffd737f5b507db559dd6f1')}, {'index': 7817, '_id': ObjectId('67ffd737f5b507db559dd6f2')}, {'index': 7818, '_id': ObjectId('67ffd737f5b507db559dd6f3')}, {'index': 7819, '_id': ObjectId('67ffd737f5b507db559dd6f4')}, {'index': 7820, '_id': ObjectId('67ffd737f5b507db559dd6f5')}, {'index': 7821, '_id': ObjectId('67ffd737f5b507db559dd6f6')}, {'index': 7822, '_id': ObjectId('67ffd737f5b507db559dd6f7')}, {'index': 7823, '_id': ObjectId('67ffd737f5b507db559dd6f8')}, {'index': 7824, '_id': ObjectId('67ffd737f5b507db559dd6f9')}, {'index': 7825, '_id': ObjectId('67ffd737f5b507db559dd6fa')}, {'index': 7826, '_id': ObjectId('67ffd737f5b507db559dd6fb')}, {'index': 7827, '_id': ObjectId('67ffd737f5b507db559dd6fc')}, ...
{'index': 9990, '_id': ObjectId('67ffd737f5b507db559ddf40')}, {'index': 9991, '_id': ObjectId('67ffd737f5b507db559ddf41')}, {'index': 9992, '_id': ObjectId('67ffd737f5b507db559ddf42')}, {'index': 9993, '_id': ObjectId('67ffd737f5b507db559ddf43')}, {'index': 9994, '_id': ObjectId('67ffd737f5b507db559ddf44')}, {'index': 9995, '_id': ObjectId('67ffd737f5b507db559ddf45')}, {'index': 9996, '_id': ObjectId('67ffd737f5b507db559ddf46')}, {'index': 9997, '_id': ObjectId('67ffd737f5b507db559ddf47')}, {'index': 9998, '_id': ObjectId('67ffd737f5b507db559ddf48')}, {'index': 9999, '_id': ObjectId('67ffd737f5b507db559ddf49')}]}
```