### PR TITLE
Remove future compatibility imports

### DIFF
--- a/bin/Mode.py
+++ b/bin/Mode.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 __author__ = 'Yin'
 from pymongo import MongoClient

--- a/bin/analysis/find_inactive_users.py
+++ b/bin/analysis/find_inactive_users.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import logging

--- a/bin/analysis/get_app_analytics.py
+++ b/bin/analysis/get_app_analytics.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.get_database as edb

--- a/bin/debug/common.py
+++ b/bin/debug/common.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/bin/debug/extract_geojson_for_time_range_and_user.py
+++ b/bin/debug/extract_geojson_for_time_range_and_user.py
@@ -1,14 +1,8 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Exports all data for the particular group of users for the particular day range
 # Exports them as geojson using the `emission.analysis.plotting.geojson.geojson_feature_converter` method
 # Note that you probably want to edit `conf/analysis/debug.conf.json.sample` to
 # turn off `output.conversion.validityAssertions` to avoid running into asserts
 # while generating the geojson files
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import sys
 import logging

--- a/bin/debug/extract_timeline_for_day_and_user.py
+++ b/bin/debug/extract_timeline_for_day_and_user.py
@@ -1,11 +1,5 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Exports all data for the particular user for the particular day
 # Used for debugging issues with trip and section generation 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import sys
 import logging

--- a/bin/debug/extract_timeline_for_day_range_and_user.py
+++ b/bin/debug/extract_timeline_for_day_range_and_user.py
@@ -1,11 +1,5 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Exports all data for the particular user for the particular day
 # Used for debugging issues with trip and section generation 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import sys
 import logging

--- a/bin/debug/extract_trips_for_day_and_user.py
+++ b/bin/debug/extract_trips_for_day_and_user.py
@@ -1,11 +1,5 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Exports all data for the particular user for the particular day
 # Used for debugging issues with trip and section generation 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import sys
 import logging

--- a/bin/debug/fix_usercache_processing.py
+++ b/bin/debug/fix_usercache_processing.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Fixes usercache processing
 # If there are any errors in the usercache processing, fix them and reload the data
 # Basic flow
@@ -10,8 +6,6 @@ from __future__ import absolute_import
 # - Find errors
 # - Fix errors
 # - Repeat until no errors are found
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import sys
 import logging

--- a/bin/debug/intake_single_user.py
+++ b/bin/debug/intake_single_user.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/bin/debug/load_multi_timeline_for_range.py
+++ b/bin/debug/load_multi_timeline_for_range.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import str
 from builtins import range

--- a/bin/debug/load_timeline_for_day_and_user.py
+++ b/bin/debug/load_timeline_for_day_and_user.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import emission.storage.json_wrappers as esj

--- a/bin/debug/purge_multi_timeline_for_range.py
+++ b/bin/debug/purge_multi_timeline_for_range.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import argparse

--- a/bin/debug/simulate_server_to_phone.py
+++ b/bin/debug/simulate_server_to_phone.py
@@ -1,11 +1,5 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Exports all data for the particular user for the particular day
 # Used for debugging issues with trip and section generation 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import sys
 import logging

--- a/bin/deploy/habitica_conf.py
+++ b/bin/deploy/habitica_conf.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 

--- a/bin/deploy/push_conf.py
+++ b/bin/deploy/push_conf.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 

--- a/bin/ext_service/clean_habitica_user.py
+++ b/bin/ext_service/clean_habitica_user.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import argparse
 import sys

--- a/bin/ext_service/create_party_leaders_in_db.py
+++ b/bin/ext_service/create_party_leaders_in_db.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.get_database as edb

--- a/bin/ext_service/historical/fix_autocheck_tasks.py
+++ b/bin/ext_service/historical/fix_autocheck_tasks.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import logging

--- a/bin/ext_service/remove_dups.py
+++ b/bin/ext_service/remove_dups.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.get_database as edb

--- a/bin/ext_service/reset_all_habitica_users.py
+++ b/bin/ext_service/reset_all_habitica_users.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import argparse
 import logging

--- a/bin/ext_service/reset_habitica_timestamps.py
+++ b/bin/ext_service/reset_habitica_timestamps.py
@@ -6,12 +6,6 @@ https://github.com/e-mission/e-mission-server/issues/333#issuecomment-312464984
 Can be made a little less general but a lot more performant by using the trick
 below.
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/bin/historical/before_bic2cal/intake_stage_1.py
+++ b/bin/historical/before_bic2cal/intake_stage_1.py
@@ -1,9 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import json

--- a/bin/historical/before_bic2cal/intake_stage_2.py
+++ b/bin/historical/before_bic2cal/intake_stage_2.py
@@ -1,9 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import json

--- a/bin/historical/before_bic2cal/reset_uuids.py
+++ b/bin/historical/before_bic2cal/reset_uuids.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import attrdict as ad

--- a/bin/historical/before_bic2cal/user_cache_step.py
+++ b/bin/historical/before_bic2cal/user_cache_step.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/bin/historical/correct_modes.py
+++ b/bin/historical/correct_modes.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # This script allows us to correct misclassified user confirmed trips.
 # We suspect that the user misclassified them because they were inaccurately
 # classified high confidence trips.
@@ -9,8 +5,6 @@ from __future__ import absolute_import
 # this script.  All corrections should happen through the script, and the
 # associated correction file should be checked in for further reference
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next
 from builtins import *
 from builtins import object

--- a/bin/historical/fix_ios_broken_battery.py
+++ b/bin/historical/fix_ios_broken_battery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.get_database as edb
 

--- a/bin/historical/fix_sensor_config_key.py
+++ b/bin/historical/fix_sensor_config_key.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.get_database as edb
 

--- a/bin/historical/migrations/Split_uuid_from_moves_db.py
+++ b/bin/historical/migrations/Split_uuid_from_moves_db.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from pymongo import MongoClient
 from get_database import get_uuid_db, get_moves_db, get_profile_db

--- a/bin/historical/migrations/Switch_user_test2staging.py
+++ b/bin/historical/migrations/Switch_user_test2staging.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 __author__ = 'Yin'
 from pymongo import MongoClient

--- a/bin/historical/migrations/move_carbon_footprint_to_own_field.py
+++ b/bin/historical/migrations/move_carbon_footprint_to_own_field.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # When I initially started tracking scores, I was lazy and stored the
 # carbonFootprint in the same field as the gamification score, instead of
 # having client specific fields. This made sense if you thought that there was
@@ -14,8 +10,6 @@ from __future__ import absolute_import
 # carbon footprint from the currentScore field to the carbon_footprint field,
 # and delete the currentScore and previousScore fields
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from get_database import get_uuid_db, get_profile_db
 from dao.user import User

--- a/bin/historical/migrations/move_filter_field.py
+++ b/bin/historical/migrations/move_filter_field.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.storage.timeseries.format_hacks.move_filter_field as estfm
 

--- a/bin/historical/migrations/move_trips_places_sections_stops_to_analysis_timeseries_db.py
+++ b/bin/historical/migrations/move_trips_places_sections_stops_to_analysis_timeseries_db.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import arrow

--- a/bin/historical/migrations/populate_local_dt.py
+++ b/bin/historical/migrations/populate_local_dt.py
@@ -1,14 +1,8 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Note that this script is only retained for historical purposes,
 # to document how we expanded the local date entries. It will not run
 # any more, since we have removed the trip, place, section and stop
 # collections and merged them into the analysis database
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 # logging.basicConfig(level=logging.DEBUG)

--- a/bin/historical/migrations/rename_client_ts_to_ts.py
+++ b/bin/historical/migrations/rename_client_ts_to_ts.py
@@ -1,13 +1,7 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 #Modifies the Stage_client_stats collection of Stage_database.
 #Changes the client_ts field to ts.
 
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from pymongo import MongoClient
 client = MongoClient()

--- a/bin/historical/migrations/stats_from_db_to_ts.py
+++ b/bin/historical/migrations/stats_from_db_to_ts.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/bin/historical/migrations/updateExistence.py
+++ b/bin/historical/migrations/updateExistence.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from moves import Moves
 from pymongo import MongoClient

--- a/bin/historical/read_data_from_raw_dumps.py
+++ b/bin/historical/read_data_from_raw_dumps.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Read data from a temporary set of "dump" files that were stored on the
 # mission server in the first half of 2015. These files were identical to the
 # inputs from moves, except that they also had accuracy values for the points.
@@ -14,8 +10,6 @@ from __future__ import absolute_import
 # smoothing algorithms. This script is not useful otherwise.
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import json

--- a/bin/intake_multiprocess.py
+++ b/bin/intake_multiprocess.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/bin/monitor/delete_single_pipeline_state_and_objects.py
+++ b/bin/monitor/delete_single_pipeline_state_and_objects.py
@@ -3,12 +3,6 @@ Script to launch the pipeline reset code.
 Options documented in 
 https://github.com/e-mission/e-mission-server/issues/333#issuecomment-312464984
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/bin/plot_trip.py
+++ b/bin/plot_trip.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 from main import gmap_display

--- a/bin/public/extract_uuids_from_email_list.py
+++ b/bin/public/extract_uuids_from_email_list.py
@@ -1,13 +1,7 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Converts user emails -> UUIDs
 # The UUIDs can be used to extract data for moving across servers
 # Typically used as the file input to the
 # extract_timeline_for_day_range_and_user.py script
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import sys

--- a/bin/public/request_public_data.py
+++ b/bin/public/request_public_data.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import argparse

--- a/bin/purge_analysis_database.py
+++ b/bin/purge_analysis_database.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from pymongo import MongoClient
 import json

--- a/bin/purge_database.py
+++ b/bin/purge_database.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from pymongo import MongoClient
 import json

--- a/bin/push/push_to_users.py
+++ b/bin/push/push_to_users.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/bin/push/send_complex_push.py
+++ b/bin/push/send_complex_push.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/bin/push/silent_ios_push.py
+++ b/bin/push/silent_ios_push.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/bin/reset_pipeline.py
+++ b/bin/reset_pipeline.py
@@ -3,12 +3,6 @@ Script to launch the pipeline reset code.
 Options documented in 
 https://github.com/e-mission/e-mission-server/issues/333#issuecomment-312464984
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/analysis/classification/inference/mode/seed/pipeline.py
+++ b/emission/analysis/classification/inference/mode/seed/pipeline.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from builtins import object

--- a/emission/analysis/configs/config.py
+++ b/emission/analysis/configs/config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import importlib

--- a/emission/analysis/configs/config_utils.py
+++ b/emission/analysis/configs/config_utils.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/analysis/configs/consent.py
+++ b/emission/analysis/configs/consent.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.analysis.configs.config_utils as eacc

--- a/emission/analysis/configs/sensor_config.py
+++ b/emission/analysis/configs/sensor_config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.analysis.configs.config_utils as eacc

--- a/emission/analysis/configs/sync_config.py
+++ b/emission/analysis/configs/sync_config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.analysis.configs.config_utils as eacc

--- a/emission/analysis/intake/cleaning/check_increasing_timestamp.py
+++ b/emission/analysis/intake/cleaning/check_increasing_timestamp.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import os

--- a/emission/analysis/intake/cleaning/clean_and_resample.py
+++ b/emission/analysis/intake/cleaning/clean_and_resample.py
@@ -1,7 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # We need to decide whether the functions will return the cleaned entries or
 # just save them directly. Returning makes it easier to test, saving makes it
 # easier to code because you can work locally and just save the results.
@@ -13,8 +9,6 @@ from __future__ import absolute_import
 # TODO: We can revisit once we see what the structures look like.
 
 # General imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/intake/cleaning/cleaning_methods/jump_smoothing.py
+++ b/emission/analysis/intake/cleaning/cleaning_methods/jump_smoothing.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
 # Techniques to smooth jumps in location tracking. Each of these returns a
 # boolean mask of inliers and outliers. We assume that the incoming dataframe
 # has a column called "speed" that represents the speed at each point. The
@@ -9,8 +5,6 @@ from __future__ import absolute_import
 # The result is in the inlier_mask field of the appropriate object
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/intake/cleaning/cleaning_methods/speed_outlier_detection.py
+++ b/emission/analysis/intake/cleaning/cleaning_methods/speed_outlier_detection.py
@@ -1,13 +1,7 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Techniques for outlier detection of speeds. Each of these returns a speed threshold that 
 # can be used with outlier detection techniques.
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/analysis/intake/cleaning/filter_accuracy.py
+++ b/emission/analysis/intake/cleaning/filter_accuracy.py
@@ -13,14 +13,8 @@ The high level algorithm is to:
         is idempotent. That ensures that we can simply reset the pipeline state
         and re-run everything if we have any changes that we need to make.
 """ 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/analysis/intake/cleaning/location_smoothing.py
+++ b/emission/analysis/intake/cleaning/location_smoothing.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/intake/segmentation/restart_checking.py
+++ b/emission/analysis/intake/segmentation/restart_checking.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import pandas as pd
 import numpy as np

--- a/emission/analysis/intake/segmentation/section_segmentation.py
+++ b/emission/analysis/intake/segmentation/section_segmentation.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_motion.py
+++ b/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_motion.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_with_visit_transitions.py
+++ b/emission/analysis/intake/segmentation/section_segmentation_methods/smoothed_high_confidence_with_visit_transitions.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/analysis/intake/segmentation/trip_segmentation.py
+++ b/emission/analysis/intake/segmentation/trip_segmentation.py
@@ -1,9 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py
+++ b/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_dist_filter.py
@@ -1,6 +1,3 @@
-from __future__ import division, unicode_literals, print_function, absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str, range, zip
 from past.utils import old_div
 import logging

--- a/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_time_filter.py
+++ b/emission/analysis/intake/segmentation/trip_segmentation_methods/dwell_segmentation_time_filter.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/intake/segmentation/vij_implementation_unused.py
+++ b/emission/analysis/intake/segmentation/vij_implementation_unused.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/modelling/similarity/similarity_metric_type.py
+++ b/emission/analysis/modelling/similarity/similarity_metric_type.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import enum
 
 

--- a/emission/analysis/modelling/tour_model/K_medoid.py
+++ b/emission/analysis/modelling/tour_model/K_medoid.py
@@ -1,10 +1,4 @@
 # Standard imports
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import random
 

--- a/emission/analysis/modelling/tour_model/cluster_groundtruth.py
+++ b/emission/analysis/modelling/tour_model/cluster_groundtruth.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *

--- a/emission/analysis/modelling/tour_model/cluster_pipeline.py
+++ b/emission/analysis/modelling/tour_model/cluster_pipeline.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import math
 import uuid as uu

--- a/emission/analysis/modelling/tour_model/create_tour_model_matrix.py
+++ b/emission/analysis/modelling/tour_model/create_tour_model_matrix.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/analysis/modelling/tour_model/featurization.py
+++ b/emission/analysis/modelling/tour_model/featurization.py
@@ -1,10 +1,4 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *

--- a/emission/analysis/modelling/tour_model/kmedoid.py
+++ b/emission/analysis/modelling/tour_model/kmedoid.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/modelling/tour_model/prior_unused/cluster_groundtruth.py
+++ b/emission/analysis/modelling/tour_model/prior_unused/cluster_groundtruth.py
@@ -2,13 +2,7 @@
 Portions of the pipeline related to defining 
 ground truth for clusters
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import os, re
 

--- a/emission/analysis/modelling/tour_model/prior_unused/cluster_pipeline.py
+++ b/emission/analysis/modelling/tour_model/prior_unused/cluster_pipeline.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/modelling/tour_model/prior_unused/exploratory_scripts/explore_smoothing_trajectories.py
+++ b/emission/analysis/modelling/tour_model/prior_unused/exploratory_scripts/explore_smoothing_trajectories.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/emission/analysis/modelling/tour_model/prior_unused/exploratory_scripts/generate_smoothing_from_ground_truth_clusters.py
+++ b/emission/analysis/modelling/tour_model/prior_unused/exploratory_scripts/generate_smoothing_from_ground_truth_clusters.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import logging

--- a/emission/analysis/modelling/tour_model/prior_unused/exploratory_scripts/plot_error_types.py
+++ b/emission/analysis/modelling/tour_model/prior_unused/exploratory_scripts/plot_error_types.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/emission/analysis/modelling/tour_model/prior_unused/truth_pipeline.py
+++ b/emission/analysis/modelling/tour_model/prior_unused/truth_pipeline.py
@@ -43,13 +43,7 @@ For each of the representative trips, open them in MyMaps, and then adjust, add,
 * Maps will then be created of for each of these modified sections that compare the original section with its ground truth. If any issues are observed, then they can be modified and this importing process can be repeated.
 
 """
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import input
 from builtins import str
 from builtins import *

--- a/emission/analysis/modelling/tour_model/prior_unused/util.py
+++ b/emission/analysis/modelling/tour_model/prior_unused/util.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *

--- a/emission/analysis/modelling/tour_model/representatives.py
+++ b/emission/analysis/modelling/tour_model/representatives.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from builtins import object

--- a/emission/analysis/modelling/tour_model/similarity.py
+++ b/emission/analysis/modelling/tour_model/similarity.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from builtins import object

--- a/emission/analysis/modelling/tour_model/tour_model.py
+++ b/emission/analysis/modelling/tour_model/tour_model.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Our imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 

--- a/emission/analysis/modelling/tour_model/tour_model_matrix.py
+++ b/emission/analysis/modelling/tour_model/tour_model_matrix.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Our imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *

--- a/emission/analysis/modelling/tour_model/trajectory_matching/DTW.py
+++ b/emission/analysis/modelling/tour_model/trajectory_matching/DTW.py
@@ -1,9 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from builtins import object

--- a/emission/analysis/modelling/tour_model/trajectory_matching/DifferenceMetricPipeline.py
+++ b/emission/analysis/modelling/tour_model/trajectory_matching/DifferenceMetricPipeline.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/modelling/tour_model/trajectory_matching/Frechet.py
+++ b/emission/analysis/modelling/tour_model/trajectory_matching/Frechet.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import numpy as np

--- a/emission/analysis/modelling/tour_model/trajectory_matching/LCS.py
+++ b/emission/analysis/modelling/tour_model/trajectory_matching/LCS.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Our imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/modelling/tour_model/trajectory_matching/Profile.py
+++ b/emission/analysis/modelling/tour_model/trajectory_matching/Profile.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 __author__ = 'Yin'

--- a/emission/analysis/modelling/tour_model/trajectory_matching/route_matching.py
+++ b/emission/analysis/modelling/tour_model/trajectory_matching/route_matching.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/modelling/trip_model/model_type.py
+++ b/emission/analysis/modelling/trip_model/model_type.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from enum import Enum
 import emission.analysis.modelling.trip_model.trip_model as eamuu
 import emission.analysis.modelling.similarity.od_similarity as eamso

--- a/emission/analysis/modelling/user_model/alternative_trips_module.py
+++ b/emission/analysis/modelling/user_model/alternative_trips_module.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/analysis/modelling/user_model/alternative_trips_pipeline.py
+++ b/emission/analysis/modelling/user_model/alternative_trips_pipeline.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import optparse

--- a/emission/analysis/modelling/user_model/emissions_model.py
+++ b/emission/analysis/modelling/user_model/emissions_model.py
@@ -1,11 +1,5 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 # simple user utility model taking cost, time, and mode into account
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 from past.utils import old_div

--- a/emission/analysis/modelling/user_model/query.py
+++ b/emission/analysis/modelling/user_model/query.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import sys
 import datetime

--- a/emission/analysis/modelling/user_model/simple_cost_time_mode_model.py
+++ b/emission/analysis/modelling/user_model/simple_cost_time_mode_model.py
@@ -1,12 +1,6 @@
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 # simple user utility model taking cost, time, and mode into account
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import numpy as np
 import logging

--- a/emission/analysis/modelling/user_model/user_utility_model.py
+++ b/emission/analysis/modelling/user_model/user_utility_model.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import division
 # Phase 1: Build a model for User Utility Function (per Vij, Shankari)
 # First, for each trip, we must obtain alternatives through some method
 # (currently Google Maps API), alongside the actual trips which were taken.
@@ -19,8 +15,6 @@ from __future__ import division
 # set of alternative routes. In Phase 2, this learning is time-dependent (think traffic).
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 from builtins import object

--- a/emission/analysis/modelling/user_model/utility_model_pipeline.py
+++ b/emission/analysis/modelling/user_model/utility_model_pipeline.py
@@ -2,13 +2,7 @@
 Construct user utility model or retrieve from database and update with
 augmented trips. Store in database and return the model.
 """
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 from builtins import object

--- a/emission/analysis/plotting/geojson/__init__.py
+++ b/emission/analysis/plotting/geojson/__init__.py
@@ -1,8 +1,2 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 __author__ = 'shankari'

--- a/emission/analysis/plotting/geojson/geojson_feature_converter.py
+++ b/emission/analysis/plotting/geojson/geojson_feature_converter.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import map
 from builtins import str
 from builtins import *

--- a/emission/analysis/plotting/leaflet_osm/ipython_helper.py
+++ b/emission/analysis/plotting/leaflet_osm/ipython_helper.py
@@ -1,12 +1,6 @@
 """
 Helper functions that can display leaflet maps inline in an ipython notebook
 """
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *

--- a/emission/analysis/plotting/leaflet_osm/our_plotter.py
+++ b/emission/analysis/plotting/leaflet_osm/our_plotter.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import str
 from builtins import *

--- a/emission/analysis/point_features.py
+++ b/emission/analysis/point_features.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import math

--- a/emission/analysis/result/carbon.py
+++ b/emission/analysis/result/carbon.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import logging

--- a/emission/analysis/result/metrics/simple_metrics.py
+++ b/emission/analysis/result/metrics/simple_metrics.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import numpy as np
 import logging

--- a/emission/analysis/result/metrics/time_grouping.py
+++ b/emission/analysis/result/metrics/time_grouping.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import enum

--- a/emission/analysis/result/recommendation/recommendation.py
+++ b/emission/analysis/result/recommendation/recommendation.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 class Recommendation(object):

--- a/emission/analysis/result/recommendation/recommendation_pipeline.py
+++ b/emission/analysis/result/recommendation/recommendation_pipeline.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 from builtins import object

--- a/emission/analysis/result/userclient.py
+++ b/emission/analysis/result/userclient.py
@@ -1,12 +1,6 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Functions that manipulate both user and client information. It seemed better
 # to call that out into a separate module, rather than decide whether to stick
 # it into User or into Client.
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from emission.core.wrapper.user import User
 from emission.core.wrapper.client import Client

--- a/emission/analysis/section_features.py
+++ b/emission/analysis/section_features.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import math

--- a/emission/core/common.py
+++ b/emission/core/common.py
@@ -1,10 +1,4 @@
 # Standard imports
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import map
 from builtins import *
 from random import randrange

--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from pymongo import MongoClient
 import pymongo

--- a/emission/core/timer.py
+++ b/emission/core/timer.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 from timeit import default_timer

--- a/emission/core/wrapper/appuiconfig.py
+++ b/emission/core/wrapper/appuiconfig.py
@@ -1,10 +1,4 @@
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/battery.py
+++ b/emission/core/wrapper/battery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/cleanedplace.py
+++ b/emission/core/wrapper/cleanedplace.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.place as ecwp
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/cleanedsection.py
+++ b/emission/core/wrapper/cleanedsection.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.section as ecws
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/cleanedtrip.py
+++ b/emission/core/wrapper/cleanedtrip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.trip as ecwt
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/client.py
+++ b/emission/core/wrapper/client.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 #
 # In the current iteration, there is a client object that can be loaded from
 # the filesystem into the database and its settings loaded from the database.
@@ -13,8 +9,6 @@ from __future__ import absolute_import
 # Ah but this assumes that the settings file is in `emission/clients/` and we
 # just deleted that entire directory. Changing this to conf for now...
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 from builtins import object

--- a/emission/core/wrapper/common_place.py
+++ b/emission/core/wrapper/common_place.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/common_trip.py
+++ b/emission/core/wrapper/common_trip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/compositetrip.py
+++ b/emission/core/wrapper/compositetrip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.confirmedtrip as ecwc
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/confirmedplace.py
+++ b/emission/core/wrapper/confirmedplace.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.place as ecwp
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/confirmedsection.py
+++ b/emission/core/wrapper/confirmedsection.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.cleanedsection as ecwc
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/confirmedtrip.py
+++ b/emission/core/wrapper/confirmedtrip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.trip as ecwt
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/consentconfig.py
+++ b/emission/core/wrapper/consentconfig.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/entry.py
+++ b/emission/core/wrapper/entry.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import bson.objectid as boi

--- a/emission/core/wrapper/expectedtrip.py
+++ b/emission/core/wrapper/expectedtrip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.trip as ecwt
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/filter_modules.py
+++ b/emission/core/wrapper/filter_modules.py
@@ -4,13 +4,7 @@ structured:
 module_name { query_string: function_for_query }
 
 """
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import sys

--- a/emission/core/wrapper/incident.py
+++ b/emission/core/wrapper/incident.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/inferredsection.py
+++ b/emission/core/wrapper/inferredsection.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.cleanedsection as ecwc
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/inferredtrip.py
+++ b/emission/core/wrapper/inferredtrip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.trip as ecwt
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/localdate.py
+++ b/emission/core/wrapper/localdate.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import arrow

--- a/emission/core/wrapper/location.py
+++ b/emission/core/wrapper/location.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/metadata.py
+++ b/emission/core/wrapper/metadata.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import datetime as pydt

--- a/emission/core/wrapper/modestattimesummary.py
+++ b/emission/core/wrapper/modestattimesummary.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/motionactivity.py
+++ b/emission/core/wrapper/motionactivity.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/onetimesurvey.py
+++ b/emission/core/wrapper/onetimesurvey.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/pipelinestate.py
+++ b/emission/core/wrapper/pipelinestate.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/place.py
+++ b/emission/core/wrapper/place.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/placeuserinput.py
+++ b/emission/core/wrapper/placeuserinput.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.userinput as ecwui
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/rawplace.py
+++ b/emission/core/wrapper/rawplace.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.place as ecwp

--- a/emission/core/wrapper/rawtrip.py
+++ b/emission/core/wrapper/rawtrip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.trip as ecwt

--- a/emission/core/wrapper/recreatedlocation.py
+++ b/emission/core/wrapper/recreatedlocation.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.location as ecwl
 import emission.core.wrapper.motionactivity as ecwm

--- a/emission/core/wrapper/section.py
+++ b/emission/core/wrapper/section.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/sensorconfig.py
+++ b/emission/core/wrapper/sensorconfig.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/smoothresults.py
+++ b/emission/core/wrapper/smoothresults.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import datetime as pydt

--- a/emission/core/wrapper/statsevent.py
+++ b/emission/core/wrapper/statsevent.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/stop.py
+++ b/emission/core/wrapper/stop.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/syncconfig.py
+++ b/emission/core/wrapper/syncconfig.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/tour_model.py
+++ b/emission/core/wrapper/tour_model.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/transition.py
+++ b/emission/core/wrapper/transition.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/trip.py
+++ b/emission/core/wrapper/trip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/trip_old.py
+++ b/emission/core/wrapper/trip_old.py
@@ -1,12 +1,6 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 #maps team provided get_cost function
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *

--- a/emission/core/wrapper/tripiterator.py
+++ b/emission/core/wrapper/tripiterator.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import unicode_literals
-from __future__ import division
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next
 from builtins import *
 from builtins import object

--- a/emission/core/wrapper/tripuserinput.py
+++ b/emission/core/wrapper/tripuserinput.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.userinput as ecwui
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/untrackedtime.py
+++ b/emission/core/wrapper/untrackedtime.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import emission.core.wrapper.trip as ecwt
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/user.py
+++ b/emission/core/wrapper/user.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 from past.utils import old_div

--- a/emission/core/wrapper/userinput.py
+++ b/emission/core/wrapper/userinput.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import enum

--- a/emission/core/wrapper/userlabel.py
+++ b/emission/core/wrapper/userlabel.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.core.wrapper.wrapperbase as ecwb

--- a/emission/core/wrapper/wrapperbase.py
+++ b/emission/core/wrapper/wrapperbase.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import attrdict as ad

--- a/emission/incomplete_tests/TestAlternativeTripPipeline.py
+++ b/emission/incomplete_tests/TestAlternativeTripPipeline.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next
 from builtins import *
 import unittest

--- a/emission/incomplete_tests/TestApiCalls.py
+++ b/emission/incomplete_tests/TestApiCalls.py
@@ -1,13 +1,7 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # This tests REST API directly, and exercises code in the API wrapper layer
 # It runs the test against a running webserver. The webserver host and port are
 # read from the config.json file
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import json

--- a/emission/incomplete_tests/TestCarbon.py
+++ b/emission/incomplete_tests/TestCarbon.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import unittest

--- a/emission/incomplete_tests/TestCommonPlaceQueries.py
+++ b/emission/incomplete_tests/TestCommonPlaceQueries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import unittest

--- a/emission/incomplete_tests/TestCommonTripQueries.py
+++ b/emission/incomplete_tests/TestCommonTripQueries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import unittest

--- a/emission/incomplete_tests/TestDatabaseUtils.py
+++ b/emission/incomplete_tests/TestDatabaseUtils.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 from pymongo import MongoClient

--- a/emission/incomplete_tests/TestGpsSmoothing.py
+++ b/emission/incomplete_tests/TestGpsSmoothing.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 from datetime import datetime

--- a/emission/incomplete_tests/TestMoveFilterField.py
+++ b/emission/incomplete_tests/TestMoveFilterField.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/incomplete_tests/TestProfile.py
+++ b/emission/incomplete_tests/TestProfile.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import unittest

--- a/emission/incomplete_tests/TestRecommendationPipeline.py
+++ b/emission/incomplete_tests/TestRecommendationPipeline.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import json

--- a/emission/incomplete_tests/TestSimilarity.py
+++ b/emission/incomplete_tests/TestSimilarity.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import logging

--- a/emission/incomplete_tests/TestTourModelQueries.py
+++ b/emission/incomplete_tests/TestTourModelQueries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import logging

--- a/emission/incomplete_tests/TestUserModel.py
+++ b/emission/incomplete_tests/TestUserModel.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import emission.user_model_josh.utility_model as eum

--- a/emission/incomplete_tests/TestUtilityModelPipeline.py
+++ b/emission/incomplete_tests/TestUtilityModelPipeline.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import json

--- a/emission/incomplete_tests/tourModelTests/TestClusterPipeline.py
+++ b/emission/incomplete_tests/tourModelTests/TestClusterPipeline.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 from past.builtins import cmp
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/incomplete_tests/tourModelTests/TestFeaturization.py
+++ b/emission/incomplete_tests/tourModelTests/TestFeaturization.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *

--- a/emission/incomplete_tests/tourModelTests/TestRepresentatives.py
+++ b/emission/incomplete_tests/tourModelTests/TestRepresentatives.py
@@ -1,9 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import next
 from builtins import range
 from builtins import *

--- a/emission/incomplete_tests/tourModelTests/common.py
+++ b/emission/incomplete_tests/tourModelTests/common.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import logging

--- a/emission/individual_tests/TestMetricsInferredSections.py
+++ b/emission/individual_tests/TestMetricsInferredSections.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import logging

--- a/emission/individual_tests/TestNominatim.py
+++ b/emission/individual_tests/TestNominatim.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import importlib

--- a/emission/individual_tests/TestOverpass.py
+++ b/emission/individual_tests/TestOverpass.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import os

--- a/emission/integrationTests/netTests/TestHabiticaAutocheck.py
+++ b/emission/integrationTests/netTests/TestHabiticaAutocheck.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import logging

--- a/emission/integrationTests/netTests/TestHabiticaRegister.py
+++ b/emission/integrationTests/netTests/TestHabiticaRegister.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import unittest

--- a/emission/integrationTests/storageTests/TestMongodbAuth.py
+++ b/emission/integrationTests/storageTests/TestMongodbAuth.py
@@ -20,13 +20,7 @@
 # Admin user with username "admin" and password "pass" must be entered via the mongo shell manually
 # Tests can only be run one at a time
 
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 
 import unittest

--- a/emission/net/api/cfc_webapp.py
+++ b/emission/net/api/cfc_webapp.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import unicode_literals
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 from past.utils import old_div

--- a/emission/net/api/metrics.py
+++ b/emission/net/api/metrics.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 import logging

--- a/emission/net/api/pipeline.py
+++ b/emission/net/api/pipeline.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pymongo

--- a/emission/net/api/stats.py
+++ b/emission/net/api/stats.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.storage.decorations.stats_queries as esds

--- a/emission/net/api/timeline.py
+++ b/emission/net/api/timeline.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import dateutil.parser as dup

--- a/emission/net/api/usercache.py
+++ b/emission/net/api/usercache.py
@@ -1,14 +1,8 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # This is the interface that syncs the usercache to the phone using the REST API.
 # Since other services that we are planning to support (like couchdb or Azure) don't 
 # need to use the REST services on our server to sync, this is not in the generic interface
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import logging

--- a/emission/net/api/utility_model_api.py
+++ b/emission/net/api/utility_model_api.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import emission.user_model_josh.utility_model as eum

--- a/emission/net/api/visualize.py
+++ b/emission/net/api/visualize.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 from uuid import UUID

--- a/emission/net/auth/auth.py
+++ b/emission/net/auth/auth.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/net/auth/skip.py
+++ b/emission/net/auth/skip.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/net/auth/token_list.py
+++ b/emission/net/auth/token_list.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/net/ext_service/geocoder/nominatim.py
+++ b/emission/net/ext_service/geocoder/nominatim.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import urllib.parse

--- a/emission/net/ext_service/habitica/auto_tasks/active_distance.py
+++ b/emission/net/ext_service/habitica/auto_tasks/active_distance.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import json

--- a/emission/net/ext_service/habitica/auto_tasks/task.py
+++ b/emission/net/ext_service/habitica/auto_tasks/task.py
@@ -1,11 +1,5 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Initial attempt at a task definition. This is the data structure -
 # the parsing and interpreting code is elsewhere
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import enum
 import logging

--- a/emission/net/ext_service/habitica/executor.py
+++ b/emission/net/ext_service/habitica/executor.py
@@ -1,11 +1,5 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Initial attempt at a task definition. This is the data structure -
 # the parsing and interpreting code is elsewhere
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import attrdict as ad

--- a/emission/net/ext_service/habitica/proxy.py
+++ b/emission/net/ext_service/habitica/proxy.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import requests

--- a/emission/net/ext_service/otp/otp.py
+++ b/emission/net/ext_service/otp/otp.py
@@ -1,14 +1,8 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
 
 ## Library to make calls to our Open Trip Planner server
 ## Hopefully similiar to googlemaps.py
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import range
 from builtins import *

--- a/emission/net/ext_service/push/notify_interface.py
+++ b/emission/net/ext_service/push/notify_interface.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import json

--- a/emission/net/ext_service/push/notify_interface_impl/firebase.py
+++ b/emission/net/ext_service/push/notify_interface_impl/firebase.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import requests

--- a/emission/net/ext_service/push/notify_queries.py
+++ b/emission/net/ext_service/push/notify_queries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import logging

--- a/emission/net/ext_service/push/notify_usage.py
+++ b/emission/net/ext_service/push/notify_usage.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import requests

--- a/emission/net/ext_service/push/query/dispatch.py
+++ b/emission/net/ext_service/push/query/dispatch.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import importlib

--- a/emission/net/ext_service/push/query/language.py
+++ b/emission/net/ext_service/push/query/language.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Input spec sample at
 # emission/net/ext_service/push/sample.specs/platform.query.sample
 
@@ -9,8 +5,6 @@ from __future__ import absolute_import
 # Output: list of uuids
 # 
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/net/ext_service/push/query/platform.py
+++ b/emission/net/ext_service/push/query/platform.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Input spec sample at
 # emission/net/ext_service/push/sample.specs/platform.query.sample
 
@@ -9,8 +5,6 @@ from __future__ import absolute_import
 # Output: list of uuids
 # 
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/net/ext_service/push/query/point_count.py
+++ b/emission/net/ext_service/push/query/point_count.py
@@ -1,15 +1,9 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Input spec sample at
 # emission/net/ext_service/push/sample.specs/point_count.query.sample
 
 # Input: query spec
 # Output: list of uuids
 # 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/net/ext_service/push/query/trip_metrics.py
+++ b/emission/net/ext_service/push/query/trip_metrics.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Input spec sample at
 # emission/net/ext_service/push/sample.specs/trip_metrics.query.sample sample
 # finds all users who have at least one day in Feb 2017 with no more than 10
@@ -11,8 +7,6 @@ from __future__ import absolute_import
 # Input: query spec
 # Output: list of uuids
 # 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import numpy as np

--- a/emission/net/usercache/abstract_usercache.py
+++ b/emission/net/usercache/abstract_usercache.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # The server side implementation of the user cache
 
 # This is an abstract superclass that can be implemented with couchbase, azure,
@@ -17,8 +13,6 @@ from __future__ import absolute_import
 # rest of the code (ha!) allows us to separate those concerns as well
 
 # Let's switch to new-style classes finally!!
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 class UserCache(object):

--- a/emission/net/usercache/abstract_usercache_handler.py
+++ b/emission/net/usercache/abstract_usercache_handler.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/net/usercache/builtin_usercache.py
+++ b/emission/net/usercache/builtin_usercache.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import time

--- a/emission/net/usercache/builtin_usercache_handler.py
+++ b/emission/net/usercache/builtin_usercache_handler.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import logging

--- a/emission/net/usercache/formatters/android/activity.py
+++ b/emission/net/usercache/formatters/android/activity.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.android.motion_activity as fam

--- a/emission/net/usercache/formatters/android/app_ui_config.py
+++ b/emission/net/usercache/formatters/android/app_ui_config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.one_time_survey as fgo

--- a/emission/net/usercache/formatters/android/battery.py
+++ b/emission/net/usercache/formatters/android/battery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/android/client_error.py
+++ b/emission/net/usercache/formatters/android/client_error.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/android/client_nav_event.py
+++ b/emission/net/usercache/formatters/android/client_nav_event.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/android/client_time.py
+++ b/emission/net/usercache/formatters/android/client_time.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/android/consent.py
+++ b/emission/net/usercache/formatters/android/consent.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pytz

--- a/emission/net/usercache/formatters/android/demographic_survey.py
+++ b/emission/net/usercache/formatters/android/demographic_survey.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.one_time_survey as fgo

--- a/emission/net/usercache/formatters/android/destination_confirm.py
+++ b/emission/net/usercache/formatters/android/destination_confirm.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/android/filtered_location.py
+++ b/emission/net/usercache/formatters/android/filtered_location.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.android.location as fal

--- a/emission/net/usercache/formatters/android/incident.py
+++ b/emission/net/usercache/formatters/android/incident.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import arrow

--- a/emission/net/usercache/formatters/android/location.py
+++ b/emission/net/usercache/formatters/android/location.py
@@ -1,9 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import logging

--- a/emission/net/usercache/formatters/android/mode_confirm.py
+++ b/emission/net/usercache/formatters/android/mode_confirm.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/android/motion_activity.py
+++ b/emission/net/usercache/formatters/android/motion_activity.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/net/usercache/formatters/android/place_addition_input.py
+++ b/emission/net/usercache/formatters/android/place_addition_input.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/android/purpose_confirm.py
+++ b/emission/net/usercache/formatters/android/purpose_confirm.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/android/replaced_mode.py
+++ b/emission/net/usercache/formatters/android/replaced_mode.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/android/sensor_config.py
+++ b/emission/net/usercache/formatters/android/sensor_config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pytz

--- a/emission/net/usercache/formatters/android/sync_config.py
+++ b/emission/net/usercache/formatters/android/sync_config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pytz

--- a/emission/net/usercache/formatters/android/transition.py
+++ b/emission/net/usercache/formatters/android/transition.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/net/usercache/formatters/android/trip_addition_input.py
+++ b/emission/net/usercache/formatters/android/trip_addition_input.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/android/trip_user_input.py
+++ b/emission/net/usercache/formatters/android/trip_user_input.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/common.py
+++ b/emission/net/usercache/formatters/common.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import pytz
 import logging

--- a/emission/net/usercache/formatters/formatter.py
+++ b/emission/net/usercache/formatters/formatter.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import importlib

--- a/emission/net/usercache/formatters/generic/userlabel.py
+++ b/emission/net/usercache/formatters/generic/userlabel.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import arrow

--- a/emission/net/usercache/formatters/ios/app_ui_config.py
+++ b/emission/net/usercache/formatters/ios/app_ui_config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.one_time_survey as fgo

--- a/emission/net/usercache/formatters/ios/battery.py
+++ b/emission/net/usercache/formatters/ios/battery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/net/usercache/formatters/ios/client_error.py
+++ b/emission/net/usercache/formatters/ios/client_error.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/ios/client_nav_event.py
+++ b/emission/net/usercache/formatters/ios/client_nav_event.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/ios/client_time.py
+++ b/emission/net/usercache/formatters/ios/client_time.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/ios/consent.py
+++ b/emission/net/usercache/formatters/ios/consent.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/ios/demographic_survey.py
+++ b/emission/net/usercache/formatters/ios/demographic_survey.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.one_time_survey as fgo

--- a/emission/net/usercache/formatters/ios/destination_confirm.py
+++ b/emission/net/usercache/formatters/ios/destination_confirm.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/ios/filtered_location.py
+++ b/emission/net/usercache/formatters/ios/filtered_location.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.ios.location as fil

--- a/emission/net/usercache/formatters/ios/incident.py
+++ b/emission/net/usercache/formatters/ios/incident.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import arrow

--- a/emission/net/usercache/formatters/ios/location.py
+++ b/emission/net/usercache/formatters/ios/location.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 # It is not clear if we need to copy here, given that we are almost

--- a/emission/net/usercache/formatters/ios/mode_confirm.py
+++ b/emission/net/usercache/formatters/ios/mode_confirm.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/ios/motion_activity.py
+++ b/emission/net/usercache/formatters/ios/motion_activity.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/net/usercache/formatters/ios/place_addition_input.py
+++ b/emission/net/usercache/formatters/ios/place_addition_input.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/ios/purpose_confirm.py
+++ b/emission/net/usercache/formatters/ios/purpose_confirm.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/ios/replaced_mode.py
+++ b/emission/net/usercache/formatters/ios/replaced_mode.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/ios/sensor_config.py
+++ b/emission/net/usercache/formatters/ios/sensor_config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pytz

--- a/emission/net/usercache/formatters/ios/sync_config.py
+++ b/emission/net/usercache/formatters/ios/sync_config.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import copy

--- a/emission/net/usercache/formatters/ios/transition.py
+++ b/emission/net/usercache/formatters/ios/transition.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/net/usercache/formatters/ios/trip_addition_input.py
+++ b/emission/net/usercache/formatters/ios/trip_addition_input.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/net/usercache/formatters/ios/trip_user_input.py
+++ b/emission/net/usercache/formatters/ios/trip_user_input.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import emission.net.usercache.formatters.generic.userlabel as fgl

--- a/emission/pipeline/export_stage.py
+++ b/emission/pipeline/export_stage.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import json

--- a/emission/pipeline/intake_stage.py
+++ b/emission/pipeline/intake_stage.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import json

--- a/emission/pipeline/model_stage.py
+++ b/emission/pipeline/model_stage.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import sys
 import logging

--- a/emission/pipeline/reset.py
+++ b/emission/pipeline/reset.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pandas as pd

--- a/emission/pipeline/scheduler.py
+++ b/emission/pipeline/scheduler.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import logging

--- a/emission/public/pull_and_load_public_data.py
+++ b/emission/public/pull_and_load_public_data.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 

--- a/emission/storage/compat/convert_moves_style_data.py
+++ b/emission/storage/compat/convert_moves_style_data.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import json
 import attrdict as ad

--- a/emission/storage/decorations/analysis_timeseries_queries.py
+++ b/emission/storage/decorations/analysis_timeseries_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pymongo

--- a/emission/storage/decorations/common_place_queries.py
+++ b/emission/storage/decorations/common_place_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import geojson as gj

--- a/emission/storage/decorations/common_trip_queries.py
+++ b/emission/storage/decorations/common_trip_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pymongo

--- a/emission/storage/decorations/local_date_queries.py
+++ b/emission/storage/decorations/local_date_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pymongo

--- a/emission/storage/decorations/location_queries.py
+++ b/emission/storage/decorations/location_queries.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import logging

--- a/emission/storage/decorations/place_queries.py
+++ b/emission/storage/decorations/place_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/storage/decorations/section_queries.py
+++ b/emission/storage/decorations/section_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pymongo

--- a/emission/storage/decorations/stats_queries.py
+++ b/emission/storage/decorations/stats_queries.py
@@ -1,11 +1,5 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 import time
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 
 # Our imports

--- a/emission/storage/decorations/stop_queries.py
+++ b/emission/storage/decorations/stop_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pymongo

--- a/emission/storage/decorations/timeline.py
+++ b/emission/storage/decorations/timeline.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/storage/decorations/tour_model_queries.py
+++ b/emission/storage/decorations/tour_model_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/storage/decorations/trip_queries.py
+++ b/emission/storage/decorations/trip_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import itertools
 import logging

--- a/emission/storage/decorations/useful_queries.py
+++ b/emission/storage/decorations/useful_queries.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 from datetime import datetime, timedelta

--- a/emission/storage/decorations/user_queries.py
+++ b/emission/storage/decorations/user_queries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Utility class to return useful user queries
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/storage/pipeline_queries.py
+++ b/emission/storage/pipeline_queries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import datetime as pydt

--- a/emission/storage/timeseries/abstract_timeseries.py
+++ b/emission/storage/timeseries/abstract_timeseries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/storage/timeseries/aggregate_timeseries.py
+++ b/emission/storage/timeseries/aggregate_timeseries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 from uuid import UUID

--- a/emission/storage/timeseries/builtin_timeseries.py
+++ b/emission/storage/timeseries/builtin_timeseries.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import pandas as pd

--- a/emission/storage/timeseries/cache_series.py
+++ b/emission/storage/timeseries/cache_series.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Simple decorator that pulls data from a combination of the usercache and the timeseries.
 # We could avoid this if we put data directly into the timeseries when it came in instead of
 # buffering
@@ -10,8 +6,6 @@ from __future__ import absolute_import
 # We may also be able to remove this if we run the pipeline more frequently, but would
 # need to test that
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 
 import emission.core.get_database as edb

--- a/emission/storage/timeseries/format_hacks/move_filter_field.py
+++ b/emission/storage/timeseries/format_hacks/move_filter_field.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # For some reason, probably because we were trying to serialize the default
 # object, we put the "filter" field into the metadata. But the filter doesn't
 # make sense for data other than location, so it doesn't seem like it should be
@@ -12,8 +8,6 @@ from __future__ import absolute_import
 # So this simple script moves the filter from the metadata into the data for
 # location entries and removes it for all other entries
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 

--- a/emission/storage/timeseries/geoquery.py
+++ b/emission/storage/timeseries/geoquery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import logging

--- a/emission/storage/timeseries/tcquery.py
+++ b/emission/storage/timeseries/tcquery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 import emission.net.usercache.abstract_usercache as enua

--- a/emission/storage/timeseries/timequery.py
+++ b/emission/storage/timeseries/timequery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from builtins import object
 class TimeQuery(object):

--- a/emission/tests/analysisTests/configTests/TestSaveAllConfigs.py
+++ b/emission/tests/analysisTests/configTests/TestSaveAllConfigs.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/analysisTests/intakeTests/TestCleanAndResample.py
+++ b/emission/tests/analysisTests/intakeTests/TestCleanAndResample.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import unittest

--- a/emission/tests/analysisTests/intakeTests/TestFilterAccuracy.py
+++ b/emission/tests/analysisTests/intakeTests/TestFilterAccuracy.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/analysisTests/intakeTests/TestLocationSmoothing.py
+++ b/emission/tests/analysisTests/intakeTests/TestLocationSmoothing.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import unittest

--- a/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
+++ b/emission/tests/analysisTests/intakeTests/TestPipelineRealData.py
@@ -1,7 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # This test compares the output of the intake pipeline
 # with known ground truth output.
 # The way to add a new test is:
@@ -25,8 +21,6 @@ from __future__ import absolute_import
 # Copy it back and add the test to this file
 # $ mv /tmp/iphone_2016-02-22.ground_truth emission/tests/data/real_examples
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 import unittest

--- a/emission/tests/analysisTests/intakeTests/TestSectionSegmentation.py
+++ b/emission/tests/analysisTests/intakeTests/TestSectionSegmentation.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/analysisTests/intakeTests/TestTripSegmentation.py
+++ b/emission/tests/analysisTests/intakeTests/TestTripSegmentation.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/analysisTests/intakeTests/TestUserStat.py
+++ b/emission/tests/analysisTests/intakeTests/TestUserStat.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals, print_function, division, absolute_import
 import unittest
 import uuid
 import logging
@@ -9,8 +8,6 @@ import pandas as pd
 import arrow
 
 from builtins import *
-from future import standard_library
-standard_library.install_aliases()
 
 # Standard imports
 import emission.storage.json_wrappers as esj

--- a/emission/tests/analysisTests/modeinferTests/TestFeatureCalc.py
+++ b/emission/tests/analysisTests/modeinferTests/TestFeatureCalc.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import copy

--- a/emission/tests/analysisTests/modeinferTests/TestPipeline.py
+++ b/emission/tests/analysisTests/modeinferTests/TestPipeline.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 #Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import unittest

--- a/emission/tests/analysisTests/plottingTests/TestGeojsonFeatureConverter.py
+++ b/emission/tests/analysisTests/plottingTests/TestGeojsonFeatureConverter.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/analysisTests/resultTests/TestTimeGrouping.py
+++ b/emission/tests/analysisTests/resultTests/TestTimeGrouping.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import logging

--- a/emission/tests/common.py
+++ b/emission/tests/common.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import logging

--- a/emission/tests/coreTests/TestBase.py
+++ b/emission/tests/coreTests/TestBase.py
@@ -1,14 +1,8 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Test the base class enhancements over AttrDict
 # Since the base class should not really contain any properties, we create a
 # dummy subclass here and use it for testing.
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import str
 from builtins import *
 import unittest

--- a/emission/tests/coreTests/TestEntry.py
+++ b/emission/tests/coreTests/TestEntry.py
@@ -1,13 +1,7 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Test the class that supports usercache entries
 # The main change here is that 
 
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import logging
 import unittest

--- a/emission/tests/coreTests/wrapperTests/TestClient.py
+++ b/emission/tests/coreTests/wrapperTests/TestClient.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import sys

--- a/emission/tests/coreTests/wrapperTests/TestUser.py
+++ b/emission/tests/coreTests/wrapperTests/TestUser.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import unittest

--- a/emission/tests/coreTests/wrapperTests/TestUserCustomLabel.py
+++ b/emission/tests/coreTests/wrapperTests/TestUserCustomLabel.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 

--- a/emission/tests/exportTests/TestExportModule.py
+++ b/emission/tests/exportTests/TestExportModule.py
@@ -1,5 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import os
 from os import path

--- a/emission/tests/netTests/TestAuthSelection.py
+++ b/emission/tests/netTests/TestAuthSelection.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import json

--- a/emission/tests/netTests/TestBuiltinUserCache.py
+++ b/emission/tests/netTests/TestBuiltinUserCache.py
@@ -1,10 +1,4 @@
-from __future__ import division
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 from past.utils import old_div
 import unittest

--- a/emission/tests/netTests/TestBuiltinUserCacheHandlerInput.py
+++ b/emission/tests/netTests/TestBuiltinUserCacheHandlerInput.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import unittest

--- a/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
+++ b/emission/tests/netTests/TestBuiltinUserCacheHandlerOutput.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import range
 from builtins import *
 import unittest

--- a/emission/tests/netTests/TestFormatters.py
+++ b/emission/tests/netTests/TestFormatters.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/netTests/TestMetricsCleanedSections.py
+++ b/emission/tests/netTests/TestMetricsCleanedSections.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import logging

--- a/emission/tests/netTests/TestPush.py
+++ b/emission/tests/netTests/TestPush.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import json

--- a/emission/tests/netTests/TestVisualize.py
+++ b/emission/tests/netTests/TestVisualize.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import json

--- a/emission/tests/netTests/TestWebserver.py
+++ b/emission/tests/netTests/TestWebserver.py
@@ -1,12 +1,6 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 
 # Standard imports
-from future import standard_library
 
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import json

--- a/emission/tests/netTests/pushTests/TestPointCountQuery.py
+++ b/emission/tests/netTests/pushTests/TestPointCountQuery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import logging

--- a/emission/tests/netTests/pushTests/TestTripMetricsQuery.py
+++ b/emission/tests/netTests/pushTests/TestTripMetricsQuery.py
@@ -1,9 +1,3 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import logging

--- a/emission/tests/pipelineTests/TestPipelineReset.py
+++ b/emission/tests/pipelineTests/TestPipelineReset.py
@@ -1,11 +1,5 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # This test is for the pipeline reset code
 
-from future import standard_library
-standard_library.install_aliases()
 from builtins import zip
 from builtins import *
 import unittest

--- a/emission/tests/storageTests/TestAnalysisTimeseries.py
+++ b/emission/tests/storageTests/TestAnalysisTimeseries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/storageTests/TestLocalDateQueries.py
+++ b/emission/tests/storageTests/TestLocalDateQueries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import arrow

--- a/emission/tests/storageTests/TestModelStorage.py
+++ b/emission/tests/storageTests/TestModelStorage.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/storageTests/TestMongoGeoJSONQueries.py
+++ b/emission/tests/storageTests/TestMongoGeoJSONQueries.py
@@ -1,10 +1,4 @@
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 

--- a/emission/tests/storageTests/TestPipelineQueries.py
+++ b/emission/tests/storageTests/TestPipelineQueries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/storageTests/TestPlaceQueries.py
+++ b/emission/tests/storageTests/TestPlaceQueries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/storageTests/TestSectionQueries.py
+++ b/emission/tests/storageTests/TestSectionQueries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/storageTests/TestStopQueries.py
+++ b/emission/tests/storageTests/TestStopQueries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/storageTests/TestTimeSeries.py
+++ b/emission/tests/storageTests/TestTimeSeries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/storageTests/TestTimeline.py
+++ b/emission/tests/storageTests/TestTimeline.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import logging

--- a/emission/tests/storageTests/TestTripQueries.py
+++ b/emission/tests/storageTests/TestTripQueries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import datetime as pydt

--- a/emission/tests/storageTests/TestUsefulQueries.py
+++ b/emission/tests/storageTests/TestUsefulQueries.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 from datetime import datetime

--- a/emission/tests/storageTests/analysis_ts_common.py
+++ b/emission/tests/storageTests/analysis_ts_common.py
@@ -1,10 +1,4 @@
-from __future__ import unicode_literals
-from __future__ import print_function
-from __future__ import division
-from __future__ import absolute_import
 # Standard imports
-from future import standard_library
-standard_library.install_aliases()
 from builtins import *
 import unittest
 import logging


### PR DESCRIPTION
Eliminate unnecessary future compatibility imports from scoped files to streamline the codebase. This is the first low-risk, direct removal of imports that are currently unused.

More complex changes in a forthcoming PR.

Testing done: Unit tests pass