### PR TITLE
🔧 use confirmed trips for agg metrics

### DIFF
--- a/emission/net/api/metrics.py
+++ b/emission/net/api/metrics.py
@@ -28,7 +28,7 @@ def summarize_by_local_date(user_id, start_ld, end_ld, freq_name, metric_list, i
 
 def summarize_by_yyyy_mm_dd(user_id, start_ymd, end_ymd, freq, metric_list, include_agg, app_config): 
     time_query = estf.FmtTimeQuery("data.start_fmt_time", start_ymd, end_ymd)
-    trips = esda.get_entries(esda.COMPOSITE_TRIP_KEY, None, time_query)
+    trips = esda.get_entries(esda.CONFIRMED_TRIP_KEY, None, time_query)
     return asyncio.run(emcms.generate_summaries(metric_list, trips, app_config))
 
 def _call_group_fn(group_fn, user_id, start_time, end_time, freq, metric_list, include_aggregate):


### PR DESCRIPTION
Step 1 of https://github.com/e-mission/e-mission-docs/issues/1126 is to simply use confirmed trips instead of composite trips to compute metrics. Confirmed trips are smaller than composite trips, so this will use less memory. e-mission-common is already set up to handle both types the same way.

Testing done:
https://github.com/e-mission/e-mission-docs/issues/1126#issuecomment-2828147799