### PR TITLE
✨ Plumb through support for modifiable, user-specific state

### DIFF
--- a/emission/core/get_database.py
+++ b/emission/core/get_database.py
@@ -264,6 +264,18 @@ def get_model_db():
     ModelDB.create_index([("metadata.write_ts", pymongo.DESCENDING)])
     return ModelDB
 
+
+def get_state_db():
+    """
+    " Stores modifiable state documents keyed by state type for each user.
+    " This follows the same write-and-replace pattern as the model database.
+    """
+    StateDB = _get_current_db().Stage_updateable_states
+    StateDB.create_index([("user_id", pymongo.ASCENDING)])
+    StateDB.create_index([("metadata.key", pymongo.ASCENDING)])
+    StateDB.create_index([("metadata.write_ts", pymongo.DESCENDING)])
+    return StateDB
+
 def _create_analysis_result_indices(tscoll):
     tscoll.create_index([("metadata.key", pymongo.ASCENDING)])
 

--- a/emission/core/wrapper/payment.py
+++ b/emission/core/wrapper/payment.py
@@ -1,0 +1,15 @@
+"""
+Vehicle data model for deployments that utilize a library or fleet of shared vehicles.
+Tracks vehicle location (dock/bay/parking spot ID or user UUID if checked out) and active reservations.
+"""
+from builtins import *
+import logging
+import emission.core.wrapper.wrapperbase as ecwb
+
+class Payment(ecwb.WrapperBase):
+    props = {
+        "placeholder": ecwb.WrapperBase.Access.RW,
+    }
+
+    def _populateDependencies(self):
+        pass

--- a/emission/core/wrapper/vehicle.py
+++ b/emission/core/wrapper/vehicle.py
@@ -1,0 +1,16 @@
+from builtins import *
+import emission.core.wrapper.wrapperbase as ecwb
+
+
+class Vehicle(ecwb.WrapperBase):
+    props = {
+        "placeholder": ecwb.WrapperBase.Access.RW,
+    }
+
+    enums = {}
+    geojson = []
+    nullable = []
+    local_dates = []
+
+    def _populateDependencies(self):
+        pass

--- a/emission/storage/modifiable/abstract_state_storage.py
+++ b/emission/storage/modifiable/abstract_state_storage.py
@@ -1,0 +1,57 @@
+import enum
+from typing import Optional, Union
+
+import emission.core.wrapper.wrapperbase as ecwb
+
+
+class StateName(enum.Enum):
+    VEHICLE = "VEHICLE"
+    PAYMENT = "PAYMENT"
+
+
+class StateStorage(object):
+    @staticmethod
+    def _getStateName2Wrapper():
+        return {
+            StateName.VEHICLE: "vehicle",
+            StateName.PAYMENT: "payment",
+        }
+
+    @staticmethod
+    def get_state_wrapper(state_name: Union[StateName, str]) -> str:
+        if isinstance(state_name, str):
+            state_name = StateName[state_name]
+        return StateStorage._getStateName2Wrapper()[state_name]
+
+    @staticmethod
+    def get_state_storage(user_id):
+        """
+        :param user_id: the user_id that we want state storage for
+        :returns: a state storage for that particular user
+        """
+        import emission.storage.modifiable.builtin_state_storage as bsts
+
+        return bsts.BuiltinStateStorage(user_id)
+
+    def __init__(self, user_id):
+        self.user_id = user_id
+
+    def upsert_state(self, state_name: StateName, state: ecwb.WrapperBase):
+        """
+        :param state_name: enum-backed state name
+        :param state: payload to persist
+        """
+        pass
+
+    def get_current_state(self, state_name: StateName) -> Optional[ecwb.WrapperBase]:
+        """
+        :param state_name: enum-backed state name
+        :returns: the most recent state for this state_name
+        """
+        pass
+
+    def delete_state(self, state_name: StateName):
+        """
+        :param state_name: enum-backed state name
+        """
+        pass

--- a/emission/storage/modifiable/builtin_state_storage.py
+++ b/emission/storage/modifiable/builtin_state_storage.py
@@ -1,0 +1,68 @@
+import logging
+from typing import Optional
+
+from pymongo import ReturnDocument
+
+import emission.core.get_database as edb
+import emission.core.wrapper.metadata as ecwm
+import emission.core.wrapper.wrapperbase as ecwb
+import emission.storage.modifiable.abstract_state_storage as esas
+
+
+class BuiltinStateStorage(esas.StateStorage):
+    def __init__(self, user_id):
+        super(BuiltinStateStorage, self).__init__(user_id)
+
+    def _get_state_wrapper_class(self, state_name: esas.StateName):
+        wrapper_name = esas.StateStorage.get_state_wrapper(state_name)
+        return ecwb.WrapperBase._get_class(wrapper_name)
+
+    def _state_key(self, state_name: esas.StateName) -> str:
+        return "state/%s" % state_name.value.lower()
+
+    def upsert_state(self, state_name: esas.StateName, state: ecwb.WrapperBase):
+        key = self._state_key(state_name)
+        state_wrapper_class = self._get_state_wrapper_class(state_name)
+        if isinstance(state, state_wrapper_class):
+            state_to_store = state
+        else:
+            raise TypeError("state must be a wrapper instance of the mapped state wrapper class")
+
+        entry = {
+            "user_id": self.user_id,
+            "metadata": ecwm.Metadata.create_metadata_for_result(key),
+            "data": state_to_store,
+        }
+        find_query = {"user_id": self.user_id, "metadata.key": key}
+        logging.debug("Upserting entry %s into state DB" % entry)
+        updated_doc = edb.get_state_db().find_one_and_replace(
+            find_query,
+            entry,
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        assert edb.get_state_db().count_documents(find_query) == 1, (
+            "There should be exactly one entry for %s after upsert" % key
+        )
+        return updated_doc["_id"]
+
+    def get_current_state(self, state_name: esas.StateName) -> Optional[ecwb.WrapperBase]:
+        key = self._state_key(state_name)
+        state_wrapper_class = self._get_state_wrapper_class(state_name)
+        find_query = {"user_id": self.user_id, "metadata.key": key}
+        result_it = edb.get_state_db().find(find_query).sort("metadata.write_ts", -1).limit(1)
+        result_list = list(result_it)
+        assert len(result_list) <= 1, "There should be at most one entry for %s" % key
+        if len(result_list) == 0:
+            return None
+        first_entry = result_list[0]
+        return state_wrapper_class(first_entry["data"])
+
+    def delete_state(self, state_name: esas.StateName):
+        key = self._state_key(state_name)
+        find_query = {"user_id": self.user_id, "metadata.key": key}
+        assert edb.get_state_db().count_documents(find_query) <= 1, (
+            "There should be at most one entry for %s" % key
+        )
+        deleted = edb.get_state_db().delete_many(find_query)
+        logging.debug("Deleted %s existing state entries for %s" % (deleted.deleted_count, key))

--- a/emission/tests/storageTests/TestModelStorage.py
+++ b/emission/tests/storageTests/TestModelStorage.py
@@ -29,7 +29,7 @@ class TestModelStorage(unittest.TestCase):
     '''
     def setUp(self):
         logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
-        level=logging.DEBUG)
+            level=logging.DEBUG)
 
         # configuration for randomly-generated test data
         self.user_id = user_id = 'TestRunGreedyModel-TestData'

--- a/emission/tests/storageTests/TestStateStorage.py
+++ b/emission/tests/storageTests/TestStateStorage.py
@@ -1,0 +1,89 @@
+from builtins import *
+import logging
+import unittest
+import uuid
+
+import emission.core.get_database as edb
+import emission.core.wrapper.payment as ecwp
+import emission.core.wrapper.vehicle as ecwvs
+import emission.storage.modifiable.abstract_state_storage as esas
+
+
+class TestStateStorage(unittest.TestCase):
+    def setUp(self):
+        logging.basicConfig(format='%(asctime)s:%(levelname)s:%(message)s',
+            level=logging.DEBUG)
+
+        self.user_id = uuid.uuid4()
+        self.state_storage = esas.StateStorage.get_state_storage(self.user_id)
+
+    def tearDown(self):
+        edb.get_state_db().delete_many({"user_id": self.user_id})
+
+    def test_state_enum_contains_vehicle_and_payment(self):
+        self.assertEqual(esas.StateName.VEHICLE.value, "VEHICLE")
+        self.assertEqual(esas.StateName.PAYMENT.value, "PAYMENT")
+
+    def test_state_enum_to_wrapper_mapping(self):
+        state_mapping = esas.StateStorage._getStateName2Wrapper()
+
+        self.assertEqual(state_mapping[esas.StateName.VEHICLE], "vehicle")
+        self.assertEqual(state_mapping[esas.StateName.PAYMENT], "payment")
+        self.assertEqual(
+            esas.StateStorage.get_state_wrapper(esas.StateName.VEHICLE),
+            "vehicle",
+        )
+        self.assertEqual(
+            esas.StateStorage.get_state_wrapper("PAYMENT"),
+            "payment",
+        )
+
+    def test_upsert_and_get_current_state_for_vehicle(self):
+        vehicle_state = ecwvs.Vehicle({"placeholder": "new vehicle added"})
+        self.state_storage.upsert_state(esas.StateName.VEHICLE, vehicle_state)
+
+        current_state = self.state_storage.get_current_state(esas.StateName.VEHICLE)
+        self.assertIsNotNone(current_state)
+        self.assertTrue(isinstance(current_state, ecwvs.Vehicle))
+        self.assertEqual(current_state["placeholder"], "new vehicle added")
+
+    def test_upsert_and_get_current_state_for_payment(self):
+        payment_state = ecwp.Payment({"placeholder": "settled"})
+        self.state_storage.upsert_state(esas.StateName.PAYMENT, payment_state)
+
+        current_state = self.state_storage.get_current_state(esas.StateName.PAYMENT)
+        self.assertIsNotNone(current_state)
+        self.assertTrue(isinstance(current_state, ecwp.Payment))
+        self.assertEqual(current_state["placeholder"], "settled")
+
+    def test_upsert_state_replaces_existing_state_for_same_state_name(self):
+        self.state_storage.upsert_state(
+            esas.StateName.VEHICLE,
+            ecwvs.Vehicle({"placeholder": "old"}),
+        )
+        self.state_storage.upsert_state(
+            esas.StateName.VEHICLE,
+            ecwvs.Vehicle({"placeholder": "new"}),
+        )
+
+        current_state = self.state_storage.get_current_state(esas.StateName.VEHICLE)
+        self.assertEqual(current_state["placeholder"], "new")
+
+        vehicle_count = edb.get_state_db().count_documents(
+            {"user_id": self.user_id, "metadata.key": "state/vehicle"}
+        )
+        self.assertEqual(vehicle_count, 1)
+
+    def test_upsert_state_rejects_dict(self):
+        with self.assertRaises(TypeError):
+            self.state_storage.upsert_state(
+                esas.StateName.VEHICLE,
+                {"placeholder": "value"},
+            )
+
+
+if __name__ == '__main__':
+    import emission.tests.common as etc
+
+    etc.configLogging()
+    unittest.main()


### PR DESCRIPTION
As OpenPATH gets more complex, we need to store additional user-specific state. This is not really a time-series use case, since the state is designed to be updated, and we will want to retrieve the most recent version. It could be implemented as a timeseries if we want to support edit history and/or versioning.

We already store models as user-specific modifiable data. We extend this to store user-specific modifiable state as well.

This allows us to avoid overloading the user profile, and separates out state that is only relevant to a particular feature.

Changes:
➕ implement a new abstract/builtin module under "modifiable" storage ➕ show how it will work for two types of state (vehicles and payments) related to the vehicle library (https://github.com/e-mission/e-mission-server/pull/1099) ➕ add tests for the new module
➕ minor formatting fix for the model storage tests to match the new tests