### PR TITLE
🔥 💩 Temporarily disable all metrics calls by aborting

### DIFF
--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -355,6 +355,8 @@ def deleteUserCustomLabel():
 
 @post('/result/metrics/<time_type>')
 def summarize_metrics(time_type):
+    logging.debug("Metrics call, finished querying values through skipping")
+    abort(503, "Metrics calls have been temporarily disabled to avoid overloading the server")
     _fill_aggregate_backward_compat(request)
     user_uuid = get_user_or_aggregate_auth(request)
 
@@ -375,6 +377,7 @@ def summarize_metrics(time_type):
     else:
         old_style = True
         is_return_aggregate = True
+
 
     app_config = request.json['app_config'] if 'app_config' in request.json else None
 


### PR DESCRIPTION
The webapp crashes that we have seen recently and attempted to mitigate using https://github.com/e-mission/e-mission-server/pull/1046 https://github.com/e-mission/e-mission-server/pull/1047 https://github.com/e-mission/e-mission-server/pull/1049 turned out to be due to the metrics calls.

A couple of the issues are:
1. metrics calls read the aggregate data, which can be large for large studies such as `uw-ebike`. We have seen 50k+ composite trips being read.
2. even for user specific metrics, it looks like the postprocessing can lead to runaway CPU/memory utilization. I am not sure why this is, but it is 100% reproducible when tested on a laptop using docker.

As a temporary fix, we disable all metrics calls. The rest of the phone code will work properly. This should address the crashes we have seen and allow the UW team to continue with recruitment

Testing done:
- without this change, the webapp crashed within 6 calls
- when only aggregate calls were aborted, the webapp crashed within 5 minutes under load
- when all metrics calls were aborted, the webapp has been stable for over 30 minutes