### PR TITLE
🧪 Add a load testing framework for the webapp

### DIFF
--- a/bin/locust/README.md
+++ b/bin/locust/README.md
@@ -1,0 +1,85 @@
+# Locust Load Testing Setup (partially auto-generated using Copilot)
+
+This directory contains the configuration and scripts required to perform load testing of the webapp. For greater versimilitude, it runs the webapp behind an nginx server.
+
+## Files and Directories
+
+### `docker-compose.loadtest.yml`
+This file defines the Docker Compose setup for running load tests. It includes the following services:
+
+- **locust**: Runs the Locust load testing tool.
+- **nginxrp**: Runs an Nginx reverse proxy for routing and load balancing.
+- **webapp**: Hosts the e-mission web application.
+- **db**: Runs a MongoDB instance for the backend database.
+
+### `nginx.conf`
+The Nginx configuration file used by the `nginxrp` service. It defines routing rules, rate limiting, and proxy settings.
+
+### `webapp.py`
+A Python script defining Locust tasks for simulating user behavior and generating load on the web application.
+
+## Usage
+
+### Prerequisites
+- Docker and Docker Compose must be installed on your system.
+
+### Steps to Run
+1. Start the containers using Docker Compose:
+   ```bash
+   docker-compose -f docker-compose.loadtest.yml up
+   ```
+
+2. The webapp and locust containers do not automatically start their servers, allowing easier development.
+
+3. Activate webapp in the container (once)
+   ```bash
+   cd /usr/src/devapp && source setup/activate.sh
+   ```
+
+3. Run the webapp in the container manually (restart after code changes as needed)
+   ```bash
+   ./e-mission-py.bash emission/net/api/cfc_webapp.py
+   ```
+
+3. Setup locust in the container (once)
+   ```bash
+   source setup/activate.sh
+   pip install locust
+   ```
+
+3. Run locust in the container manually (restart after code changes as needed)
+   ```bash
+   locust -f ../devapp/webapp.py
+   ```
+
+2. Access the Locust web interface at `http://localhost:8089`.
+
+3. Configure the number of users and spawn rate in the Locust UI, then start the test.
+
+4. Monitor the Nginx reverse proxy at `http://localhost:8081`.
+
+5. Note that changes to the reverse proxy configuration currently require restarting the nginx container since it is not run in "dev mode" like the webapp and locust.
+
+## Notes
+- Ensure that the `nginx.conf` file is correctly configured for your testing needs. For example:
+  - To simulate rate limiting, add or adjust the `limit_req` directives in the `http` block.
+  - To test specific routing rules, modify the `location` blocks to point to the desired endpoints.
+
+- Modify `webapp.py` to define custom user behavior for load testing. For example:
+  - Use Locust's `HttpUser` class to define user tasks, such as login or data submission.
+  - Adjust the `wait_time` attribute to simulate realistic user interaction delays.
+  - Add custom headers or authentication tokens to mimic real-world API requests.
+- Ensure that the required ports (8080, 8081, 8089) are not in use by other applications. You can check port usage with the following commands:
+  ```bash
+  netstat -tuln | grep <port>
+  ```
+  or
+  ```bash
+  lsof -i:<port>
+  ```
+## Troubleshooting
+- If services fail to start, check the logs using:
+  ```bash
+  docker-compose -f docker-compose.loadtest.yml logs
+  ```
+- Ensure that the required ports (8080, 8081, 8089) are not in use by other applications.

--- a/bin/locust/docker-compose.loadtest.yml
+++ b/bin/locust/docker-compose.loadtest.yml
@@ -18,7 +18,7 @@ services:
     ports:
       - "8081:80"
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
     networks:
       - emission
   webapp:

--- a/bin/locust/docker-compose.loadtest.yml
+++ b/bin/locust/docker-compose.loadtest.yml
@@ -1,0 +1,55 @@
+version: "3"
+services:
+  locust:
+    image: shankari/e-mission-server:master_2025-03-13--45-18
+    entrypoint: "sleep infinity"
+    ports:
+      - "8089:8089"
+    volumes:
+      - .:/usr/src/devapp
+    networks:
+      - emission
+  nginxrp:
+    image: nginx:1.24.0
+    # In case we want to bump up the debug level for troubleshooting    
+    # command: [nginx-debug, '-g', 'daemon off;']
+    depends_on:
+      - webapp
+    ports:
+      - "8081:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    networks:
+      - emission
+  webapp:
+    image: shankari/e-mission-server:master_2025-03-13--45-18
+    # Placeholder command to keep the container running
+    entrypoint: "sleep infinity"
+    depends_on:
+      - db
+    environment:
+      - DB_HOST=db
+      - WEB_SERVER_HOST=0.0.0.0
+      - CRON_MODE=
+      - STUDY_CONFIG=stage-program
+    ports:
+      # ipynb in numbers
+      - "8080:8080"
+    volumes:
+      - ../../:/usr/src/devapp
+    networks:
+      - emission
+  db:
+    image: mongo:8.0.4
+    volumes:
+      - mongo-data:/data/db
+    networks:
+       - emission
+
+# Define the custom network for inter-service communication
+networks:
+  emission:
+volumes:
+  # Persistent storage for MongoDB database data
+  mongo-data:
+

--- a/bin/locust/nginx.conf
+++ b/bin/locust/nginx.conf
@@ -1,5 +1,3 @@
-events { }
-http {
     limit_req_zone all_hosts zone=everything_else:10m rate=50r/m;
     limit_req_zone all_hosts zone=profile_update:10m rate=4r/m;
     limit_req_zone all_hosts zone=usercache_get_put:10m rate=100r/m;
@@ -103,4 +101,3 @@ http {
         }
 
     }
-}

--- a/bin/locust/nginx.conf
+++ b/bin/locust/nginx.conf
@@ -1,0 +1,106 @@
+events { }
+http {
+    limit_req_zone all_hosts zone=everything_else:10m rate=50r/m;
+    limit_req_zone all_hosts zone=profile_update:10m rate=4r/m;
+    limit_req_zone all_hosts zone=usercache_get_put:10m rate=100r/m;
+
+    server {
+        listen 80;
+        charset utf-8;
+        server_tokens off;
+
+# Re-enable once we have figured out how to get the set_headers module to work        
+#         more_set_headers "X-XSS-Protection: 1; mode=block";
+#         more_set_headers "Access-Control-Allow-Origin: $host";
+#         more_set_headers "X-Frame-Options: SAMEORIGIN";
+#         more_set_headers "Referrer-Policy: same-origin";
+#         more_set_headers "Allow: GET, POST, HEAD";
+        if ($request_method ~ ^(OPTIONS)$ ) { return 403; }
+        
+#         proxy_cookie_path off;
+#         proxy_cookie_path / "/; HTTPOnly; Secure";
+ 
+        error_page 404 https://www.nrel.gov/notfound;
+
+        location /static {
+            alias /www/static;
+        }
+
+        location / {
+            rewrite /(.+$) /api/$1 break;
+        }
+
+        location /api/ {
+            proxy_pass http://webapp:8080/;
+            proxy_pass_header Content-Type; 
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_hide_header Access-Control-Allow-Origin;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_cookie_path / "/; Secure; HttpOnly; SameSite=strict";
+            client_max_body_size 1G;
+            proxy_read_timeout 300;
+            proxy_connect_timeout 300;
+            proxy_send_timeout 300;
+            limit_req zone=everything_else burst=5 nodelay;
+        }
+
+        location = /api/profile/update {
+            proxy_pass http://webapp:8080/profile/update;
+            proxy_pass_header Content-Type; 
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_hide_header Access-Control-Allow-Origin;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_cookie_path / "/; Secure; HttpOnly; SameSite=strict";
+            client_max_body_size 1G;
+            proxy_read_timeout 300;
+            proxy_connect_timeout 300;
+            proxy_send_timeout 300;
+            limit_req zone=profile_update burst=2 delay=2;
+        }
+
+        location = /api/usercache/get {
+            proxy_pass http://webapp:8080/usercache/get;
+            proxy_pass_header Content-Type; 
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_hide_header Access-Control-Allow-Origin;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_cookie_path / "/; Secure; HttpOnly; SameSite=strict";
+            client_max_body_size 1G;
+            proxy_read_timeout 300;
+            proxy_connect_timeout 300;
+            proxy_send_timeout 300;
+            limit_req zone=usercache_get_put burst=20 delay=20;
+        }
+
+        location = /api/usercache/put {
+            proxy_pass http://webapp:8080/usercache/put;
+            proxy_pass_header Content-Type; 
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_hide_header Access-Control-Allow-Origin;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_cookie_path / "/; Secure; HttpOnly; SameSite=strict";
+            client_max_body_size 1G;
+            proxy_read_timeout 900;
+            proxy_connect_timeout 900;
+            proxy_send_timeout 900;
+            limit_req zone=usercache_get_put burst=20 delay=20;
+        }
+
+    }
+}

--- a/bin/locust/webapp.py
+++ b/bin/locust/webapp.py
@@ -14,22 +14,56 @@ def generate_random_string(length=12):
     characters = string.ascii_letters + string.digits
     return ''.join(secrets.choice(characters) for _ in range(length))
 
+def random_src_random_created_dest(self):
+    self.opcode = generate_random_string(12)
+    self.client.post("/profile/create", json={"user": self.opcode})
+    self.src_uuid = secrets.choice(uuid_db_list)["uuid"]
+    print(f"Connecting existing user {self.src_uuid=} to opcode {self.opcode=}")
+    self.key_to_read = "background/filtered_location"
+
+def random_src_single_existing_dest(self):
+    self.opcode = "some_dest_opcode_REPLACEME"
+    self.src_uuid = secrets.choice(uuid_db_list)["uuid"]
+    self.key_to_read = "background/filtered_location"
+    print(f"Connecting existing source user {self.src_uuid=} to existing dest opcode {self.opcode=}")
+
+def same_src_dest_random(self):
+    # we can't really copy data from a different user in the same program
+    # because it may overlap with the existing users' data and mess everything up
+    # so we just copy the data from the same user if that task is enabled
+    chosen_user = secrets.choice(uuid_db_list)
+    self.opcode = chosen_user["user_email"]
+    self.src_uuid = chosen_user["uuid"]
+    self.key_to_read = "analysis/composite_trip"
+    print(f"Simulating existing user with {self.src_uuid=} and {self.opcode=}")
+
+def backoff_wait_time(self):
+    self.iteration = self.iteration + 1
+    if self.iteration % 100 == 0:
+        print(f"Iteration {self.iteration}, wait time = {self.iteration / 100}")
+    return self.iteration / 100
+
+uuid_db_list = list(edb.get_uuid_db().find())
+
 class PhoneAppUser(HttpUser):
+    # host = "https://openpath-stage.nrel.gov/api"
     host = "http://nginxrp/api"
     iteration = 0
-    uuid_db_list = list(edb.get_uuid_db().find())
 
     def wait_time(self):
-        self.iteration = self.iteration + 1
-        if self.iteration % 100 == 0:
-            print(f"Iteration {self.iteration}, wait time = {self.iteration / 100}")
-        return self.iteration / 100    
+        return backoff_wait_time(self)
+        # return 5
     
     def on_start(self):
-       self.opcode = generate_random_string(12)
-       self.client.post("/profile/create", json={"user": self.opcode})
-       self.src_uuid = secrets.choice(self.uuid_db_list)["uuid"]
-       print(f"Connecting existing user {self.src_uuid=} to opcode {self.opcode=}")
+        # use this to copy data from an existing dump to a new dummy local
+        # program, this will focus on writes
+        # random_src_random_created_dest(self)
+        # use this with staging, remember to fill in the single opcode
+        # random_src_single_existing_dest(self)
+        # use this with when the existing dump has already been loaded in the
+        # database under load; this will focus on reads
+        same_src_dest_random(self)
+
 
     @task(3)
     def profile_update(self):
@@ -43,10 +77,12 @@ class PhoneAppUser(HttpUser):
 
     @task(2)
     def find_entries_timestamp(self):
+       start_ts = 0 if self.key_to_read == "background/location" else \
+            arrow.utcnow().shift(days=-7).timestamp()
        self.client.post("/datastreams/find_entries/timestamp",
                         json={"user": self.opcode,
-                              "key_list": ["background/location"],
-                              "start_time": 0,
+                              "key_list": [self.key_to_read],
+                              "start_time": start_ts,
                               "end_time": arrow.utcnow().timestamp()})
 
     @task
@@ -60,3 +96,20 @@ class PhoneAppUser(HttpUser):
        wrapped_json = {"user": self.opcode, "phone_to_server": entries}
        self.client.post("/usercache/put", data=esj.wrapped_dumps(wrapped_json),
                         headers={"Content-Type": "application/json"})
+
+    @task
+    def metrics(self):
+       DEFAULT_METRIC_LIST = {
+           'footprint': ['mode_confirm'],
+           'distance': ['mode_confirm'],
+           'duration': ['mode_confirm'],
+           'count': ['mode_confirm'],
+       }
+       wrapped_json = {"user": self.opcode,
+          "metric_list": DEFAULT_METRIC_LIST,
+          "start_time": arrow.utcnow().shift(days=-7).isoformat(),
+          "end_time": arrow.utcnow().isoformat(),
+          "is_return_aggregate": True if self.iteration % 2 == 0 else False,
+          "freq": "D"}
+       self.client.post("/result/metrics/yyyy_mm_dd", data=esj.wrapped_dumps(wrapped_json),
+                         headers={"Content-Type": "application/json"})

--- a/bin/locust/webapp.py
+++ b/bin/locust/webapp.py
@@ -15,7 +15,7 @@ def generate_random_string(length=12):
     return ''.join(secrets.choice(characters) for _ in range(length))
 
 class PhoneAppUser(HttpUser):
-    host = "http://host.docker.internal:8080"
+    host = "http://nginxrp/api"
     iteration = 0
     uuid_db_list = list(edb.get_uuid_db().find())
 
@@ -60,7 +60,3 @@ class PhoneAppUser(HttpUser):
        wrapped_json = {"user": self.opcode, "phone_to_server": entries}
        self.client.post("/usercache/put", data=esj.wrapped_dumps(wrapped_json),
                         headers={"Content-Type": "application/json"})
-    @task
-    def hello(self):
-        self.client.get("/hello")
-        

--- a/bin/locust/webapp.py
+++ b/bin/locust/webapp.py
@@ -1,0 +1,66 @@
+import string
+import secrets
+from uuid import UUID
+import os
+import arrow
+from locust import HttpUser, task, constant
+
+import emission.core.get_database as edb
+import emission.core.wrapper.user as ecwu
+import emission.storage.json_wrappers as esj
+
+def generate_random_string(length=12):
+    """Generates a random string of the specified length."""
+    characters = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(characters) for _ in range(length))
+
+class PhoneAppUser(HttpUser):
+    host = "http://host.docker.internal:8080"
+    iteration = 0
+    uuid_db_list = list(edb.get_uuid_db().find())
+
+    def wait_time(self):
+        self.iteration = self.iteration + 1
+        if self.iteration % 100 == 0:
+            print(f"Iteration {self.iteration}, wait time = {self.iteration / 100}")
+        return self.iteration / 100    
+    
+    def on_start(self):
+       self.opcode = generate_random_string(12)
+       self.client.post("/profile/create", json={"user": self.opcode})
+       self.src_uuid = secrets.choice(self.uuid_db_list)["uuid"]
+       print(f"Connecting existing user {self.src_uuid=} to opcode {self.opcode=}")
+
+    @task(3)
+    def profile_update(self):
+       self.client.post("/profile/update",
+                        json={"user": self.opcode,
+                              "update_doc": {"platform": "locust", "app_version": "1.9.3"}})
+
+    @task(2)
+    def usercache_get(self):
+       self.client.post("/usercache/get", json={"user": self.opcode})
+
+    @task(2)
+    def find_entries_timestamp(self):
+       self.client.post("/datastreams/find_entries/timestamp",
+                        json={"user": self.opcode,
+                              "key_list": ["background/location"],
+                              "start_time": 0,
+                              "end_time": arrow.utcnow().timestamp()})
+
+    @task
+    def usercache_put(self):
+       entries = list(edb.get_timeseries_db().find({"user_id": self.src_uuid}).sort("metadata.key", 1).limit(10000))
+       for e in entries:
+           del e["_id"]
+           del e["user_id"]
+           if "type" not in e["metadata"]:
+               e["metadata"]["type"] = "missing"
+       wrapped_json = {"user": self.opcode, "phone_to_server": entries}
+       self.client.post("/usercache/put", data=esj.wrapped_dumps(wrapped_json),
+                        headers={"Content-Type": "application/json"})
+    @task
+    def hello(self):
+        self.client.get("/hello")
+        


### PR DESCRIPTION
- We utilize the Locust testing suite for our testing purposes.
- The operations selected are the top four from two representative windows of approximately 10 minutes on the `uw-ebike` system.
- The proportion of the operations chosen is also consistent with the proportion in those logs
- The test suite can be launched using Docker Compose for ease of use, although two of the services are launched manually to allow quick iteration in dev mode

Testing results:

1000 users, launched at 100 users/minute, without rate limiting on the server, dynamic wait time on the client (wait_time = iteration / 100)

| CPU usage | RPS |
|-------|-------|
| ![image](https://github.com/user-attachments/assets/245de342-ec62-4874-9887-9d9f239edff4) | ![image](https://github.com/user-attachments/assets/63c5099a-2bed-48d5-94fe-3dbded961fd8) |

Same as above, but with rate limiting on the server. This allows us to iterate on changes locally without affecting ongoing data collection.

![image](https://github.com/user-attachments/assets/b88eb5cd-126d-434a-b1e7-c67f9baf9b64)
<img width="816" alt="Screenshot 2025-04-18 at 3 30 52 PM" src="https://github.com/user-attachments/assets/cedac966-af61-4277-acad-bae6b9255de3" />

@JGreenlee for visibility


