### PR TITLE
⚡️ Use dataframes instead of lists in the clean_and_resample stage

### DIFF
--- a/emission/tests/analysisTests/intakeTests/TestCleanAndResample.py
+++ b/emission/tests/analysisTests/intakeTests/TestCleanAndResample.py
@@ -55,10 +55,8 @@ class TestCleanAndResample(unittest.TestCase):
                                                    dummy_loc))
 
         tq = estt.TimeQuery("data.ts", TS_START - 10, TS_START + 10 + 10)
-        loc_entries = self.ts.find_entries(["background/filtered_location"], tq)
         loc_df = self.ts.get_data_df("background/filtered_location", tq)
-        filtered_loc_df = eaicc.remove_outliers(loc_entries, loc_df["_id"])
-        self.assertEqual(len(loc_entries), len(loc_df))
+        filtered_loc_df = eaicc.remove_outliers(loc_df, loc_df["_id"])
         self.assertEqual(len(filtered_loc_df), 0)
 
     def testRemoveAllOutliers(self):


### PR DESCRIPTION
While testing https://github.com/e-mission/e-mission-server/pull/1074, the CLEAN_AND_RESAMPLE stage took several hours, more than any other stage by an order of magnitude

On investigation, the slowdown appeared to be primarily due to these two locations

```
2025-07-07 14:55:45,462:DEBUG:8296488704:Getting filtered points for section ...
2025-07-07 14:55:45,462:DEBUG:8296488704:Saving entries into cleaned section Cleanedsection({'source': 'SmoothedHighConfidenceMotion', 'ble_sensed_mode': None, 'trip_id': ObjectId('686c4261c988febdea21d1d0')})
2025-07-07 14:55:51,062:DEBUG:8296488704:get_entry_at_ts query = {'user_id': UUID('...'), 'metadata.key': 'analysis/smoothing', 'data.section': ObjectId('686c41afc988febdea21b031')}
```

```
2025-07-07 18:25:19,631:DEBUG:8296488704:At index -1, loc is 67250ffb610916dddd01d1de
2025-07-07 18:25:21,024:DEBUG:8296488704:Raw place is 686c4186c988febdea21a176 and corresponding location is 67250ffb610916dddd01d1de
```

which correspond to code that iterates over the location list https://github.com/e-mission/e-mission-server/blob/d8a4fc2fe0c281516703bfdb21a2fb24c8e36a9e/emission/analysis/intake/cleaning/clean_and_resample.py#L359

```
    section_loc_entries = [l for l in loc_entries
                        if l.data.ts >= section.data.start_ts
                        and l.data.ts <= section.data.end_ts]
```

and

https://github.com/e-mission/e-mission-server/blob/d8a4fc2fe0c281516703bfdb21a2fb24c8e36a9e/emission/analysis/intake/cleaning/clean_and_resample.py#L713

```
                raw_place_enter_loc_entry = next(l for l in loc_entries
                                                 if l.data.ts == raw_place.data.enter_ts)
```

Further, we use the location as a dataframe almost all through the code; we convert the location entries to a dataframe almost immediately in `get_filtered_points` (see the first list iteration above).

So, this commit implements a performance improvement by converting location data processing from list-based operations to DataFrame-based operations througout this step in the pipeline.

Couple of high-level points to note:
- The one exception is in `_get_raw_place_enter_loc_entry` where we have to get the location for the place entrance. This is currently expected to be a location entry object instead of a dataframe row. Since we are already calling `ecwe.Entry.create_entry` to create a dummy entry if no location exists, we use the same method to create an entry from the dataframe row as well
- We need to make sure to reset the index when we filter the points for a particular section (see `section_loc_entries` above). If we don't do this, then the original index is retained, and when we concatenate to add speeds and distances, then they are added as additional rows. This caused some test failures.
- We also need to manually wrap the `loc` entries as geojson objects in a couple of places so we could continue to access the coordinates as properties. If the location is an Entry, this wrapping happens automatically.
- changed the tests to also only read the locations as a dataframe

Benefits:
- More efficient filtering and querying operations using pandas
- Reduced memory overhead from eliminating list-to-DataFrame conversions
- Better performance for large datasets through vectorized operations
- Cleaner code with fewer intermediate data structure conversions

Testing done:
All real tests pass

```
$ ./e-mission-py.bash emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
----------------------------------------------------------------------
Ran 39 tests in 149.268s

OK
```

Before this change (from https://github.com/e-mission/e-mission-server/commit/8c488ee42ad3f75079a1efacf41740e9c3006170), CLEAN_AND_RESAMPLE took 7 hours

```
2025-07-07T14:27:52.426162-07:00**********UUID redacted-user-1: moving to long term**********
Creating usercache_compound_hack index in the background
2025-07-07T14:28:09.344998-07:00**********UUID redacted-user-1: updating incoming user inputs**********
2025-07-07T14:28:14.427709-07:00**********UUID redacted-user-1: filter accuracy if needed**********
2025-07-07T14:28:14.444610-07:00**********UUID redacted-user-1: segmenting into trips**********

2025-07-07T14:52:22.595771-07:00**********UUID redacted-user-1: segmenting into sections**********
2025-07-07T14:53:31.340540-07:00**********UUID redacted-user-1: smoothing sections**********
2025-07-07T14:54:02.104743-07:00**********UUID redacted-user-1: cleaning and resampling timeline**********
Cleaning and resampling failed for user redacted-user-1
Traceback (most recent call last):
  File "~/emission/analysis/intake/cleaning/clean_and_resample.py", line 89, in clean_and_resample
    last_raw_place = save_cleaned_segments_for_ts(user_id, time_query.startTs, time_query.endTs)
  File "~/emission/analysis/intake/cleaning/clean_and_resample.py", line 124, in save_cleaned_segments_for_ts
    return save_cleaned_segments_for_timeline(user_id, tl, ts, loc_entries, stops_entries, sections_entries)
  File "~/emission/analysis/intake/cleaning/clean_and_resample.py", line 149, in save_cleaned_segments_for_timeline
    (last_cleaned_place, filtered_tl) = create_and_link_timeline(tl, user_id, trip_map)
  File "~/emission/analysis/intake/cleaning/clean_and_resample.py", line 990, in create_and_link_timeline
    link_trip_start(ts, curr_cleaned_trip, curr_cleaned_start_place, raw_start_place)
  File "~/emission/analysis/intake/cleaning/clean_and_resample.py", line 1043, in link_trip_start
    _fix_squished_place_mismatch(cleaned_trip.user_id, cleaned_trip.get_id(),
  File "~/emission/analysis/intake/cleaning/clean_and_resample.py", line 1227, in _fix_squished_place_mismatch
    assert False
AssertionError
2025-07-07T21:50:47.714815-07:00**********UUID redacted-user-1: inferring transportation mode**********
2025-07-07T22:56:06.289772-07:00**********UUID redacted-user-1: inferring labels**********
2025-07-07T22:56:06.301884-07:00**********UUID redacted-user-1: populating expectations**********
2025-07-07T22:56:06.313822-07:00**********UUID redacted-user-1: creating confirmed objects **********
2025-07-07T22:56:06.327162-07:00**********UUID redacted-user-1: creating composite objects **********
2025-07-07T22:56:06.398289-07:00**********UUID redacted-user-1: storing user stats **********
```

After this change, the same stage took 5 minutes

```
2025-07-08T15:36:05.916463-07:00**********UUID redacted-user-1: moving to long term**********
Creating usercache_compound_hack index in the background
2025-07-08T15:36:05.926514-07:00**********UUID redacted-user-1: updating incoming user inputs**********
2025-07-08T15:36:08.430687-07:00**********UUID redacted-user-1: filter accuracy if needed**********
2025-07-08T15:36:08.436017-07:00**********UUID redacted-user-1: segmenting into trips**********
2025-07-08T16:00:29.119199-07:00**********UUID redacted-user-1: segmenting into sections**********
2025-07-08T16:02:06.474589-07:00**********UUID redacted-user-1: cleaning and resampling timeline**********
Traceback (most recent call last):
  File "/Users/kshankar/e-mission/gis_branch_tests/emission/analysis/intake/cleaning/clean_and_resample.py", line 89, in clean_and_resample
    last_raw_place = save_cleaned_segments_for_ts(user_id, time_query.startTs, time_query.endTs)
  File "/Users/kshankar/e-mission/gis_branch_tests/emission/analysis/intake/cleaning/clean_and_resample.py", line 124, in save_cleaned_segments_for_ts
    return save_cleaned_segments_for_timeline(user_id, tl, ts, loc_df, stops_entries, sections_entries)
  File "/Users/kshankar/e-mission/gis_branch_tests/emission/analysis/intake/cleaning/clean_and_resample.py", line 149, in save_cleaned_segments_for_timeline
    (last_cleaned_place, filtered_tl) = create_and_link_timeline(tl, user_id, trip_map)
  File "/Users/kshankar/e-mission/gis_branch_tests/emission/analysis/intake/cleaning/clean_and_resample.py", line 985, in create_and_link_timeline
    link_trip_start(ts, curr_cleaned_trip, curr_cleaned_start_place, raw_start_place)
  File "/Users/kshankar/e-mission/gis_branch_tests/emission/analysis/intake/cleaning/clean_and_resample.py", line 1038, in link_trip_start
    _fix_squished_place_mismatch(cleaned_trip.user_id, cleaned_trip.get_id(),
  File "/Users/kshankar/e-mission/gis_branch_tests/emission/analysis/intake/cleaning/clean_and_resample.py", line 1222, in _fix_squished_place_mismatch
    assert False
AssertionError
2025-07-08T16:07:12.047276-07:00**********UUID redacted-user-1: inferring transportation mode**********
2025-07-08T17:28:07.952524-07:00**********UUID redacted-user-1: inferring labels**********
2025-07-08T17:28:07.961035-07:00**********UUID redacted-user-1: populating expectations**********
2025-07-08T17:28:07.966622-07:00**********UUID redacted-user-1: creating confirmed objects **********
2025-07-08T17:28:07.972802-07:00**********UUID redacted-user-1: creating composite objects **********
2025-07-08T17:28:08.021194-07:00**********UUID redacted-user-1: storing user stats **********
```