### PR TITLE
∦ Tighten the mechanism to have only one running copy of the pipeline

### DIFF
--- a/emission/tests/analysisTests/intakeTests/TestPipelineCornerCases.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineCornerCases.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock, patch
 import logging
 import uuid
 import time
@@ -154,6 +155,97 @@ class TestPipelineCornerCases(unittest.TestCase):
             list(map(get_last_processed, curr_user_states_after_test_run)))
         self.assertNotEqual(list(map(get_last_run, curr_user_states_after_run)),
             list(map(get_last_run, curr_user_states_after_test_run)))
+ 
+
+    @patch("emission.pipeline.intake_stage.edb.get_profile_db")
+    @patch("emission.pipeline.intake_stage.edb.get_pipeline_state_db")
+    @patch("emission.pipeline.intake_stage.euah.UserCacheHandler.getUserCacheHandler")
+    @patch("emission.pipeline.intake_stage.eaum.match_incoming_user_inputs")
+    def testRunIfNotInProgressUser(self, mock_match_inputs, mock_get_user_cache, mock_get_pipeline_state_db, mock_get_profile_db):
+        # Mocking user profile to simulate an active user
+        mock_get_profile_db.return_value.find_one.return_value = {
+            "user_id": "test_uuid",
+            "last_location_ts": 3600,
+            "pipeline_range": {"end_ts": None}
+        }
+
+        # Mocking pipeline state to simulate no in-progress stages
+        mock_get_pipeline_state_db.return_value.count_documents.return_value = 0
+
+        # Mocking UserCacheHandler
+        mock_user_cache_handler = MagicMock()
+        mock_get_user_cache.return_value = mock_user_cache_handler
+
+        # Run the function
+        epi.run_intake_pipeline_for_user("test_uuid")
+
+        mock_match_inputs.assert_called()
+        mock_user_cache_handler.moveToLongTerm.assert_called()
+
+    @patch("emission.pipeline.intake_stage.edb.get_profile_db")
+    @patch("emission.pipeline.intake_stage.edb.get_pipeline_state_db")
+    @patch("emission.pipeline.intake_stage.euah.UserCacheHandler.getUserCacheHandler")
+    @patch("emission.pipeline.intake_stage.eaum.match_incoming_user_inputs")
+    def testReturnIfInProgressuser(self, mock_match_inputs, mock_get_user_cache, mock_get_pipeline_state_db, mock_get_profile_db):
+        # Mock a non-dormant user so we will get to the next check
+        mock_get_profile_db.return_value.find_one.return_value = {
+            "user_id": "test_uuid",
+            "last_location_ts": 3600,
+            "pipeline_range": {"end_ts": None}
+        }
+
+        # Mocking pipeline state to simulate in-progress stages
+        mock_get_pipeline_state_db.return_value.count_documents.return_value = 1
+
+        mock_user_cache_handler = MagicMock()
+        mock_get_user_cache.return_value = mock_user_cache_handler
+
+        epi.run_intake_pipeline_for_user("test_uuid")
+
+        # Assert that the pipeline skipped processing for in-progress stages
+        mock_match_inputs.assert_not_called()
+        mock_user_cache_handler.moveToLongTerm.assert_not_called()
+
+    # Test without mocks
+    def testRunInParallel(self):
+        all_pipeline_states = edb.get_pipeline_state_db().find()
+
+        initial_last_runs = \
+            [ps["last_ts_run"] for ps in edb.get_pipeline_state_db().find({"user_id": self.testUUID})]
+        print(initial_last_runs)
+
+        print("-" * 10, "Running test pipeline on real data, expecting states to be set", "-" * 10)
+        etc.setupRealExample(self, "emission/tests/data/real_examples/shankari_2016-07-25")
+        # we force run the pipeline by setting profile back so we will run the pipeline this time
+        edb.get_profile_db().update_one({"user_id": self.testUUID},
+                                        {"$set": {"pipeline_range.end_ts": None}})
+        epi.run_intake_pipeline_for_user(self.testUUID)
+        after_first_run = edb.get_profile_db().find_one({"user_id": self.testUUID})
+        # 1469493031.0 is the number I got when running the test for the first time
+        self.assertEqual(after_first_run.get("pipeline_range", {}).get("end_ts", None), 1469493031.0)
+
+        first_round_last_runs = \
+            [ps["last_ts_run"] for ps in edb.get_pipeline_state_db().find({"user_id": self.testUUID})]
+        print(first_round_last_runs)
+
+        # force the user to be active again
+        edb.get_profile_db().update_one({"user_id": self.testUUID},
+                                        {"$set": {"pipeline_range.end_ts": None}})
+
+        # force set section segmentation's curr_run_ts
+        edb.get_pipeline_state_db().update_one(
+            {"user_id": self.testUUID,
+            "pipeline_stage": ewps.PipelineStages.SECTION_SEGMENTATION.value},
+            {"$set": {"curr_run_ts": 3600}}
+        )
+
+        epi.run_intake_pipeline_for_user(self.testUUID)
+
+        new_last_runs = \
+            [ps["last_ts_run"] for ps in edb.get_pipeline_state_db().find({"user_id": self.testUUID})]
+
+        # Since we should have bailed out when there was already an active run
+        self.assertEqual(first_round_last_runs, new_last_runs)
 
 if __name__ == '__main__':
     etc.configLogging()


### PR DESCRIPTION
Our pipeline cannot have two copies running in parallel at the same time; we will end up with two copies or none. The expectation is that we have a logically linear timestream and jumping in and out of it intermittently will lead to incorrect results.

We do this by using the `curr_run_ts` as a semaphore. If the `curr_run_ts` of a particular user was set, then other pipelines running in parallel would detect it and would not process that stage.

However, when running in production, if we launched services every hour, but the pipeline took more than an hour to run, we would end up with two pipelines running in parallel, but one much futher along than the other.

Theoretically, this is OK. The later pipeline will process the initial states properly before failing at the conflict. But then when the stage with the conflict completes, it will reset the `curr_run_ts`.

Concretely, let us assume that the first run (run1) of the pipeline started at 8am and it took 3 hours to complete, so it ended at 11am. It was stuck for a long time at the bottleneck on S5

In the meantime, a new run (run2) started at 9am.

So some steps may be:

```
-  9:10: run1 - > S5, run2 - > S1
-  9:20: run1 - > S5, run2 - > S2
-  9:30: run1 - > S5, run2 - > S3
-  9:40: run1 - > S5, run2 - > S4
-  9:50: run1 - > S5, run2 - > S5 <- - - -  CRASH - - - - - - >
- 10:50: run1 - > S5, run2 - > S6 <- - - -  run2 has leapfrogged S5, but that just means that subsequent steps will not update their `last_processed_ts`   - - - - - - >
- 10:50: run1 - > S6, run2 - > S6 <- - - - `curr_run_ts` of S5 is reset by run1 ---->
- 11:00  run1 - > S7
- 11:10  run3 - > S1 (but after the work that run2 did)
```

So it should work, but:
- we will use up 2x the resources and
- if run1 is killed and we have to reset the pipeline, then all the work that run2 did will be wasted

Let's keep it simple, and not even start `run2` when `run1` is still in progress, since it is likely to fail anyway. This is also consistent with the original vision of the `curr_run_ts` as a semaphore, so it is likely to be more robust.

If we ever build in additional support for manipulating the pipeline at the stage level - for example, by changing the reset to work on a per-stage basis, or add additional resources to the cluster, we can revisit this decision

Testing done:

Tests (including the newly added ones) in `TestPipelineCornerCases` pass

```

----------------------------------------------------------------------
Ran 6 tests in 1.940s

OK
```

Running this against a local dump with a few invalid states . Don't see any failures because of the `curr_run_ts.

```
Pipeline for e0e0c5bb-5bfb-4d8f-88b6-2fd602aef234 has in_progress_stages=1, skipping
Pipeline for 220f4503-631a-4d68-a937-431fa36472b5 has in_progress_stages=2, skipping
2025-04-20T22:28:56.049586-07:00**********UUID e9abc855-abfd-413b-877b-6018ba0701ca: moving to long term**********
2025-04-20T22:28:56.111654-07:00**********UUID ed2a2933-95ea-49ea-8b39-29f1ec9758da: segmenting into sections**********
2025-04-20T22:28:56.193898-07:00**********UUID f6adb9f3-4782-4d01-80e6-8722fb47eb93: cleaning and resampling timeline**********
2025-04-20T22:28:56.368976-07:00**********UUID e9abc855-abfd-413b-877b-6018ba0701ca: updating incoming user inputs**********
```