### PR TITLE
🐛 use munge_agg_metrics in get_agg_metrics_from_db

### DIFF
--- a/setup/environment36.yml
+++ b/setup/environment36.yml
@@ -18,7 +18,7 @@ dependencies:
 - scipy=1.10.0
 - utm=0.7.0
 - pip:
-  - git+https://github.com/JGreenlee/e-mission-common@0.6.4
+  - git+https://github.com/e-mission/e-mission-common@0.6.5
   - pyfcm==2.0.1
   - pygeocoder==1.2.5
   - pymongo==4.6.3


### PR DESCRIPTION
With e-mission-common 0.6.5, we are creating and storing metrics summaries in a different format. https://github.com/e-mission/e-mission-docs/issues/1126#issuecomment-2849606586 We need to munge so that the phone receives the original format

    # Backwards compat to get summaries into the old format that the phone expects in May 2025
    # After phone changes and waiting a few months, we can remove this