### PR TITLE
👔 Improve the logic to whether we should skip the pipeline

### DIFF
--- a/bin/historical/migrations/add_sections_and_summaries_to_trips.py
+++ b/bin/historical/migrations/add_sections_and_summaries_to_trips.py
@@ -65,6 +65,6 @@ if __name__ == '__main__':
     args = parser.parse_args()
     split_lists = eps.get_split_uuid_lists(args.n_workers)
     logging.info("Finished generating split lists %s" % split_lists)
-    eps.dispatch(split_lists, skip_if_no_new_data=False, target_fn=add_sections_to_trips)
+    eps.dispatch(split_lists, target_fn=add_sections_to_trips)
 
 

--- a/bin/historical/migrations/populate_pipeline_range.py
+++ b/bin/historical/migrations/populate_pipeline_range.py
@@ -39,5 +39,5 @@ if __name__ == '__main__':
     args = parser.parse_args()
     split_lists = eps.get_split_uuid_lists(args.n_workers)
     logging.info("Finished generating split lists %s" % split_lists)
-    eps.dispatch(split_lists, skip_if_no_new_data=False, target_fn=add_pipeline_range)
+    eps.dispatch(split_lists, target_fn=add_pipeline_range)
 

--- a/bin/intake_multiprocess.py
+++ b/bin/intake_multiprocess.py
@@ -20,8 +20,6 @@ if __name__ == '__main__':
         intake_log_config = json.load(open("conf/log/intake.conf.sample", "r"))
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--skip_if_no_new_data", action="store_true",
-                        help="skip the pipeline if there is no new data")
     parser.add_argument("n_workers", type=int,
                         help="the number of worker processors to use")
     args = parser.parse_args()
@@ -34,4 +32,4 @@ if __name__ == '__main__':
 
     split_lists = eps.get_split_uuid_lists(args.n_workers)
     logging.info("Finished generating split lists %s" % split_lists)
-    eps.dispatch(split_lists, args.skip_if_no_new_data)
+    eps.dispatch(split_lists)

--- a/emission/pipeline/intake_stage.py
+++ b/emission/pipeline/intake_stage.py
@@ -42,7 +42,7 @@ import emission.storage.decorations.stats_queries as esds
 import emission.core.wrapper.user as ecwu
 import emission.analysis.result.user_stat as eaurs
 
-def run_intake_pipeline(process_number, uuid_list, skip_if_no_new_data=False):
+def run_intake_pipeline(process_number, uuid_list):
     """
     Run the intake pipeline with the specified process number and uuid list.
     Note that the process_number is only really used to customize the log file name
@@ -75,13 +75,32 @@ def run_intake_pipeline(process_number, uuid_list, skip_if_no_new_data=False):
             continue
 
         try:
-            run_intake_pipeline_for_user(uuid, skip_if_no_new_data)
+            run_intake_pipeline_for_user(uuid)
         except Exception as e:
             esds.store_pipeline_error(uuid, "WHOLE_PIPELINE", time.time(), None)
             logging.exception("Found error %s while processing pipeline "
                               "for user %s, skipping" % (e, uuid))
 
-def run_intake_pipeline_for_user(uuid, skip_if_no_new_data):
+def run_intake_pipeline_for_user(uuid):
+        user_profile = edb.get_profile_db().find_one({"user_id": uuid})
+        # Before this, we used to use a check of "have I moved new entries to long-term"
+        # But that fails if a pipeline has been stuck for a long time, and the user is dormant
+        # Since we added profile-level metrics to display in the admin
+        # dashboard, we can now use those for a more principled check. But in
+        # trip segmentation, we elide the last few location points since there
+        # is a delay of 5-10 minutes while detecting trip end.
+        # - if the user is dormant, we will miss any trips in the last 10 mins, which is NBD
+        # - if the user is not dormant, we will handle the locations as part of the next run
+        last_loc_ts = arrow.get(user_profile.get('last_location_ts', 0))
+        last_proc_time = user_profile.get('pipeline_range', {}).get('end_ts', None)
+        last_proc_ts = arrow.get(last_proc_time) if last_proc_time is not None else arrow.get(0)
+        fmt_string = f"For {uuid=}, last location entry is at {last_loc_ts}({last_loc_ts.timestamp()}), pipeline has run until {last_proc_ts}({last_proc_ts.timestamp()}), difference = {last_loc_ts - last_proc_ts}({(last_loc_ts.timestamp() - last_proc_ts.timestamp())})"
+        if  (last_loc_ts.timestamp() - last_proc_ts.timestamp()) <= 10 * 60: # 10 minutes
+            print(f"{fmt_string}, skipping")
+            return
+        else:
+            logging.info(f"{fmt_string}, continuing")
+
         uh = euah.UserCacheHandler.getUserCacheHandler(uuid)
 
         with ect.Timer() as uct:
@@ -91,13 +110,6 @@ def run_intake_pipeline_for_user(uuid, skip_if_no_new_data):
 
         esds.store_pipeline_time(uuid, ecwp.PipelineStages.USERCACHE.name,
                                  time.time(), uct.elapsed)
-
-        if skip_if_no_new_data and new_entry_count == 0:
-            print("No new entries, and skip_if_no_new_data = %s, skipping the rest of the pipeline" % skip_if_no_new_data)
-            return
-        else:
-            print("New entry count == %s and skip_if_no_new_data = %s, continuing" %
-                (new_entry_count, skip_if_no_new_data))
 
         with ect.Timer() as uit:
             logging.info("*" * 10 + "UUID %s: updating incoming user inputs" % uuid + "*" * 10)

--- a/emission/pipeline/scheduler.py
+++ b/emission/pipeline/scheduler.py
@@ -60,7 +60,7 @@ def get_split_uuid_lists(n_splits):
     logging.debug("Split values are %s" % ret_splits)
     return ret_splits
 
-def dispatch(split_lists, skip_if_no_new_data, target_fn=None):
+def dispatch(split_lists, target_fn=None):
     ctx = mp.get_context('spawn')
     process_list = []
     for i, uuid_list in enumerate(split_lists):
@@ -68,7 +68,7 @@ def dispatch(split_lists, skip_if_no_new_data, target_fn=None):
         pid = i
         if target_fn is None:
             target_fn = epi.run_intake_pipeline
-        p = ctx.Process(target=target_fn, args=(pid, uuid_list, skip_if_no_new_data))
+        p = ctx.Process(target=target_fn, args=(pid, uuid_list))
         logging.info("Created process %s to process %s list of size %s" %
                      (p, i, len(uuid_list)))
         p.start()

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -134,6 +134,8 @@ def createAndFillUUID(testObj):
     else:
         logging.info("No reg email found, not registering email")
         testObj.testUUID = uuid.uuid4()
+    # ensure that there is unprocessed data so that the pipeline will actually be run
+    edb.get_profile_db().update_one({"user_id": testObj.testUUID}, {"$set": {"last_location_ts": 3650, "pipeline_range": {"end_ts": None}}}, upsert=True)
 
 def setupRealExample(testObj, dump_file):
     logging.info("Before loading from %s, timeseries db size = %s" %

--- a/emission/tests/netTests/TestPipeline.py
+++ b/emission/tests/netTests/TestPipeline.py
@@ -37,7 +37,7 @@ class TestPipeline(unittest.TestCase):
 
     def testAnalysisResults(self):
         self.assertEqual(pipeline.get_range(self.testUUID), (None, None))
-        epi.run_intake_pipeline_for_user(self.testUUID, skip_if_no_new_data = False)
+        epi.run_intake_pipeline_for_user(self.testUUID)
         pr = pipeline.get_range(self.testUUID)
         self.assertAlmostEqual(pr[0], 1440688739.672)
         self.assertAlmostEqual(pr[1], 1440729142.709)

--- a/emission/tests/storageTests/TestSectionQueries.py
+++ b/emission/tests/storageTests/TestSectionQueries.py
@@ -79,8 +79,8 @@ class TestSectionQueries(unittest.TestCase):
     def testCleaned2InferredSectionList(self):
 
         # Running the pipeline for the two user datasets
-        epi.run_intake_pipeline_for_user(self.testUUID1, skip_if_no_new_data = False)
-        epi.run_intake_pipeline_for_user(self.testUUID2, skip_if_no_new_data = False)
+        epi.run_intake_pipeline_for_user(self.testUUID1)
+        epi.run_intake_pipeline_for_user(self.testUUID2)
 
         # Fetching the timeseries entries containing both raw data and analysis data after running intake pipeline
         ts_agg = esta.TimeSeries.get_aggregate_time_series()


### PR DESCRIPTION
Before this, we used to skip the pipeline run in production settings if there was no new data. But if the pipeline is unstable, we can have people whose pipeline stopped running, and then they uninstalled the app. When we reset the pipeline, it will never re-run because there is no new data, potentially leading to a lot of unprocessed data sitting around.

Now that we store additional metrics in the profile, we can use that for a more principled check that will work in both production and dev settings.

The check is simple:
- if there is unprocessed data, run the pipeline, otherwise skip
- the check for unprocessed data is "do we have any location points beyond the end of the pipeline"?

Note that, since there is a little bit of fuzz in trip end detection, the check is also fuzzy. For example, if I stop moving at 3:00pm, the app will continue collecting data until 3:10 so that it can see that I have stopped moving; otherwise, it will stop at every stoplight, which is not great. But then if we end the trip at 3:00pm (or 3:05), it will look like the data from 3:05 to 3:10 is unprocessed, which will cause us to re-run the pipeline and spin our wheels.

The fuzz allows us to fix this:
- if the user is dormant, we will miss any trips in the last 10 mins, which is NBD
- if the user is not dormant, we will handle the locations as part of the next run

Testing done:
- Ran against a local dev server copy with a mixture of situations

```
For uuid=UUID('...'), last location entry is at 2025-04-03T03:42:00.507721+00:00(1743651720.507721), pipeline has run until 2025-04-03T03:42:00.507721+00:00(1743651720.507721), difference = 0:00:00, skipping
For uuid=UUID('...'), last location entry is at 2025-03-19T21:02:02.588467+00:00(1742418122.588467), pipeline has run until 2025-03-19T21:02:02.588467+00:00(1742418122.588467), difference = 0:00:00, skipping
2025-04-20 21:38:42,192:INFO:140737476424192:For uuid=UUID('...'), last location entry is at 2025-04-03T22:22:59.341000+00:00(1743718979.341), pipeline has run until 2025-04-01T18:16:29.187000+00:00(1743531389.187), difference = 2 days, 4:06:30.154000, continuing
```