### PR TITLE
👔 Reset the cached pipeline state in the profile as well

### DIFF
--- a/bin/locust/webapp.py
+++ b/bin/locust/webapp.py
@@ -73,7 +73,8 @@ class PhoneAppUser(HttpUser):
 
     @task(2)
     def usercache_get(self):
-       self.client.post("/usercache/get", json={"user": self.opcode})
+       response = self.client.post("/usercache/get", json={"user": self.opcode})
+       print(f"Got {response.text} in response to the call")
 
     @task(2)
     def find_entries_timestamp(self):

--- a/emission/analysis/userinput/matcher.py
+++ b/emission/analysis/userinput/matcher.py
@@ -52,7 +52,7 @@ def match_incoming_inputs(user_id, timerange):
                 assert False, "Found weird key {ui.metadata.key} that was not in the search list"
             update_confirmed_and_composite(ts, confirmed_obj)
         else:
-            logging.warn("No match found for single user input %s, moving forward anyway" % ui)
+            logging.info("No match found for single user input %s, moving forward anyway" % ui)
         lastInputProcessed = ui
 
     return lastInputProcessed

--- a/emission/pipeline/reset.py
+++ b/emission/pipeline/reset.py
@@ -145,7 +145,7 @@ def del_objects_after(user_id, reset_ts, is_dry_run):
         logging.info("this is a dry-run, returning from del_objects_after without modifying anything")
     else:
         result = edb.get_analysis_timeseries_db().delete_many(del_query)
-        logging.info("this is not a dry-run, result of deleting analysis entries is %s" % result)
+        logging.info("this is not a dry-run, result of deleting analysis entries is %s" % result.raw_result)
 
 def reset_last_place(last_place, is_dry_run):
     if is_dry_run:
@@ -174,7 +174,7 @@ def reset_last_place(last_place, is_dry_run):
     logging.debug("reset_query = %s" % reset_query)
 
     result = edb.get_analysis_timeseries_db().update_one(match_query, reset_query)
-    logging.debug("this is not a dry run, result of update in reset_last_place = %s" % result)
+    logging.debug("this is not a dry run, result of update in reset_last_place = %s" % result.raw_result)
 
     logging.debug("after update, entry is %s" %
                   edb.get_analysis_timeseries_db().find_one(match_query))
@@ -232,15 +232,15 @@ def reset_pipeline_state(user_id, reset_ts, is_dry_run):
         result = edb.get_pipeline_state_db().update_many(
                     trip_seg_reset_pipeline_query, trip_seg_update_pipeline_query,
                     upsert=False)
-        logging.debug("this is not a dry run, result of updating trip_segmentation stage in reset_pipeline_state = %s" % result)
+        logging.debug("this is not a dry run, result of updating trip_segmentation stage in reset_pipeline_state = %s" % result.raw_result)
 
         result = edb.get_pipeline_state_db().update_many(
                     reset_pipeline_query, update_pipeline_query,
                     upsert=False)
-        logging.debug("this is not a dry run, result of updating all other stages in reset_pipeline_state = %s" % result)
+        logging.debug("this is not a dry run, result of updating all other stages in reset_pipeline_state = %s" % result.raw_result)
 
         result = edb.get_profile_db().update_one({"user_id": user_id}, profile_update_query)
-        logging.debug("this is not a dry run, result of updating the profile in reset_pipeline_state = %s" % result)
+        logging.debug("this is not a dry run, result of updating the profile in reset_pipeline_state = %s" % result.raw_result)
 
 
 def reset_curr_run_state(user_id, is_dry_run):
@@ -253,7 +253,7 @@ def reset_curr_run_state(user_id, is_dry_run):
     else:
         result = edb.get_pipeline_state_db().update_many(
                     reset_curr_run_ts_query, reset_curr_run_ts_update)
-        logging.debug("this is not a dry run, result of removing any curr_run_ts entries = %s" % result)
+        logging.debug("this is not a dry run, result of removing any curr_run_ts entries = %s" % result.raw_result)
 # 
 # END: reset_user_to_ts
 # 
@@ -287,10 +287,11 @@ def _del_entries_for_query(del_query, is_dry_run):
         logging.info("this is a dry run, returning from reset_user_to-start without modifying anything")
     else: 
         result = edb.get_analysis_timeseries_db().delete_many(del_query)
-        logging.info("this is not a dry run, result of removing analysis objects = %s" % result)
+        logging.info("this is not a dry run, result of removing analysis objects = %s" % result.raw_result)
         result = edb.get_pipeline_state_db().delete_many(del_query)
-        logging.info("this is not a dry run, result of removing pipeline states = %s" % result)
+        logging.info("this is not a dry run, result of removing pipeline states = %s" % result.raw_result)
         result = edb.get_profile_db().update_one(del_query,  reset_profile_ts_update)
+        logging.info("this is not a dry run, result of resetting profile = %s" % result.raw_result)
 
 # 
 # END: reset_to_start

--- a/setup/environment36.yml
+++ b/setup/environment36.yml
@@ -19,7 +19,7 @@ dependencies:
 - scipy=1.10.0
 - utm=0.7.0
 - pip:
-  - git+https://github.com/JGreenlee/e-mission-common@0.6.4
+  - git+https://github.com/e-mission/e-mission-common@0.6.4
   - pyfcm==2.0.1
   - pygeocoder==1.2.5
   - pymongo==4.3.3


### PR DESCRIPTION
Before this change, the pipeline reset script would change the `get_pipeline_state_db()` but not the cached pipeline start and end in the profile.
    
Since we now use the profile to decide whether to run the pipeline, this led to issues where the pipeline for a user would not re-run even after the pipeline was reset.
https://github.com/e-mission/e-mission-docs/issues/1105#issuecomment-2852181010
    
I wonder if we should use only the pipeline state to decide whether or not to run the pipeline, instead of the profile. It seems like restructuring to use a single source of truth would be good.
    
Testing done:
Ran it to reset our test user back to `2024-07-30`; verified that the value in the profile was reset
Verified that the pipeline was not skipped on the run after the reset