### PR TITLE
🔧 Compare with the TRIP_SEGMENTATION stage instead of CLEAN_RESAMPLE

### DIFF
--- a/emission/pipeline/intake_stage.py
+++ b/emission/pipeline/intake_stage.py
@@ -102,13 +102,13 @@ def run_intake_pipeline_for_user(uuid):
         else:
             logging.info(f"{fmt_dormant_user_check}, continuing")
 
-        clean_resample_stage = edb.get_pipeline_state_db().find_one(
-            {"user_id": uuid, "pipeline_stage": ecwp.PipelineStages.CLEAN_RESAMPLING.value})
-        clean_resample_stage = {} if clean_resample_stage is None else clean_resample_stage
-        last_clean_resample_processed_ts = arrow.get(clean_resample_stage.get("last_processed_ts", 0))
-        clean_resample_ts_diff = last_loc_ts.timestamp() - last_clean_resample_processed_ts.timestamp()
-        fmt_squished_trips_at_end_check = f"For {uuid=}, last location entry is at {last_loc_ts}({last_loc_ts.timestamp()}), raw trips have been generated until {last_clean_resample_processed_ts}({last_clean_resample_processed_ts.timestamp()}), difference = {last_loc_ts - last_clean_resample_processed_ts}({(ts_diff)})"
-        if clean_resample_ts_diff <= 6 * 60 * 60:
+        trip_segment_stage = edb.get_pipeline_state_db().find_one(
+            {"user_id": uuid, "pipeline_stage": ecwp.PipelineStages.TRIP_SEGMENTATION.value})
+        trip_segment_stage = {} if trip_segment_stage is None else trip_segment_stage
+        last_trip_segment_processed_ts = arrow.get(trip_segment_stage.get("last_processed_ts", 0))
+        trip_segment_ts_diff = last_loc_ts.timestamp() - last_trip_segment_processed_ts.timestamp()
+        fmt_squished_trips_at_end_check = f"For {uuid=}, last location entry is at {last_loc_ts}({last_loc_ts.timestamp()}), raw trips have been generated until {last_trip_segment_processed_ts}({last_trip_segment_processed_ts.timestamp()}), difference = {last_loc_ts - last_trip_segment_processed_ts}({(ts_diff)})"
+        if trip_segment_ts_diff <= 6 * 60 * 60:
             print(f"{fmt_squished_trips_at_end_check}, skipping")
             return
         else:

--- a/emission/tests/analysisTests/intakeTests/TestPipelineCornerCases.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineCornerCases.py
@@ -237,7 +237,7 @@ class TestPipelineCornerCases(unittest.TestCase):
         edb.get_profile_db().update_one({"user_id": self.testUUID},
                                         {"$set": {"pipeline_range.end_ts": None}})
         edb.get_pipeline_state_db().update_one({"user_id": self.testUUID,
-                                                "pipeline_stage": ewps.PipelineStages.CLEAN_RESAMPLING.value},
+                                                "pipeline_stage": ewps.PipelineStages.TRIP_SEGMENTATION.value},
                                                {"$set": {"last_processed_ts": 0}})
 
         # force set section segmentation's curr_run_ts


### PR DESCRIPTION
In
https://github.com/e-mission/e-mission-server/commit/f2d0b9337b3400395ff00aeaf0787cb73429428d we added a check to handle the mismatch between cleaned and raw trips, which was causing a spurious detection of "fresh" data, which caused us to run the pipeline for a NOP
https://github.com/e-mission/e-mission-docs/issues/1105#issuecomment-2849399054

While testing that, we realized that it was actually possible for there to be a mismatch between TRIP and SECTION segmentation as well. This is because we got < 10 points ~ 5 days after the end of the previous trip. So we didn't have time to process them into a new trip and they were left dangling. To fix this, we use the `TRIP_SEGMENTATION` stage instead of `CLEAN_RESAMPLE` as the second level check.

Note that this means that if there are code fixes to address a problem, we cannot guarantee dormant users, who are potentially blocked running, will get the fix without resetting the pipeline.

But:
1. This is the same behavior that we used to have before this restructuring
2. Our goal was to handle the case in which our backlog was too long to process in a single batch (we were processing 250k points at a time), which this will still handle.