### PR TITLE
📊 use Stage_agg_metrics DB for preloaded aggregate metrics

### DIFF
--- a/emission/analysis/configs/dynamic_config.py
+++ b/emission/analysis/configs/dynamic_config.py
@@ -6,6 +6,7 @@ import json
 import requests
 
 STUDY_CONFIG = os.getenv('STUDY_CONFIG', "stage-program")
+DOWNLOAD_URL = "https://raw.githubusercontent.com/%s/main/configs/%s.nrel-op.json"
 
 dynamic_config = None
 def get_dynamic_config():

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -327,6 +327,12 @@ def get_fake_sections_db():
     FakeSections = _get_current_db().Stage_fake_sections
     return FakeSections
 
+def get_agg_metrics_db():
+    AggMetrics = _get_current_db().Stage_agg_metrics
+    AggMetrics.create_index([("date", pymongo.ASCENDING)])
+    AggMetrics.create_index([("metric", pymongo.ASCENDING)])
+    return AggMetrics
+
 # Static utility method to save entries to a mongodb collection.  Single
 # drop-in replacement for collection.save() now that it is deprecated in 
 # pymongo 3.0. 

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -346,7 +346,7 @@ def getMetrics(time_type):
     logging.debug("getMetrics with time_type %s and request %s" %
                   (time_type, request.json))
     if time_type != 'yyyy_mm_dd':
-        abort(404, "Metrics calls only supported for yyyy_mm_dd time type")
+        abort(404, "Please upgrade to continue using the app dashboard")
     
     user_uuid = get_user_or_aggregate_auth(request)
     start_ymd = request.json['start_time']

--- a/emission/net/api/metrics.py
+++ b/emission/net/api/metrics.py
@@ -9,13 +9,31 @@ from builtins import *
 import logging
 import asyncio
 
+import emission.core.get_database as edb
 import emission.analysis.result.metrics.time_grouping as earmt
 import emission.analysis.result.metrics.simple_metrics as earms
 import emission.storage.decorations.analysis_timeseries_queries as esda
 import emission.storage.decorations.local_date_queries as esdl
 import emission.storage.timeseries.fmt_time_query as estf
 
-import emcommon.metrics.metrics_summaries as emcms
+
+def get_agg_metrics_from_db(start_ymd, end_ymd):
+    logging.debug("get_agg_metrics(%s, %s)" % (start_ymd, end_ymd))
+    result = {}
+    query = estf.FmtTimeQuery("date", start_ymd, end_ymd).get_query()
+    metric_cursor = edb.get_agg_metrics_db().find(query)
+    metric_docs = list(metric_cursor)
+    logging.debug("AggMetrics DB had %d entries for %s" %
+                  (len(metric_docs), query))
+    for entry in metric_docs:
+        metric_name = entry["metric"]
+        if metric_name not in result:
+            result[metric_name] = []
+        # phone expects data at the top level, not nested under "data"
+        for k, v in entry.get("data", {}).items():
+            entry[k] = v
+        result[metric_name].append(entry)
+    return result
 
 def summarize_by_timestamp(user_id, start_ts, end_ts, freq, metric_list, include_aggregate, app_config=None):
     return _call_group_fn(earmt.group_by_timestamp, user_id, start_ts, end_ts,
@@ -25,11 +43,6 @@ def summarize_by_local_date(user_id, start_ld, end_ld, freq_name, metric_list, i
     local_freq = earmt.LocalFreq[freq_name]
     return _call_group_fn(earmt.group_by_local_date, user_id, start_ld, end_ld,
                           local_freq, metric_list, include_aggregate)
-
-def summarize_by_yyyy_mm_dd(user_id, start_ymd, end_ymd, freq, metric_list, include_agg, app_config): 
-    time_query = estf.FmtTimeQuery("data.start_fmt_time", start_ymd, end_ymd)
-    trips = esda.get_entries(esda.COMPOSITE_TRIP_KEY, None, time_query)
-    return asyncio.run(emcms.generate_summaries(metric_list, trips, app_config))
 
 def _call_group_fn(group_fn, user_id, start_time, end_time, freq, metric_list, include_aggregate):
     summary_fn_list = [earms.get_summary_fn(metric_name)


### PR DESCRIPTION
https://github.com/e-mission/e-mission-docs/issues/1126

define indices for Stage_agg_metrics collection, which is where the aggregate metrics will be stored when they are computed by the public dashboard

new function get_agg_metrics_from_db to read precomputed metrics from Stage_agg_metrics

In cfc_webapp.py:
- remove the 503 abort
- switch to using metrics.get_agg_metrics_from_db remove a bunch of old code that was left to support old versions of the phone UI, which are obsolete now