### PR TITLE
👷 Switch from miniconda to miniforge

### DIFF
--- a/.docker/setup_config.sh
+++ b/.docker/setup_config.sh
@@ -6,7 +6,7 @@ source setup/setup_conda.sh
 ## modify the base environment, which will still trip up the checker.
 ## Let's just upgrade the base environment to the latest everything without pinning
 ## this won't cause a regression in our code since we pin the versions that we use anyway
-conda update -c conda-forge --all
+conda update --all
 
 # Remove rattler because we don't need it, and it is tripping up openssl checks
 conda uninstall conda-rattler-solver
@@ -16,15 +16,17 @@ source setup/setup.sh
 
 ## Remove the old, unused packages to avoid tripping up the checker
 ## This is an example in case we need to remove them again
-# rm -rf /root/miniconda-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0
-rm -rf /root/miniconda-25.11.1/pkgs/conda-25.11.1-py312hca03da5_0/lib/python3.12/site-packages/tests
-rm -rf /root/miniconda-25.11.1/lib/python3.12/site-packages/tests
+# rm -rf /root/miniforge-23.1.0/pkgs/cryptography-38.0.4-py39h9ce1e76_0
+# rm -rf /root/miniforge-25.11.1/pkgs/conda-25.11.1-py312hca03da5_0/lib/python3.12/site-packages/tests
+# rm -rf /root/miniforge-25.11.1/lib/python3.12/site-packages/tests
 
 # Clean up the conda install
 conda clean -t
 conda clean -p
-find /root/miniconda-*/pkgs -wholename \*info/test\* -type d | xargs rm -rf
-find ~/miniconda-25.1.1 -name \*tests\* -path '*/site-packages/*' | grep ".*/site-packages/tests" | xargs rm -rf
+
+# Remove all tests
+find /root/miniforge-*/pkgs -wholename \*info/test\* -type d | xargs rm -rf
+find ~/miniforge-25.1.1 -name \*tests\* -path '*/site-packages/*' | grep ".*/site-packages/tests" | xargs rm -rf
 
 if [ -d "/conf" ]; then
     echo "Found configuration, overriding..."

--- a/setup/activate_conda.sh
+++ b/setup/activate_conda.sh
@@ -1,7 +1,7 @@
 source setup/export_versions.sh
 
-INSTALL_PREFIX=$HOME/miniconda-$EXP_CONDA_VER
-SOURCE_SCRIPT="$HOME/miniconda-$EXP_CONDA_VER/etc/profile.d/conda.sh"
+INSTALL_PREFIX=$HOME/miniforge-$EXP_CONDA_VER
+SOURCE_SCRIPT="$HOME/miniforge-$EXP_CONDA_VER/etc/profile.d/conda.sh"
 
 echo "Activating conda at ${SOURCE_SCRIPT}"
 source $SOURCE_SCRIPT

--- a/setup/setup_conda.sh
+++ b/setup/setup_conda.sh
@@ -42,29 +42,26 @@ case "$UNAME_S:$UNAME_M" in
     *)
         echo "Error: Unsupported platform $UNAME_S/$UNAME_M"
         echo "Supported platform mappings are Linux-x86_64, Linux-aarch64, MacOSX-x86_64, MacOSX-arm64"
-        WINDOWS_INSTALLER_URL="https://repo.anaconda.com/miniconda/Miniconda3-py39_$EXP_CONDA_VER-$EXP_CONDA_VER_SUFFIX-Windows-x86_64.exe"
+        WINDOWS_INSTALLER_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Windows-x86_64.exe"
         echo "For Windows, manually download and install $WINDOWS_INSTALLER_URL"
         exit 2
         ;;
 esac
 
 if [[ -z $INSTALL_PREFIX ]]; then
-    INSTALL_PREFIX=$HOME/miniconda-$EXP_CONDA_VER
+    INSTALL_PREFIX=$HOME/miniforge-$EXP_CONDA_VER
 fi
 SOURCE_SCRIPT="$INSTALL_PREFIX/etc/profile.d/conda.sh"
 
-echo "Installing for version $EXP_CONDA_VER and platform $PLATFORM at $INSTALL_PREFIX"
-DOWNLOAD_URL=https://repo.anaconda.com/miniconda/Miniconda3-py312_$EXP_CONDA_VER-$EXP_CONDA_VER_SUFFIX-$PLATFORM.sh
+echo "Installing Miniforge for platform $PLATFORM at $INSTALL_PREFIX"
+DOWNLOAD_URL=https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$PLATFORM.sh
+INSTALLER_PATH=$(mktemp "${TMPDIR:-/tmp}/miniforge-XXXXXX.sh")
 echo "Downloading installer from URL ${DOWNLOAD_URL}"
-curl -o miniconda.sh -L ${DOWNLOAD_URL}
-bash miniconda.sh -b -p $INSTALL_PREFIX
+curl -o "$INSTALLER_PATH" -L ${DOWNLOAD_URL}
+bash "$INSTALLER_PATH" -b -p $INSTALL_PREFIX
+rm -f "$INSTALLER_PATH"
 source $SOURCE_SCRIPT
 hash -r
-echo "About to accept TOS for 'main' and 'r'"
-conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/main
-conda tos accept --override-channels --channel https://repo.anaconda.com/pkgs/r
-echo "About to install base and libmamba environments"
-conda install -n base conda-libmamba-solver
 conda config --set solver libmamba
 conda config --set always_yes yes
 # Useful for debugging any issues with conda


### PR DESCRIPTION
In 42163953f23b9f448093945e663e151281010f1e, we attempted to remove the `defaults` channel, but it didn't actually get removed because it was configured by default in miniconda (e.g. `/root/miniconda...`)

on OSX

```
For conda, found 26.1.1, expected 26.1.1, all is good!
Installing using conda now
CI detected...
2 channel Terms of Service accepted
Channels:
 - conda-forge
 - defaults
Platform: osx-arm64
Collecting package metadata (repodata.json): - \ | / - \ | / - \ | / - \ | / done
Solving environment: \ | done
```

on Linux

```
Activating conda at /home/runner/miniconda-26.1.1/etc/profile.d/conda.sh
conda 26.1.1
For conda, found 26.1.1, expected 26.1.1, all is good!
Installing using conda now
CI detected...
2 channel Terms of Service accepted
Channels:
 - conda-forge
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): - \ | / - \ | / - \ | / - \ | / - \ | / - \ | / done
Solving environment: \ | done
```

And this combination has been very flaky recently, which is holding up our progress on multi-platform builds.
https://github.com/e-mission/e-mission-server/pull/1095#issuecomment-4577845701

Original issue: https://github.com/e-mission/e-mission-docs/issues/1143

This switches our implementation from miniconda to miniforge, per the recommended instructions here
https://conda-forge.org/docs/user/transitioning_from_defaults/#uninstalling-anaconda-and-installing-miniforge

Since miniforge comes with mamba, we no longer need to force-install mamba.

Testing done:
- Built multi-platform images using buildx (`docker buildx build --platform linux/amd64,linux/arm64 -t test_rattler .`). Both platforms were built successfully and quickly. The entire build took less than 2 minutes. Let's see if it is actually more stable.

  ``` $ docker buildx build --platform linux/amd64,linux/arm64 -t test_rattler .
[+] Building 111.0s (35/35) FINISHED                                   docker:desktop-linux
 => [internal] load build definition from Dockerfile                                   0.0s
 => => transferring dockerfile: 1.04kB                                                 0.0s
 => [linux/amd64 internal] load metadata for docker.io/library/ubuntu:jammy-20240227   0.9s
 => [linux/arm64 internal] load metadata for docker.io/library/ubuntu:jammy-20240227   0.9s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                          0.0s
 => [internal] load .dockerignore                                                      0.0s
  ```

We should have done this much sooner!