### PR TITLE
Hack to not return metrics for the in-app dashboard to avoid the Hawthorne effect

### DIFF
--- a/emission/net/api/bottle.py
+++ b/emission/net/api/bottle.py
@@ -14,7 +14,6 @@ License: MIT (see LICENSE for details)
 """
 
 import sys
-import logging
 
 __author__ = 'Marcel Hellkamp'
 __version__ = '0.13-dev'
@@ -471,7 +470,6 @@ class Router(object):
 
     def match(self, environ):
         """ Return a (target, url_args) tuple or raise HTTPError(400/404/405). """
-        logging.debug(f"403_CHECK: bottle just tried to match {environ['REQUEST_METHOD']} {environ['PATH_INFO']}")
         verb = environ['REQUEST_METHOD'].upper()
         path = environ['PATH_INFO'] or '/'
 
@@ -979,7 +977,6 @@ class Bottle(object):
         return tob(template(ERROR_PAGE_TEMPLATE, e=res, template_settings=dict(name='__ERROR_PAGE_TEMPLATE')))
 
     def _handle(self, environ):
-        logging.debug(f"403_CHECK: bottle just received {environ['REQUEST_METHOD']} {environ['PATH_INFO']}")
         path = environ['bottle.raw_path'] = environ['PATH_INFO']
         if py3k:
             environ['PATH_INFO'] = path.encode('latin1').decode('utf8', 'ignore')
@@ -989,26 +986,17 @@ class Bottle(object):
         response.bind()
 
         try:
-            logging.debug(f"403_CHECK: parsed body {request.json}")
-        except Exception as e:
-            print_exc()
-
-        try:
             while True: # Remove in 0.14 together with RouteReset
                 out = None
                 try:
-                    logging.debug(f"403_CHECK: bottle just called hook with {environ['REQUEST_METHOD']} {environ['PATH_INFO']}")
                     self.trigger_hook('before_request')
                     route, args = self.router.match(environ)
                     environ['route.handle'] = route
                     environ['bottle.route'] = route
                     environ['route.url_args'] = args
-                    logging.debug(f"403_CHECK: bottle just called route with {args}")
                     out = route.call(**args)
                     break
                 except HTTPResponse as E:
-                    logging.error(f"403_CHECK: exception at first level {E}")
-                    print_exc()
                     out = E
                     break
                 except RouteReset:
@@ -1018,24 +1006,16 @@ class Bottle(object):
                     route.reset()
                     continue
                 finally:
-                    if out and not isinstance(out, HTTPError) and len(out) > 40:
-                        logging.debug(f"403_CHECK: after call, truncated output {out[:20]}...{out[-20:]}")
-                    else:
-                        logging.debug(f"403_CHECK: after call, full output is {out}")
                     if isinstance(out, HTTPResponse):
                         out.apply(response)
                     try:
                         self.trigger_hook('after_request')
                     except HTTPResponse as E:
-                        logging.error(f"403_CHECK: exception while handling post-hook {E}")
-                        print_exc()
                         out = E
                         out.apply(response)
         except (KeyboardInterrupt, SystemExit, MemoryError):
-            print_exc()
             raise
         except Exception as E:
-            print_exc()
             if not self.catchall: raise
             stacktrace = format_exc()
             environ['wsgi.errors'].write(stacktrace)

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -432,8 +432,7 @@ def before_request():
   request.params.start_ts = time.time()
   request.params.timer = ect.Timer()
   request.params.timer.__enter__()
-  logging.debug("START %s %s %s" % (request.method, request.path,
-        request.json.get('user', None) if request.json else None))
+  logging.debug("START %s %s" % (request.method, request.path))
 
 @app.hook('after_request')
 def after_request():

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -345,6 +345,14 @@ def deleteUserCustomLabel():
 def getMetrics(time_type):
     logging.debug("getMetrics with time_type %s and request %s" %
                   (time_type, request.json))
+    # HACK HACK HACK
+    # Remove in 2026 after the uw-ebike data collection is complete
+    program_name = dynamic_config.get("url_abbreviation", None)
+    if program_name == "uw-ebike":
+        logging.info(f"Received metrics call for program {program_name} that doesn't want a dashboard, ignoring")
+        return
+    else:
+        logging.info(f"Received metrics call for program {program_name}, continuing")
     if time_type != 'yyyy_mm_dd':
         abort(404, "Please upgrade to continue using the app dashboard")
     

--- a/emission/net/api/wsgiserver2.py
+++ b/emission/net/api/wsgiserver2.py
@@ -590,7 +590,6 @@ class HTTPRequest(object):
 
     def parse_request(self):
         """Parse the next HTTP request start-line and message-headers."""
-        print(f"403_CHECK: wsgiserver started parsing request")
         self.rfile = SizeCheckWrapper(self.conn.rfile,
                                       self.server.max_request_header_size)
         try:
@@ -601,7 +600,6 @@ class HTTPRequest(object):
                 "allowed bytes.")
             return
         else:
-            print(f"403_CHECK: wsgiserver in else block with {success=}")
             if not success:
                 return
 
@@ -616,7 +614,6 @@ class HTTPRequest(object):
             if not success:
                 return
 
-        print(f"403_CHECK: wsgiserver ready to read request")
         self.ready = True
 
     def read_request_line(self):
@@ -628,7 +625,6 @@ class HTTPRequest(object):
         # (although your TCP stack might suffer for it: cf Apache's history
         # with FIN_WAIT_2).
         request_line = self.rfile.readline()
-        print(f"403_CHECK: wsgiserver read request line {request_line}")
 
         # Set started_request to True so communicate() knows to send 408
         # from here on out.
@@ -720,7 +716,6 @@ class HTTPRequest(object):
         """Read self.rfile into self.inheaders. Return success."""
 
         # then all the http headers
-        print(f"403_CHECK: wsgiserver reading headers {request_line}")
         try:
             read_headers(self.rfile, self.inheaders)
         except ValueError:
@@ -814,7 +809,6 @@ class HTTPRequest(object):
             segment       = *pchar *( ";" param )
             param         = *pchar
         """
-        print(f"403_CHECK: wsgiserver parsing {uri=}")
         if uri == ASTERISK:
             return None, None, uri
 
@@ -1927,7 +1921,6 @@ class HTTPServer(object):
         """Accept a new connection and put it on the Queue."""
         try:
             s, addr = self.socket.accept()
-            print(f"403_CHECK: wsgiserver accepted connection from socket")
             if self.stats['Enabled']:
                 self.stats['Accepts'] += 1
             if not self.ready:
@@ -1984,7 +1977,6 @@ class HTTPServer(object):
 
             conn.ssl_env = ssl_env
 
-            print(f"403_CHECK: wsgiserver queued new connection from {conn.remote_port=}")
             self.requests.put(conn)
         except socket.timeout:
             # The only reason for the timeout in start() is so we can

--- a/emission/net/auth/auth.py
+++ b/emission/net/auth/auth.py
@@ -63,7 +63,7 @@ def getSubgroupFromToken(token, config):
     if "subgroups" in config.get("opcode", {}):
       if tokenParts[2] not in config['opcode']['subgroups']:
         # subpart not in config list
-        raise ValueError(f"Invalid subgroup {tokenParts[2]} not in {config.opcode.subgroups}")
+        raise ValueError(f"Invalid subgroup {tokenParts[2]} not in {config['opcode']['subgroups']}")
       else:
         logging.debug('subgroup ' + tokenParts[2] + ' found in list ' + str(config['opcode']['subgroups']))
         return tokenParts[2];


### PR DESCRIPTION
Hawthorne effect: https://en.wikipedia.org/wiki/Hawthorne_effect
@rubinasingh and @JGreenlee for visibility

This can be removed after the principled fix to allow hiding the in-app dashboard tab, and/or replacing it with a different metrics related to response rates. Note that, for the fix to apply to the uw study, we will also need to handle automatic refresh of the dynamic config. I think we should do some user interviews and deployer/community interaction to design both of those features.

In any case, this _should_ be removed in 2026, after the uw-ebike data collection is complete.

Testing done:

Before this change:

```
    2025-06-07 19:59:00,292:DEBUG:140736765724224:START POST /result/metrics/yyyy_mm_dd
    2025-06-07 19:59:00,293:DEBUG:140736765724224:getMetrics with time_type yyyy_mm_dd and request {'user': '...', 'metric_list': {...}
    2025-06-07 19:59:00,293:DEBUG:140736765724224:User specific call, returning UUID
    2025-06-07 19:59:00,293:DEBUG:140736765724224:Old-style study, expecting token without a subgroup...
    2025-06-07 19:59:00,295:DEBUG:140736765724224:retUUID = {'subgroup': None, 'user_id': UUID('')}
    2025-06-07 19:59:00,295:DEBUG:140736765724224:get_agg_metrics(2025-05-31T19:59:00.286812+00:00, 2025-06-07T19:59:00.287253+00:00)
    2025-06-07 19:59:00,297:DEBUG:140736765724224:AggMetrics DB had 0 entries for {'date': {'$lte': '2025-06-07T19:59:00.287253+00:00Z', '$gte': '2025-05-31T19:59:00.286812+00:00'}}
    2025-06-07 19:59:00,298:DEBUG:140736765724224:getMetrics result = {}
    2025-06-07 19:59:00,298:DEBUG:140736765724224:update_last_call_timestamp called with: user_id=UUID('...'), call_path='/result/metrics/yyyy_mm_dd'
    2025-06-07 19:59:00,300:DEBUG:140736765724224:Updating user ... with fields {'last_call_ts': 1749326340.298866}
    2025-06-07 19:59:00,302:DEBUG:140736765724224:END POST /result/metrics/yyyy_mm_dd ...
```

After this change

```
    2025-06-07 20:21:58,141:DEBUG:140736641082944:START POST /result/metrics/yyyy_mm_dd
    2025-06-07 20:21:58,142:DEBUG:140736641082944:getMetrics with time_type yyyy_mm_dd and request {'user': '...', 'metric_list': {}
    2025-06-07 20:21:58,142:INFO:140736641082944:Received metrics call for program uw-ebike that doesn't want a dashboard, ignoring
    2025-06-07 20:21:58,142:DEBUG:140736641082944:update_last_call_timestamp called with: user_id='', call_path='/result/metrics/yyyy_mm_dd'
    2025-06-07 20:21:58,144:DEBUG:140736641082944:Updating user  with fields {'last_call_ts': 1749327718.142599}
    2025-06-07 20:21:58,145:DEBUG:140736641082944:User profile updated with data: {'last_call_ts': 1749327718.142599}
    2025-06-07 20:21:58,146:DEBUG:140736641082944:New profile: None
    2025-06-07 20:21:58,146:DEBUG:140736641082944:END POST /result/metrics/yyyy_mm_dd  0.0012326240539550781
```

- Also revert a change for additional logging of requests, added to help debug https://github.com/e-mission/e-mission-docs/issues/1127
- Also fix an error while logging the invalid subgroup error, found while testing this functionality against a dump from another DB