### PR TITLE
Rule Engine Changes [RULE ENGINE FILE ONLY]

### DIFF
--- a/emission/analysis/classification/inference/mode/rule_engine.py
+++ b/emission/analysis/classification/inference/mode/rule_engine.py
@@ -68,10 +68,16 @@ class RuleEngineModeInferencePipeline:
                 (section_entry.get_id(),
                  section_entry.data.start_fmt_time, section_entry.data.end_fmt_time) +
                 '~' * 10)
-            if section_entry.data.sensed_mode == ecwma.MotionTypes.AIR_OR_HSR:
-                predictedProb.append({'AIR_OR_HSR': 1})
-            else:
-                predictedProb.append(get_prediction(i, section_entry))
+            try:
+                if section_entry.data.sensed_mode == ecwma.MotionTypes.AIR_OR_HSR:
+                    predictedProb.append({'AIR_OR_HSR': 1})
+                else:
+                    predictedProb.append(get_prediction(i, section_entry))
+            except Exception as e:
+                logging.error(f"Found {e} while inferring sensed modes for {section_entry.get_id()} and {section_entry.user_id}, starting at {section_entry.data.start_fmt_time}")
+                logging.error("Creating section with UNKNOWN mode instead of skipping")
+                logging.exception(e)
+                predictedProb.append({'UNKNOWN': 1})
 
         return predictedProb
 


### PR DESCRIPTION
# Create UNKNOWN sections instead of skipping on mode inference errors

## Implementation details
- Added try/except block around mode inference code
- When exceptions occur, now adds {'UNKNOWN': 1} to predictedProb instead of skipping

