### PR TITLE
👔 add last_updated_ts metadata field; explicitly define mutable keys

### DIFF
--- a/emission/core/wrapper/metadata.py
+++ b/emission/core/wrapper/metadata.py
@@ -17,6 +17,7 @@ class Metadata(ecwb.WrapperBase):
            "platform": ecwb.WrapperBase.Access.WORM,
            "type": ecwb.WrapperBase.Access.WORM,
            "write_ts": ecwb.WrapperBase.Access.WORM,
+           "last_updated_ts": ecwb.WrapperBase.Access.RW,
            "write_local_dt": ecwb.WrapperBase.Access.WORM,
            "time_zone": ecwb.WrapperBase.Access.WORM,
            "write_fmt_time": ecwb.WrapperBase.Access.WORM,


### PR DESCRIPTION
> We want to be able to audit entry updates. This will be used to determine when admin dashboard export cache is stale. In the future, we should also be able to use this to only generate metrics when they have gone stale instead of every day. We do this by intercepting `update()` calls in the timeseries. Let's also take the opportunity to be explict about what types are mutable and immutable. In general, but there are cases where mutability is necessary (e.g., matching user inputs after a trip gets labeled, linking the last place of previous batch to first trip of new batch during segmentation)
> 
> I noticed `update_data` isn't used anywhere, but I refactored it to call `update`, that way we can be sure that if it gets used in the future, `last_updated_ts` still gets populated