### PR TITLE
👷 Finally enable multiplatform builds for the automated builds

### DIFF
--- a/.github/workflows/image_build_push.yml
+++ b/.github/workflows/image_build_push.yml
@@ -38,7 +38,7 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64/v8
         push: true
         tags: ${{ secrets.DOCKER_USER }}/${{ github.event.repository.name }}:${{ github.ref_name }}_${{ steps.date.outputs.date }}
 


### PR DESCRIPTION
Finally enable multiplatform builds in the automated builds from the GitHub action. This is a follow-on to:
- Enable multi platform builds image build (https://github.com/e-mission/e-mission-server/pull/1095)
- Switch from miniconda to miniforge (https://github.com/e-mission/e-mission-server/pull/1096)

The first PR set up the framework to enable multiplatform builds, but the miniconda-based build intermittently took several hours to run, so we could not really test enabling automated multiplatform builds.

Switching to miniforge in the second PR has made the installation process significantly faster.

This finally fixes https://github.com/e-mission/e-mission-docs/issues/1143